### PR TITLE
DM-227 add opportunity subscriber resource

### DIFF
--- a/src/back-end/index.ts
+++ b/src/back-end/index.ts
@@ -12,6 +12,7 @@ import codeWithUsOpportunityResource from 'back-end/lib/resources/opportunity/co
 import organizationResource from 'back-end/lib/resources/organization';
 import codeWithUsProposalResource from 'back-end/lib/resources/proposal/code-with-us';
 import sessionResource from 'back-end/lib/resources/session';
+import codeWithUsSubscriberResource from 'back-end/lib/resources/subscribers/code-with-us';
 import userResource from 'back-end/lib/resources/user';
 import authRouter from 'back-end/lib/routers/auth';
 import frontEndRouter from 'back-end/lib/routers/front-end';
@@ -60,6 +61,7 @@ export async function createRouter(connection: Connection): Promise<AppRouter> {
     avatarResource,
     codeWithUsOpportunityResource,
     codeWithUsProposalResource,
+    codeWithUsSubscriberResource,
     fileResource,
     organizationResource,
     sessionResource,

--- a/src/back-end/lib/db.ts
+++ b/src/back-end/lib/db.ts
@@ -887,6 +887,14 @@ export const readOneCWUOpportunity = tryDb<[Id, Session], CWUOpportunity | null>
       .select('id')).map(row => row.id);
   }
 
+  // Add on subscription flag, if authenticated user
+  if (result && session.user) {
+    const subscription = await connection<RawCWUOpportunitySubscriber>('cwuOpportunitySubscribers')
+      .where({ opportunity: result.id, user: session.user.id })
+      .first();
+    result.subscribed = !!subscription;
+  }
+
   // If admin/owner, add on list of status histories
   if (result && session.user && (session.user.type === UserType.Admin || result.createdBy === session.user.id)) {
     const rawStatusArray = await connection<RawCWUOpportunityStatusRecord>('cwuOpportunityStatuses')

--- a/src/back-end/lib/resources/subscribers/code-with-us.ts
+++ b/src/back-end/lib/resources/subscribers/code-with-us.ts
@@ -1,0 +1,150 @@
+import * as crud from 'back-end/lib/crud';
+import * as db from 'back-end/lib/db';
+import * as permissions from 'back-end/lib/permissions';
+import { basicResponse, JsonResponseBody, makeJsonResponseBody, wrapRespond } from 'back-end/lib/server';
+import { SupportedRequestBodies, SupportedResponseBodies } from 'back-end/lib/types';
+import { validateCWUOpportunityId } from 'back-end/lib/validation';
+import { omit } from 'lodash';
+import { getString } from 'shared/lib';
+import { AuthenticatedSession, Session } from 'shared/lib/resources/session';
+import { CreateRequestBody, CreateValidationErrors, CWUOpportunitySubscriber, DeleteValidationErrors } from 'shared/lib/resources/subscribers/code-with-us';
+import { Id } from 'shared/lib/types';
+import { invalid, isInvalid, valid } from 'shared/lib/validation';
+
+interface ValidatedCreateRequestBody {
+  opportunity: Id;
+  user: Id;
+  session: AuthenticatedSession;
+}
+
+interface ValidatedDeleteRequestBody {
+  opportunity: Id;
+  user: Id;
+  session: AuthenticatedSession;
+}
+
+type Resource = crud.Resource<
+  SupportedRequestBodies,
+  SupportedResponseBodies,
+  CreateRequestBody,
+  ValidatedCreateRequestBody,
+  CreateValidationErrors,
+  null,
+  null,
+  null,
+  null,
+  null,
+  ValidatedDeleteRequestBody,
+  DeleteValidationErrors,
+  Session,
+  db.Connection
+>;
+
+const resource: Resource = {
+  routeNamespace: 'subscribers/code-with-us',
+
+  create(connection) {
+    return {
+      async parseRequestBody(request) {
+        const body: unknown = request.body.tag === 'json' ? request.body.value : {};
+        return {
+          opportunity: getString(body, 'opportunity')
+        };
+      },
+      async validateRequestBody(request) {
+        const { opportunity } = request.body;
+
+        if (!request.session.user) {
+          return invalid({
+            permissions: [permissions.ERROR_MESSAGE]
+          });
+        }
+
+        const validatedCWUOpportunity = await validateCWUOpportunityId(connection, opportunity, request.session);
+        if (isInvalid(validatedCWUOpportunity)) {
+          return invalid({
+            notFound: ['The specified opportunity does not exist']
+          });
+        }
+
+        // Check for existing subscription for this user
+        const dbResult = await db.readOneCWUSubscriberByOpportunityAndUser(connection, validatedCWUOpportunity.value.id, request.session.user.id, request.session);
+        if (isInvalid(dbResult)) {
+          return invalid({
+            database: [db.ERROR_MESSAGE]
+          });
+        }
+        if (dbResult.value) {
+          return invalid({
+            conflict: ['This user is already subscribed to this opportunity.']
+          });
+        }
+
+        return valid({
+          session: request.session,
+          opportunity: validatedCWUOpportunity.value.id,
+          user: request.session.user.id
+        });
+      },
+      respond: wrapRespond<ValidatedCreateRequestBody, CreateValidationErrors, JsonResponseBody<CWUOpportunitySubscriber>, JsonResponseBody<CreateValidationErrors>, Session>({
+        valid: (async request => {
+          const dbResult = await db.createCWUOpportunitySubscriber(connection, omit(request.body, 'session'), request.body.session);
+          if (isInvalid(dbResult)) {
+            return basicResponse(503, request.session, makeJsonResponseBody({ database: [db.ERROR_MESSAGE] }));
+          }
+          return basicResponse(201, request.session, makeJsonResponseBody(dbResult.value));
+        }),
+        invalid: (async request => {
+          return basicResponse(400, request.session, makeJsonResponseBody(request.body));
+        })
+      })
+    };
+  },
+
+  delete(connection) {
+    return {
+      async validateRequestBody(request) {
+        if (!request.session.user) {
+          return invalid({
+            permissions: [permissions.ERROR_MESSAGE]
+          });
+        }
+        const validatedCWUOpportunity = await validateCWUOpportunityId(connection, request.params.id, request.session);
+        if (isInvalid(validatedCWUOpportunity)) {
+          return invalid({ notFound: ['Opportunity not found.'] });
+        }
+        // Check for existing subscription for this user
+        const dbResult = await db.readOneCWUSubscriberByOpportunityAndUser(connection, validatedCWUOpportunity.value.id, request.session.user.id, request.session);
+        if (isInvalid(dbResult)) {
+          return invalid({
+            database: [db.ERROR_MESSAGE]
+          });
+        }
+        if (!dbResult.value) {
+          return invalid({
+            notFound: ['This user is not subscribed to this opportunity.']
+          });
+        }
+        return valid({
+          opportunity: validatedCWUOpportunity.value.id,
+          user: request.session.user.id,
+          session: request.session
+        });
+      },
+      respond: wrapRespond({
+        valid: async request => {
+          const dbResult = await db.deleteCWUOpportunitySubscriber(connection, request.body, request.session);
+          if (isInvalid(dbResult)) {
+            return basicResponse(503, request.session, makeJsonResponseBody({ database: [db.ERROR_MESSAGE] }));
+          }
+          return basicResponse(200, request.session, makeJsonResponseBody(dbResult.value));
+        },
+        invalid: async request => {
+          return basicResponse(400, request.session, makeJsonResponseBody(request.body));
+        }
+      })
+    };
+  }
+};
+
+export default resource;

--- a/src/back-end/lib/server/index.ts
+++ b/src/back-end/lib/server/index.ts
@@ -423,6 +423,8 @@ export function wrapRespond<ValidReqB, InvalidReqB extends BodyWithErrors, Valid
           return respond(503, request.body.value);
         } else if (request.body.value.notFound) {
           return respond(404, request.body.value);
+        } else if (request.body.value.conflict) {
+          return respond(409, request.body.value);
         } else {
           return await responseValidation.invalid({
             ...request,

--- a/src/front-end/sass/index.scss
+++ b/src/front-end/sass/index.scss
@@ -126,7 +126,7 @@ $input-btn-padding-x:    1rem;
 $input-btn-padding-x-sm: 0.75rem;
 $input-btn-padding-x-lg: 1.25rem;
 
-$badge-font-size: 75%;
+$badge-font-size: 85%;
 
 $border-radius-sm: 0.2rem;
 $border-radius:    0.3em;
@@ -388,6 +388,7 @@ nav.navbar .nav-link:hover {
 .badge {
   display: inline-flex;
   padding: 0.35em 0.7em;
+  letter-spacing: 1px;
 }
 
 .custom-radio,

--- a/src/front-end/typescript/lib/pages/opportunity/code-with-us/edit/tab/opportunity.tsx
+++ b/src/front-end/typescript/lib/pages/opportunity/code-with-us/edit/tab/opportunity.tsx
@@ -283,7 +283,7 @@ export const component: Tab.Component<State, Msg> = {
               default: return 'Save Changes';
             }
           })(),
-          disabled: (() => {
+          disabled: isSaveChangesLoading || (() => {
             if (oppStatus === CWUOpportunityStatus.Draft) {
               // No validation required, always possible to save a draft.
               return false;

--- a/src/front-end/typescript/lib/pages/opportunity/code-with-us/lib/components/form.tsx
+++ b/src/front-end/typescript/lib/pages/opportunity/code-with-us/lib/components/form.tsx
@@ -861,7 +861,7 @@ const TabLink: View<Props & { tab: TabId; }> = ({ state, dispatch, tab, disabled
     <NavItem>
       <Link
         nav
-        symbol_={disabled || isValid() ? undefined : leftPlacement(iconLinkSymbol('exclamation-circle'))}
+        symbol_={isValid() ? undefined : leftPlacement(iconLinkSymbol('exclamation-circle'))}
         symbolClassName='text-warning'
         className={`text-nowrap ${isActive ? 'active text-body' : 'text-primary'}`}
         onClick={() => {dispatch(adt('updateActiveTab', tab)); }}>

--- a/src/front-end/typescript/lib/views/badge.tsx
+++ b/src/front-end/typescript/lib/views/badge.tsx
@@ -11,6 +11,7 @@ export interface Props {
 }
 
 const Badge: View<Props> = ({ text, color, className = '', pill }) => {
+  className = `${className} text-uppercase`;
   return (
     <reactstrap.Badge color={color} className={className} pill={pill}>
       {text}

--- a/src/migrations/tasks/20200213203214_cwu_null_createdby.ts
+++ b/src/migrations/tasks/20200213203214_cwu_null_createdby.ts
@@ -1,0 +1,19 @@
+import { makeDomainLogger } from 'back-end/lib/logger';
+import { console as consoleAdapter } from 'back-end/lib/logger/adapters';
+import Knex from 'knex';
+
+const logger = makeDomainLogger(consoleAdapter, 'migrations');
+
+export async function up(connection: Knex): Promise<void> {
+  await connection.schema.alterTable('cwuOpportunityStatuses', table => {
+    table.uuid('createdBy').nullable().alter();
+  });
+  logger.info('Completed modifying users table.');
+}
+
+export async function down(connection: Knex): Promise<void> {
+  await connection.schema.alterTable('cwuOpportunityStatuses', table => {
+    table.uuid('createdBy').notNullable().alter();
+  });
+  logger.info('Completed reverting users table.');
+}

--- a/src/migrations/tasks/20200213210722_cwu_subscribers.ts
+++ b/src/migrations/tasks/20200213210722_cwu_subscribers.ts
@@ -1,0 +1,20 @@
+import { makeDomainLogger } from 'back-end/lib/logger';
+import { console as consoleAdapter } from 'back-end/lib/logger/adapters';
+import Knex from 'knex';
+
+const logger = makeDomainLogger(consoleAdapter, 'migrations');
+
+export async function up(connection: Knex): Promise<void> {
+  await connection.schema.createTable('cwuOpportunitySubscribers', table => {
+    table.uuid('opportunity').references('id').inTable('cwuOpportunities').notNullable();
+    table.uuid('user').references('id').inTable('users').notNullable();
+    table.timestamp('createdAt').notNullable();
+    table.primary(['opportunity', 'user']);
+  });
+  logger.info('Created table cwuOpportunitySubscribers');
+}
+
+export async function down(connection: Knex): Promise<void> {
+  await connection.schema.dropTable('cwuOpportunitySubscribers');
+  logger.info('Dropped table cwuOpportunitySubscribers');
+}

--- a/src/shared/lib/resources/opportunity/code-with-us.ts
+++ b/src/shared/lib/resources/opportunity/code-with-us.ts
@@ -32,7 +32,7 @@ export function parseCWUOpportunityStatus(raw: string): CWUOpportunityStatus | n
 export interface CWUOpportunityStatusRecord {
   id: Id;
   createdAt: Date;
-  createdBy: User;
+  createdBy: User | null;
   status: CWUOpportunityStatus;
   note: string;
 }

--- a/src/shared/lib/resources/opportunity/code-with-us.ts
+++ b/src/shared/lib/resources/opportunity/code-with-us.ts
@@ -67,6 +67,7 @@ export interface CWUOpportunity {
   attachments: FileRecord[];
   addenda: Addendum[];
   statusHistory?: CWUOpportunityStatusRecord[];
+  subscribed?: boolean;
 
   // TODO
   reporting?: {

--- a/src/shared/lib/resources/subscribers/code-with-us.ts
+++ b/src/shared/lib/resources/subscribers/code-with-us.ts
@@ -1,0 +1,18 @@
+import { CWUOpportunitySlim } from 'shared/lib/resources/opportunity/code-with-us';
+import { UserSlim } from 'shared/lib/resources/user';
+import { BodyWithErrors, Id } from 'shared/lib/types';
+import { ErrorTypeFrom } from 'shared/lib/validation';
+
+export interface CWUOpportunitySubscriber {
+  opportunity: CWUOpportunitySlim;
+  user: UserSlim;
+  createdAt: Date;
+}
+
+export interface CreateRequestBody {
+  opportunity: Id;
+}
+
+export type CreateValidationErrors = ErrorTypeFrom<CreateRequestBody> & BodyWithErrors;
+
+export type DeleteValidationErrors = BodyWithErrors;

--- a/src/shared/lib/types.ts
+++ b/src/shared/lib/types.ts
@@ -49,4 +49,5 @@ export interface BodyWithErrors {
   permissions?: string[];
   database?: string[];
   notFound?: string[];
+  conflict?: string[];
 }


### PR DESCRIPTION
This PR adds a resource for opportunity subscribers/watchers.  It includes endpoints for deleting and creating subscriptions.

The create request body consists of an opportunity id, and will create a subscription for the current user (pulled from session)

The delete route should includes a URL param for the opportunity id (since delete does not have a request body).

Also updated CWUOpportunity type to include an optional `subscribed` property (only defined for authenticated users).