### PR TITLE
DM-172 remove createdBy, permissions fields from response

### DIFF
--- a/src/back-end/lib/db.ts
+++ b/src/back-end/lib/db.ts
@@ -441,6 +441,7 @@ export async function readActiveOwnerCount(connection: Connection, orgId: Id): P
 export async function readOneFileById(connection: Connection, id: Id): Promise<FileRecord> {
   const result = await connection('files')
     .where({ id })
+    .select(['name', 'id', 'createdAt', 'fileBlob'])
     .first();
   return result ? result : null;
 }

--- a/src/back-end/lib/db.ts
+++ b/src/back-end/lib/db.ts
@@ -463,7 +463,7 @@ export async function createFile(connection: Connection, fileRecord: ValidatedFi
         resolve(data);
       });
     });
-    const fileHash = await hashFile(fileRecord.name, fileData);
+    const fileHash = hashFile(fileRecord.name, fileData);
     let fileBlob = await readOneFileBlob(connection, fileHash);
     // Create a new blob if it doesn't already exist.
     if (!fileBlob) {
@@ -483,7 +483,7 @@ export async function createFile(connection: Connection, fileRecord: ValidatedFi
         createdAt: now,
         createdBy: userId,
         fileBlob: fileBlob.hash
-      }, ['*']);
+      }, ['name', 'id', 'createdAt', 'fileBlob']);
 
     // Insert values for permissions defined in metadata
     // TODO this will fail if permissions aren't experessed as a set (may have duplicate perms)

--- a/src/shared/lib/resources/file.ts
+++ b/src/shared/lib/resources/file.ts
@@ -1,6 +1,6 @@
 import { get, isArray } from 'lodash';
 import { megabytesToBytes } from 'shared/lib';
-import { User, UserType } from 'shared/lib/resources/user';
+import { UserType } from 'shared/lib/resources/user';
 import { adt, ADT, Id } from 'shared/lib/types';
 import { isString } from 'util';
 
@@ -11,10 +11,8 @@ export const SUPPORTED_IMAGE_EXTENSIONS = ['.jpg', '.jpeg', '.png'];
 export interface FileRecord {
   id: Id;
   createdAt: Date;
-  createdBy: User;
   fileBlob: Id;
   name: string;
-  permissions: Array<FilePermissions<Id, UserType>>;
 }
 
 export interface FileBlob {


### PR DESCRIPTION
This PR removes `createdBy` and `permissions` from the FileRecord type, and ensures they will not be included in any response to the client.