### PR TITLE
DM-346 do not return proposal history to vendors

### DIFF
--- a/src/back-end/lib/permissions.ts
+++ b/src/back-end/lib/permissions.ts
@@ -173,6 +173,11 @@ export async function readCWUProposalScore(connection: Connection, session: Sess
           (proposalStatus === CWUProposalStatus.Awarded || proposalStatus === CWUProposalStatus.NotAwarded) || false));
 }
 
+export async function readCWUProposalHistory(connection: Connection, session: Session, opportunityId: string): Promise<boolean> {
+  return isAdmin(session) ||
+    (session.user && await isCWUOpportunityAuthor(connection, session.user, opportunityId)) || false;
+}
+
 export function createCWUProposal(session: Session): boolean {
   return isVendor(session);
 }

--- a/src/back-end/lib/resources/proposal/code-with-us.ts
+++ b/src/back-end/lib/resources/proposal/code-with-us.ts
@@ -111,17 +111,13 @@ const resource: Resource = {
   readOne(connection) {
     return nullRequestBodyHandler<JsonResponseBody<CWUProposal | string[]>, Session>(async request => {
       const respond = (code: number, body: CWUProposal | string[]) => basicResponse(code, request.session, makeJsonResponseBody(body));
-      const validatedCWUOpportunity = await validateCWUOpportunityId(connection, request.query.opportunity, request.session);
-      if (isInvalid(validatedCWUOpportunity)) {
-        return respond(404, ['Code With Us opportunity not found.']);
-      }
 
       const validatedCWUProposal = await validateCWUProposalId(connection, request.params.id, request.session);
       if (isInvalid(validatedCWUProposal)) {
         return respond(404, ['Proposal not found.']);
       }
 
-      if (!await permissions.readOneCWUProposal(connection, request.session, request.query.opportunity, request.params.id)) {
+      if (!await permissions.readOneCWUProposal(connection, request.session, validatedCWUProposal.value.opportunity.id, request.params.id)) {
         return respond(401, [permissions.ERROR_MESSAGE]);
       }
       const dbResult = await db.readOneCWUProposal(connection, request.params.id, request.session);


### PR DESCRIPTION
Also remove opportunity query param from proposal readOne (DM-348)

You no longer need to include the opportunity id when reading one proposal 