### PR TITLE
Squashed changes

### DIFF
--- a/src/front-end/sass/index.scss
+++ b/src/front-end/sass/index.scss
@@ -387,6 +387,13 @@ table {
     @extend .bg-light;
   }
 
+  /* Note(Jesse) : In order to have the table cells not 'pop' when content
+   * that's hidden gets its display property toggled, this can be set to
+   * visibility: hidden.  I did this in an earlier PR, and it was reverted, for
+   * what reason I'm not sure.  This popping is visible on
+   * organizations/:id?tab=team when hovering over the team members.
+   * Grep for : @popping_remove_button
+   **/
   .table-show-on-hover {
     display: none;
   }

--- a/src/front-end/typescript/lib/app/router.ts
+++ b/src/front-end/typescript/lib/app/router.ts
@@ -3,6 +3,7 @@ import * as Router from 'front-end/lib/framework/router';
 import * as PageContent from 'front-end/lib/pages/content';
 import * as PageNotice from 'front-end/lib/pages/notice';
 import * as CWUOpportunityEditTab from 'front-end/lib/pages/opportunity/code-with-us/edit/tab';
+import * as OrganizationTab from 'front-end/lib/pages/organization/lib/components/tab';
 import * as CWUProposalEditTab from 'front-end/lib/pages/proposal/code-with-us/edit/tab';
 import * as CWUProposalViewTab from 'front-end/lib/pages/proposal/code-with-us/view/tab';
 import * as UserProfileTab from 'front-end/lib/pages/user/profile/tab';
@@ -241,6 +242,18 @@ const router: Router.Router<Route> = {
       }
     },
     {
+      path: '/organizations/:id',
+      makeRoute({ params, query }) {
+        return {
+          tag: 'orgView',
+          value: {
+            orgId: params.id || '',
+            tab: OrganizationTab.parseTabId(query.tab) || undefined
+          }
+        };
+      }
+    },
+    {
       path: '/users/:id',
       makeRoute({ params, query }) {
         return {
@@ -362,12 +375,15 @@ const router: Router.Router<Route> = {
         return `/users/${route.value.userId}${route.value.tab ? `?tab=${route.value.tab}` : ''}`;
       case 'userList':
         return '/users';
+
       case 'orgList':
         return '/organizations';
       case 'orgEdit':
         return `/organizations/${route.value.orgId}/edit`;
       case 'orgCreate':
         return '/organizations/create';
+      case 'orgView':
+        return `/organizations/${route.value.orgId}${route.value.tab ? `?tab=${route.value.tab}` : ''}`;
 
       case 'proposalSWUCreate':
         return `/opportunities/sprint-with-us/${route.value.opportunityId}/proposals/create`;

--- a/src/front-end/typescript/lib/app/types.ts
+++ b/src/front-end/typescript/lib/app/types.ts
@@ -18,9 +18,12 @@ import * as PageOpportunityCWUCreate from 'front-end/lib/pages/opportunity/code-
 import * as PageOpportunityCWUEdit from 'front-end/lib/pages/opportunity/code-with-us/edit';
 import * as PageOpportunityCWUView from 'front-end/lib/pages/opportunity/code-with-us/view';
 import * as PageOpportunities from 'front-end/lib/pages/opportunity/list';
+
 import * as PageOrgCreate from 'front-end/lib/pages/organization/create';
 import * as PageOrgEdit from 'front-end/lib/pages/organization/edit';
 import * as PageOrgList from 'front-end/lib/pages/organization/list';
+import * as PageOrgView from 'front-end/lib/pages/organization/view';
+
 import * as PageProposalCWUCreate from 'front-end/lib/pages/proposal/code-with-us/create';
 import * as PageProposalCWUEdit from 'front-end/lib/pages/proposal/code-with-us/edit';
 import * as PageProposalCWUExportAll from 'front-end/lib/pages/proposal/code-with-us/export/all';
@@ -50,7 +53,9 @@ export type Route
   | ADT<'notFound',             PageNotFound.RouteParams>
   | ADT<'userList',             PageUserList.RouteParams>
   | ADT<'userProfile',          PageUserProfile.RouteParams>
+
   | ADT<'orgCreate',            PageOrgCreate.RouteParams>
+  | ADT<'orgView',              PageOrgView.RouteParams>
   | ADT<'orgList',              PageOrgList.RouteParams>
   | ADT<'orgEdit',              PageOrgEdit.RouteParams>
 
@@ -117,6 +122,7 @@ export interface State {
     orgCreate?: Immutable<PageOrgCreate.State>;
     orgList?: Immutable<PageOrgList.State>;
     orgEdit?: Immutable<PageOrgEdit.State>;
+    orgView?: Immutable<PageOrgView.State>;
 
     proposalSWUCreate?: Immutable<PageProposalSWUCreate.State>;
     proposalSWUEdit?: Immutable<PageProposalSWUEdit.State>;
@@ -158,9 +164,11 @@ type InnerMsg
   | ADT<'pageNotFound',             PageNotFound.Msg>
   | ADT<'pageUserList',             PageUserList.Msg>
   | ADT<'pageUserProfile',          PageUserProfile.Msg>
+
   | ADT<'pageOrgCreate',            PageOrgCreate.Msg>
   | ADT<'pageOrgList',              PageOrgList.Msg>
   | ADT<'pageOrgEdit',              PageOrgEdit.Msg>
+  | ADT<'pageOrgView',              PageOrgView.Msg>
 
   | ADT<'pageProposalSWUCreate',    PageProposalSWUCreate.Msg>
   | ADT<'pageProposalSWUEdit',      PageProposalSWUEdit.Msg>

--- a/src/front-end/typescript/lib/app/update.ts
+++ b/src/front-end/typescript/lib/app/update.ts
@@ -28,6 +28,7 @@ import * as PageOpportunities from 'front-end/lib/pages/opportunity/list';
 import * as PageOrgCreate from 'front-end/lib/pages/organization/create';
 import * as PageOrgEdit from 'front-end/lib/pages/organization/edit';
 import * as PageOrgList from 'front-end/lib/pages/organization/list';
+import * as PageOrgView from 'front-end/lib/pages/organization/view';
 
 import * as PageProposalCWUCreate from 'front-end/lib/pages/proposal/code-with-us/create';
 import * as PageProposalCWUEdit from 'front-end/lib/pages/proposal/code-with-us/edit';
@@ -283,6 +284,19 @@ async function initPage(state: Immutable<State>, dispatch: Dispatch<Msg>, route:
         childGetModal: PageOrgCreate.component.getModal,
         mapChildMsg(value) {
           return { tag: 'pageOrgCreate' as const, value };
+        }
+      });
+
+    case 'orgView':
+      return await initAppChildPage({
+        ...defaultPageInitParams,
+        childStatePath: ['pages', 'orgView'],
+        childRouteParams: route.value,
+        childInit: PageOrgView.component.init,
+        childGetMetadata: PageOrgView.component.getMetadata,
+        childGetModal: PageOrgView.component.getModal,
+        mapChildMsg(value) {
+          return { tag: 'pageOrgView' as const, value };
         }
       });
 
@@ -711,6 +725,17 @@ const update: Update<State, Msg> = ({ state, msg }) => {
         childUpdate: PageOrgCreate.component.update,
         childGetMetadata: PageOrgCreate.component.getMetadata,
         childGetModal: PageOrgCreate.component.getModal,
+        childMsg: msg.value
+      });
+
+    case 'pageOrgView':
+      return updateAppChildPage({
+        ...defaultPageUpdateParams,
+        mapChildMsg: value => ({ tag: 'pageOrgView', value }),
+        childStatePath: ['pages', 'orgView'],
+        childUpdate: PageOrgView.component.update,
+        childGetMetadata: PageOrgView.component.getMetadata,
+        childGetModal: PageOrgView.component.getModal,
         childMsg: msg.value
       });
 

--- a/src/front-end/typescript/lib/app/view/footer.tsx
+++ b/src/front-end/typescript/lib/app/view/footer.tsx
@@ -13,7 +13,7 @@ const links: AnchorProps[] = [
   },
   {
     children: 'About',
-    dest: routeDest(adt('content', 'about'))
+    dest: routeDest(adt('content' as const, 'about'))
   },
   {
     children: 'Disclaimer',

--- a/src/front-end/typescript/lib/app/view/index.tsx
+++ b/src/front-end/typescript/lib/app/view/index.tsx
@@ -29,6 +29,7 @@ import * as PageOpportunities from 'front-end/lib/pages/opportunity/list';
 import * as PageOrgCreate from 'front-end/lib/pages/organization/create';
 import * as PageOrgEdit from 'front-end/lib/pages/organization/edit';
 import * as PageOrgList from 'front-end/lib/pages/organization/list';
+import * as PageOrgView from 'front-end/lib/pages/organization/view';
 
 import * as PageProposalCWUCreate from 'front-end/lib/pages/proposal/code-with-us/create';
 import * as PageProposalCWUEdit from 'front-end/lib/pages/proposal/code-with-us/edit';
@@ -117,6 +118,13 @@ function pageToViewPageProps(props: ComponentViewProps<State, Msg>): ViewPagePro
         PageOrgList.component,
         state => state.pages.orgList,
         value => ({ tag: 'pageOrgList', value })
+      );
+    case 'orgView':
+      return makeViewPageProps(
+        props,
+        PageOrgView.component,
+        state => state.pages.orgView,
+        value => ({ tag: 'pageOrgView', value })
       );
 
     case 'proposalSWUCreate':

--- a/src/front-end/typescript/lib/pages/opportunity/code-with-us/create.tsx
+++ b/src/front-end/typescript/lib/pages/opportunity/code-with-us/create.tsx
@@ -132,7 +132,7 @@ export const component: PageComponent<RouteParams,  SharedState, State, Msg> = {
       getDescription: () => 'Introductory text placeholder. Can provide brief instructions on how to create and manage an opportunity (e.g. save draft verion).',
       getFooter: () => (
         <span>
-          Need help? <Link newTab color='primary' dest={routeDest(adt('content', 'code-with-us-opportunity-guide'))}>Read the guide</Link> for creating and managing a CWU opportunity
+          Need help? <Link newTab color='primary' dest={routeDest(adt('content' as const, 'code-with-us-opportunity-guide'))}>Read the guide</Link> for creating and managing a CWU opportunity
         </span>
       )
     })

--- a/src/front-end/typescript/lib/pages/opportunity/code-with-us/edit/tab/index.ts
+++ b/src/front-end/typescript/lib/pages/opportunity/code-with-us/edit/tab/index.ts
@@ -102,7 +102,7 @@ export async function makeSidebarState(opportunityId: Id, activeTab: TabId): Pro
         text: 'Read Guide',
         active: false,
         newTab: true,
-        dest: routeDest(adt('content', 'code-with-us-opportunity-guide'))
+        dest: routeDest(adt('content' as const, 'code-with-us-opportunity-guide'))
       }
     ]
   }));

--- a/src/front-end/typescript/lib/pages/opportunity/sprint-with-us/create.tsx
+++ b/src/front-end/typescript/lib/pages/opportunity/sprint-with-us/create.tsx
@@ -127,7 +127,7 @@ export const component: PageComponent<RouteParams,  SharedState, State, Msg> = {
       getDescription: () => 'Introductory text placeholder. Can provide brief instructions on how to create and manage an opportunity (e.g. save draft verion).',
       getFooter: () => (
         <span>
-          Need help? <Link newTab color='primary' dest={routeDest(adt('content', 'sprint-with-us-opportunity-guide'))}>Read the guide</Link> for creating and managing a SWU opportunity
+          Need help? <Link newTab color='primary' dest={routeDest(adt('content' as const, 'code-with-us-opportunity-guide'))}>Read the guide</Link> for creating and managing a CWU opportunity
         </span>
       )
     })

--- a/src/front-end/typescript/lib/pages/opportunity/sprint-with-us/edit/tab/index.ts
+++ b/src/front-end/typescript/lib/pages/opportunity/sprint-with-us/edit/tab/index.ts
@@ -132,7 +132,7 @@ export async function makeSidebarState(opportunityId: Id, activeTab: TabId): Pro
         text: 'Read Guide',
         active: false,
         newTab: true,
-        dest: routeDest(adt('content', 'code-with-us-opportunity-guide'))
+        dest: routeDest(adt('content' as const, 'code-with-us-opportunity-guide'))
       }
     ]
   }));

--- a/src/front-end/typescript/lib/pages/organization/lib/components/form.tsx
+++ b/src/front-end/typescript/lib/pages/organization/lib/components/form.tsx
@@ -599,4 +599,3 @@ export async function persist(params: PersistParams): Promise<PersistReturnValue
       ]);
   }
 }
-

--- a/src/front-end/typescript/lib/pages/organization/lib/components/tab/index.tsx
+++ b/src/front-end/typescript/lib/pages/organization/lib/components/tab/index.tsx
@@ -1,0 +1,25 @@
+import * as TabbedPage from 'front-end/lib/components/sidebar/menu/tabbed-page';
+import * as OrganizationTab from 'front-end/lib/pages/organization/lib/components/tab/organizations';
+import * as QualificationTab from 'front-end/lib/pages/organization/lib/components/tab/qualifications';
+import * as TeamTab from 'front-end/lib/pages/organization/lib/components/tab/team';
+
+export type TabId = TabbedPage.TabId<Tabs>;
+
+type Params = {};
+
+export interface Tabs {
+  organization: TabbedPage.Tab<Params, OrganizationTab.State, OrganizationTab.InnerMsg>;
+  team: TabbedPage.Tab<Params, TeamTab.State, TeamTab.InnerMsg>;
+  qualification: TabbedPage.Tab<Params, QualificationTab.State, QualificationTab.InnerMsg>;
+}
+
+export const parseTabId: TabbedPage.ParseTabId<Tabs> = raw => {
+  switch (raw) {
+    case 'team':
+    case 'qualification':
+    case 'organization':
+      return raw;
+    default:
+      return null;
+  }
+};

--- a/src/front-end/typescript/lib/pages/organization/lib/components/tab/organizations.tsx
+++ b/src/front-end/typescript/lib/pages/organization/lib/components/tab/organizations.tsx
@@ -1,0 +1,41 @@
+import { Route } from 'front-end/lib/app/types';
+import { ComponentView, GlobalComponentMsg, Init, Update } from 'front-end/lib/framework';
+import * as Tab from 'front-end/lib/pages/proposal/code-with-us/edit/tab';
+import React from 'react';
+import { ADT } from 'shared/lib/types';
+
+export interface State extends Tab.Params {
+  nothing: true;
+}
+
+export type InnerMsg
+  = ADT<'noop'>;
+
+export type Msg = GlobalComponentMsg<InnerMsg, Route>;
+
+const init: Init<Tab.Params, State> = async params => {
+return {
+    ...params,
+    nothing: true
+  };
+};
+
+const update: Update<State, Msg> = ({ state, msg }) => {
+  switch (msg.tag) {
+    default:
+      return [state];
+  }
+};
+
+const view: ComponentView<State, Msg> = ({ state, dispatch }) => {
+  return (
+    <div>
+    </div>
+  );
+};
+
+export const component: Tab.Component<State, Msg> = {
+  init,
+  update,
+  view
+};

--- a/src/front-end/typescript/lib/pages/organization/lib/components/tab/qualifications.tsx
+++ b/src/front-end/typescript/lib/pages/organization/lib/components/tab/qualifications.tsx
@@ -1,0 +1,41 @@
+import { Route } from 'front-end/lib/app/types';
+import { ComponentView, GlobalComponentMsg, Init, Update } from 'front-end/lib/framework';
+import * as Tab from 'front-end/lib/pages/proposal/code-with-us/edit/tab';
+import React from 'react';
+import { ADT } from 'shared/lib/types';
+
+export interface State extends Tab.Params {
+  nothing: true;
+}
+
+export type InnerMsg
+  = ADT<'noop'>;
+
+export type Msg = GlobalComponentMsg<InnerMsg, Route>;
+
+const init: Init<Tab.Params, State> = async params => {
+return {
+    ...params,
+    nothing: true
+  };
+};
+
+const update: Update<State, Msg> = ({ state, msg }) => {
+  switch (msg.tag) {
+    default:
+      return [state];
+  }
+};
+
+const view: ComponentView<State, Msg> = ({ state, dispatch }) => {
+  return (
+    <div>
+    </div>
+  );
+};
+
+export const component: Tab.Component<State, Msg> = {
+  init,
+  update,
+  view
+};

--- a/src/front-end/typescript/lib/pages/organization/lib/components/tab/team.tsx
+++ b/src/front-end/typescript/lib/pages/organization/lib/components/tab/team.tsx
@@ -1,0 +1,84 @@
+import { Route } from 'front-end/lib/app/types';
+import * as History from 'front-end/lib/components/table/history';
+import { ComponentView, GlobalComponentMsg, Immutable, immutable, Init, mapComponentDispatch, Update, updateComponentChild } from 'front-end/lib/framework';
+import * as Tab from 'front-end/lib/pages/proposal/code-with-us/edit/tab';
+import { cwuProposalEventToTitleCase, cwuProposalStatusToColor, cwuProposalStatusToTitleCase } from 'front-end/lib/pages/proposal/code-with-us/lib';
+import ViewTabHeader from 'front-end/lib/pages/proposal/code-with-us/lib/views/view-tab-header';
+import React from 'react';
+import { Col, Row } from 'reactstrap';
+import { CWUProposal } from 'shared/lib/resources/proposal/code-with-us';
+import { UserType } from 'shared/lib/resources/user';
+import { adt, ADT } from 'shared/lib/types';
+
+export interface State extends Tab.Params {
+  history: Immutable<History.State>;
+}
+
+export type InnerMsg
+  = ADT<'history', History.Msg>;
+
+export type Msg = GlobalComponentMsg<InnerMsg, Route>;
+
+function getHistoryItems({ history }: CWUProposal, viewerUserType: UserType): History.Item[] {
+  if (!history) { return []; }
+  return history
+    .map(s => ({
+      type: {
+        text: s.type.tag === 'status' ? cwuProposalStatusToTitleCase(s.type.value, viewerUserType) : cwuProposalEventToTitleCase(s.type.value),
+        color: s.type.tag === 'status' ? cwuProposalStatusToColor(s.type.value, viewerUserType) : undefined
+      },
+      note: s.note,
+      createdAt: s.createdAt,
+      createdBy: s.createdBy || undefined
+    }));
+}
+
+const init: Init<Tab.Params, State> = async params => {
+  return {
+    ...params,
+    history: immutable(await History.init({
+      idNamespace: 'cwu-proposal-history',
+      items: getHistoryItems(params.proposal, params.viewerUser.type),
+      viewerUser: params.viewerUser
+    }))
+  };
+};
+
+const update: Update<State, Msg> = ({ state, msg }) => {
+  switch (msg.tag) {
+    case 'history':
+      return updateComponentChild({
+        state,
+        childStatePath: ['history'],
+        childUpdate: History.update,
+        childMsg: msg.value,
+        mapChildMsg: value => ({ tag: 'history', value })
+      });
+    default:
+      return [state];
+  }
+};
+
+const view: ComponentView<State, Msg> = ({ state, dispatch }) => {
+  return (
+    <div>
+      <ViewTabHeader proposal={state.proposal} viewerUser={state.viewerUser} />
+      <div className='mt-5 pt-5 border-top'>
+        <Row>
+          <Col xs='12'>
+            <h3 className='mb-4'>History</h3>
+            <History.view
+              state={state.history}
+              dispatch={mapComponentDispatch(dispatch, msg => adt('history' as const, msg))} />
+          </Col>
+        </Row>
+      </div>
+    </div>
+  );
+};
+
+export const component: Tab.Component<State, Msg> = {
+  init,
+  update,
+  view
+};

--- a/src/front-end/typescript/lib/pages/organization/list.tsx
+++ b/src/front-end/typescript/lib/pages/organization/list.tsx
@@ -95,7 +95,7 @@ function tableBodyRows(state: Immutable<State>): Table.BodyRows {
     return [
       {
         children: org.owner
-          ? (<Link dest={routeDest(adt('orgEdit', { orgId: org.id })) }>{org.legalName}</Link>)
+          ? (<Link dest={routeDest(adt('orgView', { orgId: org.id })) }>{org.legalName}</Link>)
           : org.legalName
       },
       ...(showOwnerColumn(state) ? [owner] : [])

--- a/src/front-end/typescript/lib/pages/organization/view.tsx
+++ b/src/front-end/typescript/lib/pages/organization/view.tsx
@@ -1,0 +1,473 @@
+import { getContextualActionsValid, getModalValid, makePageMetadata, makeStartLoading, makeStopLoading, updateValid, viewValid, withValid } from 'front-end/lib';
+import { isUserType } from 'front-end/lib/access-control';
+import router from 'front-end/lib/app/router';
+import { Route, SharedState } from 'front-end/lib/app/types';
+import * as MenuSidebar from 'front-end/lib/components/sidebar/menu';
+import * as TabbedPage from 'front-end/lib/components/sidebar/menu/tabbed-page';
+import * as Table from 'front-end/lib/components/table';
+import { ComponentView, Dispatch, GlobalComponentMsg, Immutable, immutable, mapComponentDispatch, newRoute, PageComponent, PageInit, replaceRoute, Update, updateComponentChild, updateGlobalComponentChild } from 'front-end/lib/framework';
+import * as api from 'front-end/lib/http/api';
+import Badge from 'front-end/lib/views/badge';
+import Caps from 'shared/lib/data/capabilities';
+
+import * as OrgForm from 'front-end/lib/pages/organization/lib/components/form';
+import * as OrgTabs from 'front-end/lib/pages/organization/lib/components/tab';
+import * as OrganizationTab from 'front-end/lib/pages/organization/lib/components/tab/organizations';
+import * as QualificationTab from 'front-end/lib/pages/organization/lib/components/tab/qualifications';
+import * as TeamTab from 'front-end/lib/pages/organization/lib/components/tab/team';
+
+import Icon from 'front-end/lib/views/icon';
+import { routeDest } from 'front-end/lib/views/link';
+import Link, { iconLinkSymbol, leftPlacement } from 'front-end/lib/views/link';
+import React from 'react';
+import { Col, Row } from 'reactstrap';
+import * as OrgResource from 'shared/lib/resources/organization';
+import { User, UserType } from 'shared/lib/resources/user';
+import { adt, ADT, Id } from 'shared/lib/types';
+import { invalid, valid, Validation } from 'shared/lib/validation';
+
+interface ValidState {
+  archiveLoading: number;
+  showArchiveModal: boolean;
+  user: User;
+  organization: OrgResource.Organization;
+  orgForm: Immutable<OrgForm.State>;
+  sidebar: Immutable<MenuSidebar.State>;
+  activeTab?: OrgTabs.TabId;
+
+  teamMemberTable: Immutable<Table.State>;
+}
+
+export type State = Validation<Immutable<ValidState>, null>;
+
+type InnerMsg
+  = ADT<'orgForm', OrgForm.Msg>
+  | ADT<'archive'>
+  | ADT<'table', Table.Msg>
+  | ADT<'hideArchiveModal'>
+  | ADT<'sidebar', MenuSidebar.Msg>;
+
+export type Msg = GlobalComponentMsg<InnerMsg, Route>;
+
+export interface RouteParams {
+  orgId: string;
+  tab?: OrgTabs.TabId;
+}
+
+export function idToDefinition<K extends OrgTabs.TabId>(id: K): TabbedPage.TabDefinition<OrgTabs.Tabs, K> {
+  switch (id) {
+    case 'team':
+      return {
+        component: TeamTab.component,
+        icon: 'bell',
+        title: 'Team'
+      } as TabbedPage.TabDefinition<OrgTabs.Tabs, K>;
+
+    case 'qualification':
+      return {
+        component: QualificationTab.component,
+        icon: 'balance-scale',
+        title: 'SWU Qualification'
+      } as TabbedPage.TabDefinition<OrgTabs.Tabs, K>;
+
+    case 'organization':
+    default:
+      return {
+        component: OrganizationTab.component,
+        icon: 'user',
+        title: 'Organization'
+      } as TabbedPage.TabDefinition<OrgTabs.Tabs, K>;
+  }
+}
+
+export function makeSidebarLink(tab: OrgTabs.TabId, userId: Id, activeTab: OrgTabs.TabId, orgId: Id): MenuSidebar.SidebarLink {
+  const { icon, title } = idToDefinition(tab);
+  return {
+    icon,
+    text: title,
+    active: activeTab === tab,
+    dest: routeDest(adt('orgView', {orgId, tab}))
+  };
+}
+
+export async function makeSidebarState(profileUser: User, viewerUser: User, activeTab: OrgTabs.TabId, orgId: Id): Promise<Immutable<MenuSidebar.State>> {
+  const links = (() => {
+    return [
+      makeSidebarLink('organization',   profileUser.id,  activeTab, orgId),
+      makeSidebarLink('team',           profileUser.id,  activeTab, orgId),
+      makeSidebarLink('qualification',  profileUser.id,  activeTab, orgId)
+    ];
+  })();
+  return immutable(await MenuSidebar.init({ links }));
+}
+
+const init: PageInit<RouteParams, SharedState, State, Msg> = isUserType({
+  userType: [UserType.Vendor, UserType.Admin],
+
+  async success({ dispatch, routeParams, shared }) {
+    const result = await api.organizations.readOne(routeParams.orgId);
+    const activeTab = routeParams.tab || 'organization';
+    if (api.isValid(result)) {
+      return valid(immutable({
+        archiveLoading: 0,
+        showArchiveModal: false,
+        user: shared.sessionUser,
+        organization: result.value,
+        sidebar: shared.sessionUser.type === UserType.Vendor
+                  ? await makeSidebarState(shared.sessionUser, shared.sessionUser, activeTab, result.value.id )
+                  : immutable(await MenuSidebar.init({ links: [] })),
+        orgForm: immutable(await OrgForm.init({organization: result.value })),
+        teamMemberTable: immutable(await Table.init({
+          idNamespace: 'team-member-table'
+        })),
+        activeTab
+      }));
+    } else {
+      dispatch(replaceRoute(adt('notFound' as const, {})));
+      return invalid(null);
+    }
+  },
+  async fail({dispatch, shared, routeParams}) {
+    if (!shared.session || !shared.session.user) {
+      dispatch(replaceRoute(adt('signIn' as const, {
+        redirectOnSuccess: router.routeToUrl(adt('orgEdit', {orgId: routeParams.orgId}))
+      })));
+    } else {
+      dispatch(replaceRoute(adt('notFound' as const, {})));
+    }
+
+    return invalid(null);
+  }
+});
+
+const startArchiveLoading = makeStartLoading<ValidState>('archiveLoading');
+const stopArchiveLoading = makeStopLoading<ValidState>('archiveLoading');
+
+function isOwner(user: User, org: OrgResource.Organization): boolean {
+  return user.id === org.owner.id;
+}
+
+const update: Update<State, Msg> = updateValid(({ state, msg }) => {
+  switch (msg.tag) {
+    case 'archive':
+      if (!state.showArchiveModal) {
+        return [state.set('showArchiveModal', true)];
+      } else {
+        state = startArchiveLoading(state)
+          .set('showArchiveModal', false);
+      }
+      return [
+        state,
+        async (state, dispatch) => {
+          const result = await api.organizations.delete(state.organization.id);
+          if (api.isValid(result)) {
+            // TODO show confirmation alert on page redirected to.
+            if (isOwner(state.user, state.organization)) {
+              dispatch(replaceRoute(adt('userProfile' as const, { userId: state.user.id, tab: 'organizations' as const })));
+            } else {
+              dispatch(replaceRoute(adt('orgList' as const, null)));
+            }
+          } else {
+            state = stopArchiveLoading(state);
+          }
+          return state;
+        }
+      ];
+    case 'hideArchiveModal':
+      return [state.set('showArchiveModal', false)];
+    case 'orgForm':
+      return updateGlobalComponentChild({
+        state,
+        childStatePath: ['orgForm'],
+        childUpdate: OrgForm.update,
+        childMsg: msg.value,
+        mapChildMsg: value => adt('orgForm', value)
+      });
+    case 'sidebar':
+      return updateComponentChild({
+        state,
+        childStatePath: ['sidebar'],
+        childUpdate: MenuSidebar.update,
+        childMsg: msg.value,
+        mapChildMsg: value => adt('sidebar', value)
+      });
+    default:
+      return [state];
+  }
+});
+
+const OrgFormView = (state: ValidState, dispatch: Dispatch<Msg>) => {
+  const isArchiveLoading = state.archiveLoading > 0;
+  const isLoading = isArchiveLoading;
+
+  return (
+    <div>
+      <Row>
+        <Col xs='12' className='mb-5'>
+          <h2>{state.organization.legalName}</h2>
+        </Col>
+      </Row>
+      <Row>
+        <Col xs='12'>
+          <OrgForm.view
+            state={state.orgForm}
+            disabled={true}
+            dispatch={mapComponentDispatch(dispatch, value => adt('orgForm' as const, value))} />
+        </Col>
+      </Row>
+      <Row>
+        <Col>
+          <div className='mt-5 pt-5 border-top'>
+            <h3>Archive Organization</h3>
+            <p className='mb-4'>Archiving this organization means that it will no longer be available for opportunity proposals.</p>
+          </div>
+        </Col>
+      </Row>
+      <Row>
+        <Col>
+          <Link button loading={isArchiveLoading} disabled={isLoading} color='danger' symbol_={leftPlacement(iconLinkSymbol('minus-circle'))} onClick={() => dispatch(adt('archive'))}>
+            Archive Organization
+          </Link>
+        </Col>
+      </Row>
+
+    </div>
+  );
+};
+
+const orgTeamMembers = [
+  { id: '12345',    name: 'A team member', pending: false, capabilities: ['Backend Development', 'Security Engineering']},
+  { id: '123456',   name: 'Team Member 2', pending: false, capabilities: ['DevOps Engineering', 'Agile Coaching', 'Security Engineering']},
+  { id: '1234567',  name: 'Team Member 3', pending: true,  capabilities: ['Agile Coaching', 'Security Engineering', 'Frontend Development']},
+  { id: '12345678', name: 'Team Member 4', pending: false, capabilities: ['Delivery Management', 'Technical Architecture', 'User Research', 'User Experience Design']}
+];
+
+function tableHeadCells(): Table.HeadCells {
+  return [
+    {
+      children: 'Team Member',
+      style: {
+        width: '60%',
+        minWidth: '240px'
+      }
+    },
+    {
+      children: 'Capabilities',
+      style: {
+        width: '20%'
+      }
+    },
+    {
+      children: '',
+      style: {
+        width: '20%'
+      }
+    }
+  ];
+}
+
+function reduceCapabilities( current: string[], append: string[] ) {
+  append.map( (cap) => {
+    if (!current.includes(cap)) {
+      current.push(cap);
+    }
+  });
+
+  return current;
+}
+
+function tableBodyRows(): Table.BodyRows {
+  return orgTeamMembers.map( member => {
+    return [
+      { children:
+        <div>
+          <Link dest={routeDest(adt('userProfile', { userId: member.id }))}>{member.name}</Link>
+           { member.pending ? <Badge className='ml-2' text='pending' color='warning' /> : null }
+        </div> },
+      { children: <div>{member.capabilities.length}</div>},
+
+      /* Note(Jesse): This button popping may be fixed by changing the
+       * mecahnism that showOnHover is showing/hiding elements with.
+       * Grep for : @popping_remove_button
+       **/
+      { showOnHover: true, children: <Link symbol_={leftPlacement(iconLinkSymbol('user-times'))} size='sm' button color='danger'>Remove</Link> }
+
+    ];
+  });
+}
+
+const TeamTabView = (state: ValidState, dispatch: Dispatch<Msg>, teamCapabilities: string[]) => {
+  const org = state.organization;
+  const dispatchTable = mapComponentDispatch<Msg, Table.Msg>(dispatch, value => ({ tag: 'table', value }));
+  return (
+    <div>
+      <Row>
+        <Col xs='12' className='mb-5 px-0'>
+          <h2>{org.legalName}</h2>
+        </Col>
+        <Col className='px-0 pb-4 border-bottom'>
+          <h3>Team Memeber(s)</h3>
+          <Table.view
+            headCells={tableHeadCells()}
+            bodyRows={tableBodyRows()}
+            state={state.teamMemberTable}
+            dispatch={dispatchTable} />
+        </Col>
+      </Row>
+
+      <Row className='pt-5'>
+        <Col xs='12'>
+          <h3>Team Capabilities</h3>
+          <p className='pb-3'>This is a summary of the capabilities that your organization's team posses as a whole.</p>
+        </Col>
+        <Col xs='12'>
+          <h4>Capabilities</h4>
+        </Col>
+        {
+          Caps.map( c => {
+            let icon = <Icon className='mx-2' name='circle'></Icon>;
+            if (teamCapabilities.includes(c)) {
+              icon = <Icon color='green' className='mx-2' name='check-circle'></Icon>;
+            }
+            return (
+              <Col xs='6' className='border p-2'>
+                {icon}
+                {c}
+              </Col>
+            );
+          })
+        }
+      </Row>
+
+    </div>
+  );
+};
+
+function predicatedOption(predicate: boolean, mainText: string, subtext: string) {
+  return (
+    <div className='d-flex py-2'>
+      <div>
+        { predicate ?
+            <Icon color='green' className='mx-2' name='check-circle'></Icon> :
+            <Icon className='mx-2' name='circle'></Icon> }
+      </div>
+      <div>
+        <span>{mainText}</span>
+        <div><span><small>{subtext}</small></span></div>
+      </div>
+    </div>
+    );
+}
+
+const QualificationTabView = (state: ValidState, dispatch: Dispatch<Msg>, capabilityPredicate: boolean) => {
+  const org = state.organization;
+  return (
+    <div>
+      <Row className='pb-5 border-bottom'>
+        <Col xs='12' className='mb-5 px-0'>
+          <h3>{org.legalName}</h3>
+          <p>To qualify to apply on Sprint With Us opportunities, your organization must meet the following requirements:</p>
+        </Col>
+        <Col xs='12'>
+          <h3>Requirements</h3>
+            {predicatedOption(orgTeamMembers.length >= 2,
+                              'At least two team members',
+                              'Send a request to one or more potential team members from the “Team” tab to begin the process of satisfying this requirement.')
+            }
+            {predicatedOption(capabilityPredicate,
+                              'Team members collectively possess all capabilities',
+                              'Your team members must update the capabilities on their user profile.')
+            }
+            {predicatedOption(org.acceptedSWUTerms != null,
+                              'Agree to \'Sprint WIth Us\' Terms & Conditions',
+                              'You may view the terms and conditions in the section below.')
+            }
+
+        </Col>
+      </Row>
+
+      <Row className='mt-5'>
+        <Col xs='12' className='mb-5 px-0'>
+          <h3>Terms & Conditions</h3>
+          <p>View the Sprint With Us terms and conditions using the button below.</p>
+          <Link button color='primary'>View Terms & Conditions</Link>
+        </Col>
+      </Row>
+
+    </div>
+  );
+};
+
+const view: ComponentView<State, Msg> = viewValid(({ state, dispatch }) => {
+  const teamCapabilities = orgTeamMembers.reduce((current, member) => {
+    return reduceCapabilities(current, member.capabilities);
+  }, [] as string[]);
+
+  switch (state.activeTab) {
+    case 'team': {
+      return TeamTabView(state, dispatch, teamCapabilities);
+    }
+    case 'qualification': {
+      return QualificationTabView(state, dispatch, teamCapabilities.length === Caps.length);
+    }
+    case 'organization':
+    default: {
+      return OrgFormView(state, dispatch);
+    }
+  }
+});
+
+export const component: PageComponent<RouteParams, SharedState, State, Msg> = {
+  init,
+  update,
+  view,
+  sidebar: {
+    size: 'medium',
+    color: 'light',
+    view: viewValid(({ state, dispatch }) => {
+      return (<MenuSidebar.view
+        state={state.sidebar}
+        dispatch={mapComponentDispatch(dispatch, msg => adt('sidebar' as const, msg))} />);
+    })
+  },
+  getMetadata: withValid((state) => {
+    return makePageMetadata(`${state.organization.legalName} — Organizations`);
+  }, makePageMetadata('Edit Organization')),
+  getModal: getModalValid<ValidState, Msg>(state => {
+    if (state.showArchiveModal) {
+      return {
+        title: 'Archive Organization?',
+        body: () => 'Are you sure you want to archive this organization?',
+        onCloseMsg: adt('hideArchiveModal'),
+        actions: [
+          {
+            text: 'Archive Organization',
+            icon: 'minus-circle',
+            color: 'danger',
+            msg: adt('archive'),
+            button: true
+          },
+          {
+            text: 'Cancel',
+            color: 'secondary',
+            msg: adt('hideArchiveModal')
+          }
+        ]
+      };
+    }
+
+    return null;
+  }),
+  getContextualActions: getContextualActionsValid(({ state, dispatch }) => {
+    const isArchiveLoading = state.archiveLoading > 0;
+    const isLoading =  isArchiveLoading;
+    return adt('links', [{
+      children: 'Edit Organization',
+      onClick: () => { dispatch(newRoute(adt('orgEdit' as const, { orgId: state.organization.id }))); },
+      button: true,
+      disabled: isLoading,
+      symbol_: leftPlacement(iconLinkSymbol('user-edit')),
+      color: 'primary'
+    }]);
+  })
+};

--- a/src/front-end/typescript/lib/pages/proposal/code-with-us/create.tsx
+++ b/src/front-end/typescript/lib/pages/proposal/code-with-us/create.tsx
@@ -168,7 +168,7 @@ export const component: PageComponent<RouteParams, SharedState, State, Msg> = {
       getDescription: () => 'Intruductory text placeholder.  Can provide brief instructions on how to create and manage an opportunity (e.g. save draft verion).',
       getFooter: () => (
         <span>
-          Need help? <Link dest={routeDest(adt('content', 'code-with-us-proposal-guide'))}>Read the guide</Link> for creating and managing a CWU proposal
+          Need help? <Link dest={routeDest(adt('content' as const, 'code-with-us-proposal-guide'))}>Read the guide</Link> for creating and managing a CWU proposal
         </span>
       )
     })

--- a/src/front-end/typescript/lib/pages/proposal/code-with-us/edit/tab/index.ts
+++ b/src/front-end/typescript/lib/pages/proposal/code-with-us/edit/tab/index.ts
@@ -72,7 +72,7 @@ export async function makeSidebarState(proposalId: Id, opportunityId: Id, active
         text: 'Read Guide',
         active: false,
         newTab: true,
-        dest: routeDest(adt('content', 'code-with-us-proposal-guide'))
+        dest: routeDest(adt('content' as const, 'code-with-us-proposal-guide'))
       }
     ]
   }));

--- a/src/front-end/typescript/lib/pages/proposal/code-with-us/edit/tab/proposal.tsx
+++ b/src/front-end/typescript/lib/pages/proposal/code-with-us/edit/tab/proposal.tsx
@@ -317,10 +317,10 @@ const view: ComponentView<State, Msg> = viewValid(props => {
 const SubmitTerms: View<ComponentViewProps<ValidState, Msg> & { action: string; }> = ({ action, state, dispatch }) => {
   return (
     <div>
-      <p>Please ensure you have reviewed the <Link newTab dest={routeDest(adt('content', 'terms-and-conditions'))}>Digital Marketplace Terms and Conditions</Link> prior to {action} your proposal for this Code With Us opportunity.</p>
+      <p>Please ensure you have reviewed the <Link newTab dest={routeDest(adt('content' as const, 'terms-and-conditions'))}>Digital Marketplace Terms and Conditions</Link> prior to {action} your proposal for this Code With Us opportunity.</p>
       <Checkbox.view
         extraChildProps={{
-          inlineLabel: (<span>I acknowledge that I have read, fully understand and agree to the <Link newTab dest={routeDest(adt('content', 'terms-and-conditions'))}>Digital Marketplace Terms and Conditions</Link>.</span>)
+          inlineLabel: (<span>I acknowledge that I have read, fully understand and agree to the <Link newTab dest={routeDest(adt('content' as const, 'terms-and-conditions'))}>Digital Marketplace Terms and Conditions</Link>.</span>)
         }}
         className='font-weight-bold'
         state={state.submitTermsCheckbox}

--- a/src/front-end/typescript/lib/pages/sign-up/step-two.tsx
+++ b/src/front-end/typescript/lib/pages/sign-up/step-two.tsx
@@ -139,7 +139,7 @@ const ViewProfileFormCheckboxes: ComponentView<ValidState, Msg> = ({ state, disp
         <Checkbox.view
           extraChildProps={{
             inlineLabel: (
-              <b>I acknowledge that I have read and agree to the <Link newTab dest={routeDest(adt('content', 'terms-and-conditions'))}>Terms and Conditions</Link> and <Link newTab dest={routeDest(adt('content', 'privacy'))}>Privacy Policy</Link>.<FormField.ViewRequiredAsterisk /></b>
+              <b>I acknowledge that I have read and agree to the <Link newTab dest={routeDest(adt('content' as const, 'terms-and-conditions'))}>Terms and Conditions</Link> and <Link newTab dest={routeDest(adt('content' as const, 'privacy'))}>Privacy Policy</Link>.<FormField.ViewRequiredAsterisk /></b>
             )
           }}
           disabled={isDisabled}

--- a/src/front-end/typescript/lib/pages/user/profile/tab/index.ts
+++ b/src/front-end/typescript/lib/pages/user/profile/tab/index.ts
@@ -89,6 +89,7 @@ export function idToDefinition<K extends TabId>(id: K): TabbedPage.TabDefinition
   }
 }
 
+// @duplicated_from_profile_tab
 export function makeSidebarLink(tab: TabId, userId: Id, activeTab: TabId): MenuSidebar.SidebarLink {
   const { icon, title } = idToDefinition(tab);
   return {
@@ -99,6 +100,7 @@ export function makeSidebarLink(tab: TabId, userId: Id, activeTab: TabId): MenuS
   };
 }
 
+// @duplicated_from_profile_tab
 export async function makeSidebarState(profileUser: User, viewerUser: User, activeTab: TabId): Promise<Immutable<MenuSidebar.State>> {
   const links = (() => {
     switch (viewerUser.type) {

--- a/src/front-end/typescript/lib/pages/user/profile/tab/legal.tsx
+++ b/src/front-end/typescript/lib/pages/user/profile/tab/legal.tsx
@@ -55,7 +55,7 @@ const view: ComponentView<State, Msg> = ({ state }) => {
         <Col xs='12'>
           <div className='mt-4'>
             <h3>Terms & Conditions</h3>
-            <Link newTab dest={routeDest(adt('content', 'terms-and-conditions'))}>Review the Terms & Conditions</Link>
+            <Link newTab dest={routeDest(adt('content' as const, 'terms-and-conditions'))}>Review the Terms & Conditions</Link>
           </div>
         </Col>
       </Row>


### PR DESCRIPTION
Howdy!

The tabbing situation is not integrated in the way the rest of the tabs in the app are.  I decided to do something that would work for me first, then integrate it with the framework later.  This integration work proved slow and frustrating, so it has been left unfinished.  The groundwork has been laid out for it to be completed; the route is setup correctly, and the empty components are in place and compiling.  The parts of the page that depend on that being done are also incomplete, specifically the context menu in the header.

I also was unsure about how the backend serves the data for organization team members, so I used a static array of dummy data to do the testing.

The commit history is squashed because when I was merging the development branch in I got conflicts in the same file(s) several times, and decided it would be faster to squash the commits and deal with all conflicts at the same time than over and over while rebasing to preserve history.

Cheers,
Jesse