### PR TITLE
DM-653 add permissions check for terms accepted

### DIFF
--- a/src/back-end/lib/db/user.ts
+++ b/src/back-end/lib/db/user.ts
@@ -120,3 +120,17 @@ export const updateUser = tryDb<[UpdateUserParams], User>(async (connection, use
   }
   return valid(await rawUserToUser(connection, result));
 });
+
+export async function userHasAcceptedTerms(connection: Connection, id: Id): Promise<boolean> {
+  const [result] = await connection<{ acceptedTerms: Date }>('users')
+    .where({ id })
+    .select('acceptedTerms');
+
+  if (!result) {
+    throw new Error('unable to check terms status for user');
+  }
+  if (result.acceptedTerms) {
+    return true;
+  }
+  return false;
+}

--- a/src/back-end/lib/permissions.ts
+++ b/src/back-end/lib/permissions.ts
@@ -212,7 +212,7 @@ export async function readCWUProposalHistory(connection: Connection, session: Se
 }
 
 export async function createCWUProposal(connection: Connection, session: Session): Promise<boolean> {
-  return !!session && isVendor(session) && await userHasAcceptedTerms(connection, session.user.id);
+  return isVendor(session) && await hasAcceptedTerms(connection, session);
 }
 
 export async function editCWUProposal(connection: Connection, session: Session, proposalId: string, opportunity: CWUOpportunity): Promise<boolean> {
@@ -299,11 +299,11 @@ export async function readSWUProposalScore(connection: Connection, session: Sess
 }
 
 export async function createSWUProposal(connection: Connection, session: Session): Promise<boolean> {
-  return !!session && isVendor(session) && await userHasAcceptedTerms(connection, session.user.id);
+  return isVendor(session) && await hasAcceptedTerms(connection, session);
 }
 
 export async function submitSWUProposal(connection: Connection, session: Session, organization: Organization): Promise<boolean> {
-  return !!session && isVendor(session) && await userHasAcceptedTerms(connection, session.user.id) && await isUserOwnerOfOrg(connection, session.user, organization.id) && doesOrganizationMeetSWUQualification(organization);
+  return !!session && isVendor(session) && await hasAcceptedTerms(connection, session) && await isUserOwnerOfOrg(connection, session.user, organization.id) && doesOrganizationMeetSWUQualification(organization);
 }
 
 export async function editSWUProposal(connection: Connection, session: Session, proposalId: string, opportunity: SWUOpportunity): Promise<boolean> {

--- a/src/back-end/lib/permissions.ts
+++ b/src/back-end/lib/permissions.ts
@@ -217,7 +217,7 @@ export async function createCWUProposal(connection: Connection, session: Session
 
 export async function editCWUProposal(connection: Connection, session: Session, proposalId: string, opportunity: CWUOpportunity): Promise<boolean> {
   return isAdmin(session) ||
-    (session && await isCWUProposalAuthor(connection, session.user, proposalId)) ||
+    (session && await isCWUProposalAuthor(connection, session.user, proposalId) && await hasAcceptedTerms(connection, session)) ||
     (session && await isCWUOpportunityAuthor(connection, session.user, opportunity.id) && doesCWUOpportunityStatusAllowGovToViewProposals(opportunity.status)) || false;
 }
 
@@ -308,7 +308,7 @@ export async function submitSWUProposal(connection: Connection, session: Session
 
 export async function editSWUProposal(connection: Connection, session: Session, proposalId: string, opportunity: SWUOpportunity): Promise<boolean> {
   return isAdmin(session) ||
-    (session && await isSWUProposalAuthor(connection, session.user, proposalId)) ||
+    (session && await isSWUProposalAuthor(connection, session.user, proposalId) && await hasAcceptedTerms(connection, session)) ||
     (session && await isSWUOpportunityAuthor(connection, session.user, opportunity.id) && doesSWUOpportunityStatusAllowGovToViewProposals(opportunity.status)) || false;
 }
 

--- a/src/back-end/lib/resources/organization.ts
+++ b/src/back-end/lib/resources/organization.ts
@@ -150,7 +150,7 @@ const resource: Resource = {
                       validatedContactEmail,
                       validatedContactPhone
                     ])) {
-                      if (!permissions.createOrganization(request.session) || !permissions.isSignedIn(request.session)) {
+                      if (!await permissions.createOrganization(connection, request.session) || !permissions.isSignedIn(request.session)) {
                         return invalid({
                           permissions: [permissions.ERROR_MESSAGE]
                         });

--- a/src/back-end/lib/resources/proposal/code-with-us.ts
+++ b/src/back-end/lib/resources/proposal/code-with-us.ts
@@ -160,7 +160,7 @@ const resource: Resource = {
                 proponent,
                 attachments } = request.body;
 
-        if (!permissions.isSignedIn(request.session) || !permissions.createCWUProposal(request.session)) {
+        if (!permissions.isSignedIn(request.session) || !await permissions.createCWUProposal(connection, request.session)) {
           return invalid({
             permissions: [permissions.ERROR_MESSAGE]
           });

--- a/src/back-end/lib/resources/proposal/sprint-with-us.ts
+++ b/src/back-end/lib/resources/proposal/sprint-with-us.ts
@@ -138,7 +138,7 @@ const resource: Resource = {
                 teamQuestionResponses,
                 references } = request.body;
 
-        if (!permissions.isSignedIn(request.session) || !permissions.createSWUProposal(request.session)) {
+        if (!permissions.isSignedIn(request.session) || !await permissions.createSWUProposal(connection, request.session)) {
           return invalid({
             permissions: [permissions.ERROR_MESSAGE]
           });


### PR DESCRIPTION
This PR adds a permissions check on certain actions by Vendor users to ensure they have accepted the terms and conditions prior to:

* Creating an organization
* Creating/submitting a CWU proposal
* Creating/submitting a SWU proposal

I didn't add the check to editing/deleting a proposal as we already check for authorship on the proposal, which would imply they had permission to create it.  

