### PR TITLE
DM-311 rfq swu qualified status / member lists

### DIFF
--- a/src/back-end/lib/db/organization.ts
+++ b/src/back-end/lib/db/organization.ts
@@ -1,9 +1,9 @@
-import CAPABILITIES from 'back-end/../shared/lib/data/capabilities';
 import { generateUuid } from 'back-end/lib';
 import { Connection, tryDb } from 'back-end/lib/db';
 import { createAffiliation, readManyAffiliationsForOrganization } from 'back-end/lib/db/affiliation';
 import { readOneFileById } from 'back-end/lib/db/file';
 import { spread, union } from 'lodash';
+import CAPABILITIES from 'shared/lib/data/capabilities';
 import { valid } from 'shared/lib/http';
 import { MembershipStatus, MembershipType } from 'shared/lib/resources/affiliation';
 import { FileRecord } from 'shared/lib/resources/file';

--- a/src/back-end/lib/permissions.ts
+++ b/src/back-end/lib/permissions.ts
@@ -112,6 +112,11 @@ export function readManyAffiliations(session: Session): boolean {
   return isVendor(session);
 }
 
+export async function readManyAffiliationsForOrganization(connection: Connection, session: Session, orgId: string): Promise<boolean> {
+  // Membership lists for organizations can only be read by admins or organization owner
+  return isAdmin(session) || (!!session.user && await isUserOwnerOfOrg(connection, session.user, orgId));
+}
+
 export async function createAffiliation(connection: Connection, session: Session, orgId: string): Promise<boolean> {
   // New affiliations can be created only by organization owners, or admins
   return isAdmin(session) || (!!session.user && await isUserOwnerOfOrg(connection, session.user, orgId));

--- a/src/back-end/lib/resources/organization.ts
+++ b/src/back-end/lib/resources/organization.ts
@@ -45,7 +45,7 @@ const resource: Resource = {
   readMany(connection) {
     return nullRequestBodyHandler<JsonResponseBody<OrganizationSlim[] | string[]>, Session>(async request => {
       const respond = (code: number, body: OrganizationSlim[] | string[]) => basicResponse(code, request.session, makeJsonResponseBody(body));
-      // Pass session in so we can add owner name for admin/owner only
+      // Pass session in so we can add owner name, swuQualified status for admin/owner only
       const dbResult = await db.readManyOrganizations(connection, request.session);
       if (isInvalid(dbResult)) {
         return respond(503, [db.ERROR_MESSAGE]);

--- a/src/back-end/lib/resources/organization.ts
+++ b/src/back-end/lib/resources/organization.ts
@@ -1,22 +1,22 @@
 import * as crud from 'back-end/lib/crud';
 import * as db from 'back-end/lib/db';
 import * as permissions from 'back-end/lib/permissions';
-import { basicResponse, JsonResponseBody, makeJsonResponseBody, nullRequestBodyHandler, Request, Response, wrapRespond } from 'back-end/lib/server';
+import { basicResponse, JsonResponseBody, makeJsonResponseBody, nullRequestBodyHandler, wrapRespond } from 'back-end/lib/server';
 import { SupportedRequestBodies, SupportedResponseBodies } from 'back-end/lib/types';
 import { validateFileRecord, validateOrganizationId } from 'back-end/lib/validation';
+import { get } from 'lodash';
 import { getString } from 'shared/lib';
-import { CreateRequestBody, CreateValidationErrors, DeleteValidationErrors, Organization, OrganizationSlim, UpdateRequestBody, UpdateValidationErrors } from 'shared/lib/resources/organization';
+import { CreateRequestBody, CreateValidationErrors, DeleteValidationErrors, Organization, OrganizationSlim, UpdateProfileRequestBody, UpdateRequestBody as SharedUpdateRequestBody, UpdateValidationErrors } from 'shared/lib/resources/organization';
 import { Session } from 'shared/lib/resources/session';
-import { Id } from 'shared/lib/types';
+import { ADT, adt } from 'shared/lib/types';
 import { allValid, getInvalidValue, invalid, isInvalid, isValid, optionalAsync, valid, validateUUID, Validation } from 'shared/lib/validation';
 import * as orgValidation from 'shared/lib/validation/organization';
 
-export interface ValidatedUpdateRequestBody extends UpdateRequestBody {
-  id: Id;
-  active?: boolean;
-  deactivatedOn?: Date;
-  deactivatedBy?: Id;
-}
+type UpdateRequestBody = SharedUpdateRequestBody | null;
+
+export type ValidatedUpdateRequestBody
+  = ADT<'updateProfile', UpdateProfileRequestBody>
+  | ADT<'acceptSWUTerms'>;
 
 export type ValidatedCreateRequestBody = CreateRequestBody;
 
@@ -201,121 +201,151 @@ const resource: Resource = {
     return {
       async parseRequestBody(request): Promise<UpdateRequestBody> {
         const body = request.body.tag === 'json' ? request.body.value : {};
-        return {
-          legalName: getString(body, 'legalName'),
-          logoImageFile: getString(body, 'logoImageFile'),
-          websiteUrl: getString(body, 'websiteUrl'),
-          streetAddress1: getString(body, 'streetAddress1'),
-          streetAddress2: getString(body, 'streetAddress2'),
-          city: getString(body, 'city'),
-          region: getString(body, 'region'),
-          mailCode: getString(body, 'mailCode'),
-          country: getString(body, 'country'),
-          contactName: getString(body, 'contactName'),
-          contactTitle: getString(body, 'contactTitle'),
-          contactEmail: getString(body, 'contactEmail'),
-          contactPhone: getString(body, 'contactString')
-        };
+        const tag = getString(body, 'tag');
+        const value: unknown = get(body, 'value');
+        switch (tag) {
+          case 'updateProfile':
+            return adt('updateProfile', {
+              legalName: getString(value, 'legalName'),
+              logoImageFile: getString(value, 'logoImageFile'),
+              websiteUrl: getString(value, 'websiteUrl'),
+              streetAddress1: getString(value, 'streetAddress1'),
+              streetAddress2: getString(value, 'streetAddress2'),
+              city: getString(value, 'city'),
+              region: getString(value, 'region'),
+              mailCode: getString(value, 'mailCode'),
+              country: getString(value, 'country'),
+              contactName: getString(value, 'contactName'),
+              contactTitle: getString(value, 'contactTitle'),
+              contactEmail: getString(value, 'contactEmail'),
+              contactPhone: getString(value, 'contactString')
+            });
+          case 'acceptSWUTerms':
+            return adt('acceptSWUTerms');
+          default:
+            return null;
+        }
       },
       async validateRequestBody(request): Promise<Validation<ValidatedUpdateRequestBody, UpdateValidationErrors>> {
-        const {
-          legalName,
-          logoImageFile,
-          websiteUrl,
-          streetAddress1,
-          streetAddress2,
-          city,
-          region,
-          mailCode,
-          country,
-          contactName,
-          contactTitle,
-          contactEmail,
-          contactPhone } = request.body;
-
+        if (!request.body) { return invalid({ organization: adt('parseFailure' as const)}); }
         if (!await permissions.updateOrganization(connection, request.session, request.params.id)) {
           return invalid({
             permissions: [permissions.ERROR_MESSAGE]
           });
         }
-
         const validatedOrganization = await validateOrganizationId(connection, request.params.id);
-        const validatedLegalName = orgValidation.validateLegalName(legalName);
-        const validatedLogoImageFile = await optionalAsync(logoImageFile, v => validateFileRecord(connection, v));
-        const validatedWebsiteUrl = orgValidation.validateWebsiteUrl(websiteUrl);
-        const validatedStreetAddress1 = orgValidation.validateStreetAddress1(streetAddress1);
-        const validatedStreetAddress2 = orgValidation.validateStreetAddress2(streetAddress2);
-        const validatedCity = orgValidation.validateCity(city);
-        const validatedRegion = orgValidation.validateRegion(region);
-        const validatedMailCode = orgValidation.validateMailCode(mailCode);
-        const validatedCountry = orgValidation.validateCountry(country);
-        const validatedContactName = orgValidation.validateContactName(contactName);
-        const validatedContactTitle = orgValidation.validateContactTitle(contactTitle);
-        const validatedContactEmail = orgValidation.validateContactEmail(contactEmail);
-        const validatedContactPhone = orgValidation.validateContactPhone(contactPhone);
+        switch (request.body.tag) {
+          case 'updateProfile':
+            const {
+              legalName,
+              logoImageFile,
+              websiteUrl,
+              streetAddress1,
+              streetAddress2,
+              city,
+              region,
+              mailCode,
+              country,
+              contactName,
+              contactTitle,
+              contactEmail,
+              contactPhone } = request.body.value;
 
-        if (allValid([
-          validatedOrganization,
-          validatedLegalName,
-          validatedLogoImageFile,
-          validatedWebsiteUrl,
-          validatedStreetAddress1,
-          validatedStreetAddress2,
-          validatedCity,
-          validatedRegion,
-          validatedMailCode,
-          validatedCountry,
-          validatedContactName,
-          validatedContactTitle,
-          validatedContactEmail,
-          validatedContactPhone
-        ])) {
-          return valid({
-            id: (validatedOrganization.value as Organization).id,
-            legalName: validatedLegalName.value,
-            logoImageFile: isValid(validatedLogoImageFile) && validatedLogoImageFile.value && validatedLogoImageFile.value.id,
-            websiteUrl: validatedWebsiteUrl.value,
-            streetAddress1: validatedStreetAddress1.value,
-            streetAddress2: validatedStreetAddress2.value,
-            city: validatedCity.value,
-            region: validatedRegion.value,
-            mailCode: validatedMailCode.value,
-            country: validatedCountry.value,
-            contactName: validatedContactName.value,
-            contactTitle: validatedContactTitle.value,
-            contactEmail: validatedContactEmail.value,
-            contactPhone: validatedContactPhone.value
-          } as ValidatedUpdateRequestBody);
-        } else {
-          return invalid({
-            id: getInvalidValue(validatedOrganization, undefined),
-            legalName: getInvalidValue(validatedLegalName, undefined),
-            logoImageFile: getInvalidValue(validatedLogoImageFile, undefined),
-            websiteUrl: getInvalidValue(validatedWebsiteUrl, undefined),
-            contactName: getInvalidValue(validatedContactName, undefined),
-            contactTitle: getInvalidValue(validatedContactTitle, undefined),
-            contactEmail: getInvalidValue(validatedContactEmail, undefined),
-            contactPhone: getInvalidValue(validatedContactPhone, undefined),
-            streetAddress1: getInvalidValue(validatedStreetAddress1, undefined),
-            streetAddress2: getInvalidValue(validatedStreetAddress2, undefined),
-            city: getInvalidValue(validatedCity, undefined),
-            region: getInvalidValue(validatedRegion, undefined),
-            mailCode: getInvalidValue(validatedMailCode, undefined),
-            country: getInvalidValue(validatedCountry, undefined)
-          });
+            const validatedLegalName = orgValidation.validateLegalName(legalName);
+            const validatedLogoImageFile = await optionalAsync(logoImageFile, v => validateFileRecord(connection, v));
+            const validatedWebsiteUrl = orgValidation.validateWebsiteUrl(websiteUrl);
+            const validatedStreetAddress1 = orgValidation.validateStreetAddress1(streetAddress1);
+            const validatedStreetAddress2 = orgValidation.validateStreetAddress2(streetAddress2);
+            const validatedCity = orgValidation.validateCity(city);
+            const validatedRegion = orgValidation.validateRegion(region);
+            const validatedMailCode = orgValidation.validateMailCode(mailCode);
+            const validatedCountry = orgValidation.validateCountry(country);
+            const validatedContactName = orgValidation.validateContactName(contactName);
+            const validatedContactTitle = orgValidation.validateContactTitle(contactTitle);
+            const validatedContactEmail = orgValidation.validateContactEmail(contactEmail);
+            const validatedContactPhone = orgValidation.validateContactPhone(contactPhone);
+
+            if (allValid([
+              validatedOrganization,
+              validatedLegalName,
+              validatedLogoImageFile,
+              validatedWebsiteUrl,
+              validatedStreetAddress1,
+              validatedStreetAddress2,
+              validatedCity,
+              validatedRegion,
+              validatedMailCode,
+              validatedCountry,
+              validatedContactName,
+              validatedContactTitle,
+              validatedContactEmail,
+              validatedContactPhone
+            ])) {
+              return valid(adt('updateProfile', {
+                id: (validatedOrganization.value as Organization).id,
+                legalName: validatedLegalName.value,
+                logoImageFile: isValid(validatedLogoImageFile) && validatedLogoImageFile.value && validatedLogoImageFile.value.id,
+                websiteUrl: validatedWebsiteUrl.value,
+                streetAddress1: validatedStreetAddress1.value,
+                streetAddress2: validatedStreetAddress2.value,
+                city: validatedCity.value,
+                region: validatedRegion.value,
+                mailCode: validatedMailCode.value,
+                country: validatedCountry.value,
+                contactName: validatedContactName.value,
+                contactTitle: validatedContactTitle.value,
+                contactEmail: validatedContactEmail.value,
+                contactPhone: validatedContactPhone.value
+              } as UpdateProfileRequestBody));
+            } else {
+              return invalid({
+                organization: adt('updateProfile' as const, {
+                  id: getInvalidValue(validatedOrganization, undefined),
+                  legalName: getInvalidValue(validatedLegalName, undefined),
+                  logoImageFile: getInvalidValue(validatedLogoImageFile, undefined),
+                  websiteUrl: getInvalidValue(validatedWebsiteUrl, undefined),
+                  contactName: getInvalidValue(validatedContactName, undefined),
+                  contactTitle: getInvalidValue(validatedContactTitle, undefined),
+                  contactEmail: getInvalidValue(validatedContactEmail, undefined),
+                  contactPhone: getInvalidValue(validatedContactPhone, undefined),
+                  streetAddress1: getInvalidValue(validatedStreetAddress1, undefined),
+                  streetAddress2: getInvalidValue(validatedStreetAddress2, undefined),
+                  city: getInvalidValue(validatedCity, undefined),
+                  region: getInvalidValue(validatedRegion, undefined),
+                  mailCode: getInvalidValue(validatedMailCode, undefined),
+                  country: getInvalidValue(validatedCountry, undefined)
+                })
+              });
+            }
+          case 'acceptSWUTerms':
+            if (isValid(validatedOrganization)) {
+              if (validatedOrganization.value.acceptedSWUTerms) {
+                return invalid({ organization: adt('acceptSWUTerms' as const, ['The SWU Terms have already been accepted for this organization.'])});
+              }
+              return valid(adt('acceptSWUTerms' as const));
+            }
+          default:
+            return invalid({ organization: adt('parseFailure' as const) });
         }
       },
       respond: wrapRespond({
         valid: (async request => {
-          const dbResult = await db.updateOrganization(connection, request.body);
+          let dbResult: Validation<Organization, null>;
+          switch (request.body.tag) {
+            case 'updateProfile':
+              dbResult = await db.updateOrganization(connection, request.body.value);
+              break;
+            case 'acceptSWUTerms':
+              dbResult = await db.updateOrganization(connection, { acceptedSWUTerms: new Date(), id: request.params.id });
+          }
           if (isInvalid(dbResult)) {
             return basicResponse(503, request.session, makeJsonResponseBody({ database: [db.ERROR_MESSAGE] }));
           }
           return basicResponse(200, request.session, makeJsonResponseBody(dbResult.value));
-        }) as (request: Request<ValidatedUpdateRequestBody, Session>) => Promise<Response<JsonResponseBody<Organization | UpdateValidationErrors>, Session>>,
+        }),
         invalid: (async request => {
           return basicResponse(400, request.session, makeJsonResponseBody(request.body));
-        }) as (request: Request<UpdateValidationErrors, Session>) => Promise<Response<JsonResponseBody<UpdateValidationErrors>, Session>>
+        })
       })
     };
   },

--- a/src/migrations/tasks/20200310205432_swu_terms.ts
+++ b/src/migrations/tasks/20200310205432_swu_terms.ts
@@ -1,0 +1,19 @@
+import { makeDomainLogger } from 'back-end/lib/logger';
+import { console as consoleAdapter } from 'back-end/lib/logger/adapters';
+import Knex from 'knex';
+
+const logger = makeDomainLogger(consoleAdapter, 'migrations');
+
+export async function up(connection: Knex): Promise<void> {
+  await connection.schema.alterTable('organizations', table => {
+    table.timestamp('acceptedSWUTerms').nullable();
+  });
+  logger.info('Modified organizations table.');
+}
+
+export async function down(connection: Knex): Promise<void> {
+  await connection.schema.alterTable('organizations', table => {
+    table.dropColumn('acceptedSWUTerms');
+  });
+  logger.info('Reverted organizations table.');
+}

--- a/src/shared/lib/resources/affiliation.ts
+++ b/src/shared/lib/resources/affiliation.ts
@@ -26,9 +26,15 @@ export interface Affiliation {
 // Used when returning a list of the current user's affiliations
 export interface AffiliationSlim {
   id: Id;
-  organization: Pick<Organization, 'id' | 'legalName'>;
   membershipType: MembershipType;
-  user: Pick<User, 'id' | 'status' | 'name' | 'avatarImageFile' | 'capabilities'>;
+  organization: Pick<Organization, 'id' | 'legalName'>;
+}
+
+export interface AffiliationMember {
+  id: Id;
+  membershipType: MembershipType;
+  membershipStatus: MembershipStatus;
+  user: Pick<User, 'id' | 'name' | 'avatarImageFile' | 'capabilities'>;
 }
 
 export interface CreateRequestBody {

--- a/src/shared/lib/resources/affiliation.ts
+++ b/src/shared/lib/resources/affiliation.ts
@@ -28,6 +28,7 @@ export interface AffiliationSlim {
   id: Id;
   organization: Pick<Organization, 'id' | 'legalName'>;
   membershipType: MembershipType;
+  user: Pick<User, 'id' | 'status' | 'name' | 'avatarImageFile' | 'capabilities'>;
 }
 
 export interface CreateRequestBody {

--- a/src/shared/lib/resources/organization.ts
+++ b/src/shared/lib/resources/organization.ts
@@ -1,6 +1,6 @@
 import { FileRecord } from 'shared/lib/resources/file';
 import { UserSlim } from 'shared/lib/resources/user';
-import { BodyWithErrors, Id } from 'shared/lib/types';
+import { ADT, BodyWithErrors, Id } from 'shared/lib/types';
 import { ErrorTypeFrom } from 'shared/lib/validation/index';
 
 export interface Organization {
@@ -42,8 +42,21 @@ export interface CreateRequestBody extends Omit<Organization, 'id' | 'createdAt'
 
 export type CreateValidationErrors = ErrorTypeFrom<CreateRequestBody> & BodyWithErrors;
 
-export type UpdateRequestBody = CreateRequestBody;
+export type UpdateRequestBody
+  = ADT<'updateProfile', UpdateProfileRequestBody>
+  | ADT<'acceptSWUTerms'>;
 
-export type UpdateValidationErrors = ErrorTypeFrom<UpdateRequestBody> & BodyWithErrors;
+export type UpdateProfileRequestBody = CreateRequestBody;
+
+export type UpdateProfileValidationErrors = ErrorTypeFrom<UpdateProfileRequestBody>;
+
+type UpdateADTErrors
+  = ADT<'updateProfile', UpdateProfileValidationErrors>
+  | ADT<'acceptSWUTerms', string[]>
+  | ADT<'parseFailure'>;
+
+export interface UpdateValidationErrors extends BodyWithErrors {
+  organization?: UpdateADTErrors;
+}
 
 export type DeleteValidationErrors = BodyWithErrors;

--- a/src/shared/lib/resources/organization.ts
+++ b/src/shared/lib/resources/organization.ts
@@ -24,16 +24,19 @@ export interface Organization {
   owner: UserSlim;
   deactivatedOn?: Date;
   deactivatedBy?: Id;
+  acceptedSWUTerms: Date | null;
+  swuQualified: boolean;
 }
 
 export interface OrganizationSlim {
   id: Id;
   legalName: string;
   logoImageFile?: FileRecord;
-  owner?: UserSlim;
+  owner?: UserSlim;       // Admin/owner only
+  swuQualified?: boolean; // Admin/owner only
 }
 
-export interface CreateRequestBody extends Omit<Organization, 'id' | 'createdAt' | 'updatedAt' | 'logoImageFile' | 'active' | 'owner'> {
+export interface CreateRequestBody extends Omit<Organization, 'id' | 'createdAt' | 'updatedAt' | 'logoImageFile' | 'active' | 'owner' | 'acceptedSWUTerms' | 'swuQualified'> {
   logoImageFile?: Id;
 }
 


### PR DESCRIPTION
This PR includes the following:

1. Modified readMany affiliations to take an optional `organization` query param.  If included, this endpoint will return the team members for that org id (permission for admin/org owner only)
2. Added an `acceptedSWUTerms` field to the Organization data model and type.  It's a nullable date field.
3. Added a `swuQualified` boolean flag to the Organization type.  This is calculated and included on readOne and readMany responses for admins/org owners only (similar to owner information).  It is set  true if there are at least 2 active members, all capabilities across the team are met, and the terms have been accepted.

The one piece left to do is how to accept terms.  I can do this as an update on the organization with an ADT to separate regular org profile updates from term acceptance, or just include it as part of the existing org update.  @dhruvio let me know what's preferred, as the first option would require work on the frontend.