### PR TITLE
DM-167 add constraint to sessions table

### DIFF
--- a/src/back-end/lib/db.ts
+++ b/src/back-end/lib/db.ts
@@ -140,28 +140,11 @@ export async function readOneSession(connection: Connection, id: Id): Promise<Se
   });
 }
 
-export async function updateSessionWithToken(connection: Connection, id: Id, accessToken: string): Promise<Session> {
+export async function updateSession(connection: Connection, session: Session): Promise<Session> {
   const [result] = await connection('sessions')
-    .where({ id })
+    .where({ id: session.id })
     .update({
-      accessToken,
-      updatedAt: new Date()
-    }, ['*']);
-  if (!result) {
-    throw new Error('unable to update session');
-  }
-  return await rawSessionToSession(connection, {
-    id: result.id,
-    accessToken: result.accessToken,
-    user: result.user
-  });
-}
-
-export async function updateSessionWithUser(connection: Connection, id: Id, userId: Id): Promise<Session> {
-  const [result] = await connection('sessions')
-    .where({ id })
-    .update({
-      user: userId,
+      ...session,
       updatedAt: new Date()
     }, ['*']);
   if (!result) {

--- a/src/back-end/lib/routers/auth.ts
+++ b/src/back-end/lib/routers/auth.ts
@@ -134,8 +134,6 @@ async function makeRouter(connection: Connection): Promise<Router<any, any, any,
             return makeAuthErrorRedirect(request);
           }
 
-          // let session = await updateSessionWithUser(connection, request.session.id, user.id);
-          // session = await updateSessionWithToken(connection, session.id, tokens.refresh_token);
           const session = await updateSession(connection, {
             ...request.session,
             user: user.id,

--- a/src/back-end/lib/routers/auth.ts
+++ b/src/back-end/lib/routers/auth.ts
@@ -1,5 +1,5 @@
 import { KEYCLOAK_CLIENT_ID, KEYCLOAK_CLIENT_SECRET, KEYCLOAK_REALM, KEYCLOAK_URL, ORIGIN } from 'back-end/config';
-import { Connection, createUser, findOneUserByTypeAndUsername, updateSessionWithToken, updateSessionWithUser, updateUser } from 'back-end/lib/db';
+import { Connection, createUser, findOneUserByTypeAndUsername, updateSession, updateUser } from 'back-end/lib/db';
 import { makeErrorResponseBody, makeTextResponseBody, nullRequestBodyHandler, Request, Router, TextResponseBody } from 'back-end/lib/server';
 import { ServerHttpMethod } from 'back-end/lib/types';
 import { generators, TokenSet, TokenSetParameters } from 'openid-client';
@@ -134,8 +134,13 @@ async function makeRouter(connection: Connection): Promise<Router<any, any, any,
             return makeAuthErrorRedirect(request);
           }
 
-          let session = await updateSessionWithUser(connection, request.session.id, user.id);
-          session = await updateSessionWithToken(connection, session.id, tokens.refresh_token);
+          // let session = await updateSessionWithUser(connection, request.session.id, user.id);
+          // session = await updateSessionWithToken(connection, session.id, tokens.refresh_token);
+          const session = await updateSession(connection, {
+            ...request.session,
+            user: user.id,
+            accessToken: tokens.refresh_token
+          });
 
           return {
             code: 302,

--- a/src/migrations/tasks/20200106201409_session_constraint.ts
+++ b/src/migrations/tasks/20200106201409_session_constraint.ts
@@ -1,0 +1,25 @@
+import { makeDomainLogger } from 'back-end/lib/logger';
+import { console as consoleAdapter } from 'back-end/lib/logger/adapters';
+import Knex from 'knex';
+
+const logger = makeDomainLogger(consoleAdapter, 'migrations');
+
+export async function up(connection: Knex): Promise<void> {
+  await connection.schema.raw(`
+    ALTER TABLE sessions
+    ADD CONSTRAINT "noAccessTokenWithoutUser" check(
+      ("user" IS NOT NULL AND "accessToken" IS NOT NULL)
+      OR
+      ("user" IS NULL AND "accessToken" IS NULL)
+    )
+  `);
+  logger.info('Added noAccessTokenWithoutUser constraint to sessions table.');
+}
+
+export async function down(connection: Knex): Promise<void> {
+  await connection.schema.raw(`
+    ALTER TABLE sessions
+    DROP CONSTRAINT "noAccessTokenWithoutUser"
+  `);
+  logger.info('Removed noAccessTokenWithoutUser constraint from sessions table.');
+}


### PR DESCRIPTION
This PR adds a database migration for adding a constraint to the sessions table that ensures that `accessToken` is not null if `user` is not null.