### PR TITLE
DM-694 strip idpUsername suffix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4179,13 +4179,43 @@
       "dev": true
     },
     "find-up": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-      "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-      "dev": true,
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
       "requires": {
-        "path-exists": "^2.0.0",
-        "pinkie-promise": "^2.0.0"
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "dependencies": {
+        "locate-path": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+          "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+          "requires": {
+            "p-locate": "^5.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.0.2.tgz",
+          "integrity": "sha512-iwqZSOoWIW+Ew4kAGUlN16J4M7OB3ysMLSZtnhmqx7njIHFPlxWBX8xo3lVTyFVq6mI/lL9qt2IsN1sHwaxJkg==",
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+          "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+          "requires": {
+            "p-limit": "^3.0.2"
+          }
+        },
+        "p-try": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
+        }
       }
     },
     "findup-sync": {
@@ -8803,13 +8833,9 @@
       "dev": true
     },
     "path-exists": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-      "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-      "dev": true,
-      "requires": {
-        "pinkie-promise": "^2.0.0"
-      }
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
     },
     "path-is-absolute": {
       "version": "1.0.1",
@@ -10380,6 +10406,27 @@
       "requires": {
         "find-up": "^1.0.0",
         "read-pkg": "^1.0.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+          "dev": true,
+          "requires": {
+            "path-exists": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
+          }
+        },
+        "path-exists": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+          "dev": true,
+          "requires": {
+            "pinkie-promise": "^2.0.0"
+          }
+        }
       }
     },
     "readable-stream": {

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "cookie-parser": "^1.4.4",
     "dotenv": "^6.2.0",
     "express": "^4.16.4",
+    "find-up": "^5.0.0",
     "html-to-text": "^5.1.1",
     "immutable": "^4.0.0-rc.12",
     "jimp": "^0.16.0",

--- a/src/back-end/config.ts
+++ b/src/back-end/config.ts
@@ -1,12 +1,12 @@
 import { makeDomainLogger } from 'back-end/lib/logger';
 import { console as consoleAdapter } from 'back-end/lib/logger/adapters';
 import dotenv from 'dotenv';
+import findUp from 'find-up';
 import { existsSync, mkdirSync } from 'fs';
-import { join, resolve } from 'path';
+import { dirname, join, resolve } from 'path';
 
 // export the root directory of the repository.
-// assumed the code is running via $ROOT/build/back-end/back-end/start.js
-export const REPOSITORY_ROOT_DIR = resolve(__dirname, '../../../');
+export const REPOSITORY_ROOT_DIR = dirname(findUp.sync('package.json') || '') || __dirname;
 
 // Load environment variables from a .env file.
 dotenv.config({

--- a/src/back-end/lib/routers/auth.ts
+++ b/src/back-end/lib/routers/auth.ts
@@ -199,7 +199,12 @@ async function establishSessionWithClaims(connection: Connection, request: Reque
       return null;
   }
 
-  const username = getString(claims, 'preferred_username');
+  let username = getString(claims, 'preferred_username');
+
+  // Strip the @github / @idir suffix if present.  We want to match and store the username without suffix.
+  if (username.endsWith('@github') || username.endsWith('@idir')) {
+    username = username.slice(0, username.lastIndexOf('@'));
+  }
 
   if (!username || !tokenSet.access_token || !tokenSet.refresh_token) {
     throw new Error('authentication failure - invalid claims');
@@ -218,7 +223,7 @@ async function establishSessionWithClaims(connection: Connection, request: Reque
       name: claims.name || '',
       email: claims.email || '',
       jobTitle: '',
-      idpUsername: claims.preferred_username
+      idpUsername: username
     }), null);
 
     // If email present, notify of successful account creation

--- a/src/back-end/lib/routers/auth.ts
+++ b/src/back-end/lib/routers/auth.ts
@@ -202,7 +202,7 @@ async function establishSessionWithClaims(connection: Connection, request: Reque
   let username = getString(claims, 'preferred_username');
 
   // Strip the @github / @idir suffix if present.  We want to match and store the username without suffix.
-  if (username.endsWith('@github') || username.endsWith('@idir')) {
+  if ((username.endsWith('@github') && userType === UserType.Vendor) || (username.endsWith('@idir') && userType === UserType.Government)) {
     username = username.slice(0, username.lastIndexOf('@'));
   }
 

--- a/src/migrations/knexfile.ts
+++ b/src/migrations/knexfile.ts
@@ -1,16 +1,10 @@
-import dotenv from 'dotenv';
-
-// Working directory changed to src/migrations so ensure env is loaded from correct path.
-dotenv.config({
-  debug: true,
-  path: '../../.env'
-});
+import { DB_MIGRATIONS_TABLE_NAME, POSTGRES_URL } from 'back-end/config';
 
 module.exports = {
   client: 'pg',
-  connection: process.env.POSTGRES_URL,
+  connection: POSTGRES_URL,
   migrations: {
-    tableName: 'migrations',
+    tableName: DB_MIGRATIONS_TABLE_NAME,
     directory: './tasks'
   }
 };

--- a/src/migrations/knexfile.ts
+++ b/src/migrations/knexfile.ts
@@ -1,10 +1,16 @@
-import { DB_MIGRATIONS_TABLE_NAME, POSTGRES_URL } from 'back-end/config';
+import dotenv from 'dotenv';
+
+// Working directory changed to src/migrations so ensure env is loaded from correct path.
+dotenv.config({
+  debug: true,
+  path: '../../.env'
+});
 
 module.exports = {
   client: 'pg',
-  connection: POSTGRES_URL,
+  connection: process.env.POSTGRES_URL,
   migrations: {
-    tableName: DB_MIGRATIONS_TABLE_NAME,
+    tableName: 'migrations',
     directory: './tasks'
   }
 };

--- a/src/migrations/stub.ts
+++ b/src/migrations/stub.ts
@@ -2,7 +2,7 @@ import { makeDomainLogger } from 'back-end/lib/logger';
 import { console as consoleAdapter } from 'back-end/lib/logger/adapters';
 import Knex from 'knex';
 
-makeDomainLogger(consoleAdapter, 'migrations');
+makeDomainLogger(consoleAdapter, 'migrations', 'development');
 
 // tslint:disable-next-line: no-empty
 export async function up(connection: Knex): Promise<void> {

--- a/src/migrations/tasks/20191110222844_init.ts
+++ b/src/migrations/tasks/20191110222844_init.ts
@@ -4,7 +4,7 @@ import Knex from 'knex';
 import { MembershipType } from 'shared/lib/resources/affiliation';
 import { UserStatus, UserType } from 'shared/lib/resources/user';
 
-const logger = makeDomainLogger(consoleAdapter, 'migrations');
+const logger = makeDomainLogger(consoleAdapter, 'migrations', 'development');
 
 export async function up(connection: Knex): Promise<void> {
     // Initialize tables

--- a/src/migrations/tasks/20191123120154_files.ts
+++ b/src/migrations/tasks/20191123120154_files.ts
@@ -3,7 +3,7 @@ import { console as consoleAdapter } from 'back-end/lib/logger/adapters';
 import Knex from 'knex';
 import { UserType } from 'shared/lib/resources/user';
 
-const logger = makeDomainLogger(consoleAdapter, 'migrations');
+const logger = makeDomainLogger(consoleAdapter, 'migrations', 'development');
 
 export async function up(connection: Knex): Promise<void> {
     // File binaries

--- a/src/migrations/tasks/20191203143238_alter_columns.ts
+++ b/src/migrations/tasks/20191203143238_alter_columns.ts
@@ -2,7 +2,7 @@ import { makeDomainLogger } from 'back-end/lib/logger';
 import { console as consoleAdapter } from 'back-end/lib/logger/adapters';
 import Knex from 'knex';
 
-makeDomainLogger(consoleAdapter, 'migrations');
+makeDomainLogger(consoleAdapter, 'migrations', 'development');
 
 export async function up(connection: Knex): Promise<void> {
   await connection.schema.alterTable('users', table => {

--- a/src/migrations/tasks/20191208110137_flatten_org.ts
+++ b/src/migrations/tasks/20191208110137_flatten_org.ts
@@ -2,7 +2,7 @@ import { makeDomainLogger } from 'back-end/lib/logger';
 import { console as consoleAdapter } from 'back-end/lib/logger/adapters';
 import Knex from 'knex';
 
-const logger = makeDomainLogger(consoleAdapter, 'migrations');
+const logger = makeDomainLogger(consoleAdapter, 'migrations', 'development');
 
 export async function up(connection: Knex): Promise<void> {
   await connection.schema.alterTable('organizations', table => {

--- a/src/migrations/tasks/20191214014311_add_affiliation_id.ts
+++ b/src/migrations/tasks/20191214014311_add_affiliation_id.ts
@@ -4,7 +4,7 @@ import { console as consoleAdapter } from 'back-end/lib/logger/adapters';
 import Knex from 'knex';
 import { MembershipStatus } from 'shared/lib/resources/affiliation';
 
-const logger = makeDomainLogger(consoleAdapter, 'migrations');
+const logger = makeDomainLogger(consoleAdapter, 'migrations', 'development');
 
 export async function up(connection: Knex): Promise<void> {
   // Add uuid as primary on affiliations, drop existing primary key

--- a/src/migrations/tasks/20191217200136_file_permissions.ts
+++ b/src/migrations/tasks/20191217200136_file_permissions.ts
@@ -2,7 +2,7 @@ import { makeDomainLogger } from 'back-end/lib/logger';
 import { console as consoleAdapter } from 'back-end/lib/logger/adapters';
 import Knex from 'knex';
 
-const logger = makeDomainLogger(consoleAdapter, 'migrations');
+const logger = makeDomainLogger(consoleAdapter, 'migrations', 'development');
 
 export async function up(connection: Knex): Promise<void> {
   await connection.schema.renameTable('fileReadPermissions', 'filePermissionsUserType');

--- a/src/migrations/tasks/20200106201409_session_constraint.ts
+++ b/src/migrations/tasks/20200106201409_session_constraint.ts
@@ -2,7 +2,7 @@ import { makeDomainLogger } from 'back-end/lib/logger';
 import { console as consoleAdapter } from 'back-end/lib/logger/adapters';
 import Knex from 'knex';
 
-const logger = makeDomainLogger(consoleAdapter, 'migrations');
+const logger = makeDomainLogger(consoleAdapter, 'migrations', 'development');
 
 export async function up(connection: Knex): Promise<void> {
   await connection.schema.raw(`

--- a/src/migrations/tasks/20200118194855_user_email_constraint.ts
+++ b/src/migrations/tasks/20200118194855_user_email_constraint.ts
@@ -2,7 +2,7 @@ import { makeDomainLogger } from 'back-end/lib/logger';
 import { console as consoleAdapter } from 'back-end/lib/logger/adapters';
 import Knex from 'knex';
 
-const logger = makeDomainLogger(consoleAdapter, 'migrations');
+const logger = makeDomainLogger(consoleAdapter, 'migrations', 'development');
 
 export async function up(connection: Knex): Promise<void> {
   await connection.schema.alterTable('users', table => {

--- a/src/migrations/tasks/20200126113825_cwu_init.ts
+++ b/src/migrations/tasks/20200126113825_cwu_init.ts
@@ -21,7 +21,7 @@ enum CWUProposalStatus {
   Withdrawn = 'WITHDRAWN'
 }
 
-const logger = makeDomainLogger(consoleAdapter, 'migrations');
+const logger = makeDomainLogger(consoleAdapter, 'migrations', 'development');
 
 export async function up(connection: Knex): Promise<void> {
   // Create CWUOpportunity table

--- a/src/migrations/tasks/20200130085107_cwu_attachments_modify.ts
+++ b/src/migrations/tasks/20200130085107_cwu_attachments_modify.ts
@@ -2,7 +2,7 @@ import { makeDomainLogger } from 'back-end/lib/logger';
 import { console as consoleAdapter } from 'back-end/lib/logger/adapters';
 import Knex from 'knex';
 
-const logger = makeDomainLogger(consoleAdapter, 'migrations');
+const logger = makeDomainLogger(consoleAdapter, 'migrations', 'development');
 
 export async function up(connection: Knex): Promise<void> {
   await connection.schema.alterTable('cwuOpportunityAttachments', table => {

--- a/src/migrations/tasks/20200201235459_cwu_cascades.ts
+++ b/src/migrations/tasks/20200201235459_cwu_cascades.ts
@@ -2,7 +2,7 @@ import { makeDomainLogger } from 'back-end/lib/logger';
 import { console as consoleAdapter } from 'back-end/lib/logger/adapters';
 import Knex from 'knex';
 
-const logger = makeDomainLogger(consoleAdapter, 'migrations');
+const logger = makeDomainLogger(consoleAdapter, 'migrations', 'development');
 
 export async function up(connection: Knex): Promise<void> {
   await connection.schema.alterTable('cwuOpportunityVersions', table => {

--- a/src/migrations/tasks/20200206021543_cwu_proposals_cascades.ts
+++ b/src/migrations/tasks/20200206021543_cwu_proposals_cascades.ts
@@ -2,7 +2,7 @@ import { makeDomainLogger } from 'back-end/lib/logger';
 import { console as consoleAdapter } from 'back-end/lib/logger/adapters';
 import Knex from 'knex';
 
-const logger = makeDomainLogger(consoleAdapter, 'migrations');
+const logger = makeDomainLogger(consoleAdapter, 'migrations', 'development');
 
 export async function up(connection: Knex): Promise<void> {
   await connection.schema.alterTable('cwuProposalStatuses', table => {

--- a/src/migrations/tasks/20200206140459_fix_proposals.ts
+++ b/src/migrations/tasks/20200206140459_fix_proposals.ts
@@ -2,7 +2,7 @@ import { makeDomainLogger } from 'back-end/lib/logger';
 import { console as consoleAdapter } from 'back-end/lib/logger/adapters';
 import Knex from 'knex';
 
-const logger = makeDomainLogger(consoleAdapter, 'migrations');
+const logger = makeDomainLogger(consoleAdapter, 'migrations', 'development');
 
 export async function up(connection: Knex): Promise<void> {
   await connection.schema.alterTable('cwuProposals', table => {

--- a/src/migrations/tasks/20200210213435_add_proposal_enums.ts
+++ b/src/migrations/tasks/20200210213435_add_proposal_enums.ts
@@ -2,7 +2,7 @@ import { makeDomainLogger } from 'back-end/lib/logger';
 import { console as consoleAdapter } from 'back-end/lib/logger/adapters';
 import Knex from 'knex';
 
-const logger = makeDomainLogger(consoleAdapter, 'migrations');
+const logger = makeDomainLogger(consoleAdapter, 'migrations', 'development');
 
 enum CWUProposalStatus {
   Draft = 'DRAFT',

--- a/src/migrations/tasks/20200210233100_unique_proposal_constraint.ts
+++ b/src/migrations/tasks/20200210233100_unique_proposal_constraint.ts
@@ -2,7 +2,7 @@ import { makeDomainLogger } from 'back-end/lib/logger';
 import { console as consoleAdapter } from 'back-end/lib/logger/adapters';
 import Knex from 'knex';
 
-const logger = makeDomainLogger(consoleAdapter, 'migrations');
+const logger = makeDomainLogger(consoleAdapter, 'migrations', 'development');
 
 export async function up(connection: Knex): Promise<void> {
   await connection.schema.alterTable('cwuProposals', table => {

--- a/src/migrations/tasks/20200213203214_cwu_null_createdby.ts
+++ b/src/migrations/tasks/20200213203214_cwu_null_createdby.ts
@@ -2,7 +2,7 @@ import { makeDomainLogger } from 'back-end/lib/logger';
 import { console as consoleAdapter } from 'back-end/lib/logger/adapters';
 import Knex from 'knex';
 
-const logger = makeDomainLogger(consoleAdapter, 'migrations');
+const logger = makeDomainLogger(consoleAdapter, 'migrations', 'development');
 
 export async function up(connection: Knex): Promise<void> {
   await connection.schema.alterTable('cwuOpportunityStatuses', table => {

--- a/src/migrations/tasks/20200213210722_cwu_subscribers.ts
+++ b/src/migrations/tasks/20200213210722_cwu_subscribers.ts
@@ -2,7 +2,7 @@ import { makeDomainLogger } from 'back-end/lib/logger';
 import { console as consoleAdapter } from 'back-end/lib/logger/adapters';
 import Knex from 'knex';
 
-const logger = makeDomainLogger(consoleAdapter, 'migrations');
+const logger = makeDomainLogger(consoleAdapter, 'migrations', 'development');
 
 export async function up(connection: Knex): Promise<void> {
   await connection.schema.createTable('cwuOpportunitySubscribers', table => {

--- a/src/migrations/tasks/20200222173125_unique_status_date.ts
+++ b/src/migrations/tasks/20200222173125_unique_status_date.ts
@@ -2,7 +2,7 @@ import { makeDomainLogger } from 'back-end/lib/logger';
 import { console as consoleAdapter } from 'back-end/lib/logger/adapters';
 import Knex from 'knex';
 
-const logger = makeDomainLogger(consoleAdapter, 'migrations');
+const logger = makeDomainLogger(consoleAdapter, 'migrations', 'development');
 
 export async function up(connection: Knex): Promise<void> {
   await connection.schema.alterTable('cwuOpportunityStatuses', table => {

--- a/src/migrations/tasks/20200222204440_add_events.ts
+++ b/src/migrations/tasks/20200222204440_add_events.ts
@@ -11,7 +11,7 @@ enum CWUProposalEvent {
   ScoreEntered = 'SCORE_ENTERED'
 }
 
-const logger = makeDomainLogger(consoleAdapter, 'migrations');
+const logger = makeDomainLogger(consoleAdapter, 'migrations', 'development');
 
 export async function up(connection: Knex): Promise<void> {
   await connection.schema.alterTable('cwuOpportunityStatuses', table => {

--- a/src/migrations/tasks/20200301202432_cwu_proposal_null_createdby.ts
+++ b/src/migrations/tasks/20200301202432_cwu_proposal_null_createdby.ts
@@ -2,7 +2,7 @@ import { makeDomainLogger } from 'back-end/lib/logger';
 import { console as consoleAdapter } from 'back-end/lib/logger/adapters';
 import Knex from 'knex';
 
-const logger = makeDomainLogger(consoleAdapter, 'migrations');
+const logger = makeDomainLogger(consoleAdapter, 'migrations', 'development');
 
 export async function up(connection: Knex): Promise<void> {
   await connection.schema.alterTable('cwuProposalStatuses', table => {

--- a/src/migrations/tasks/20200302210721_reporting_counters.ts
+++ b/src/migrations/tasks/20200302210721_reporting_counters.ts
@@ -2,7 +2,7 @@ import { makeDomainLogger } from 'back-end/lib/logger';
 import { console as consoleAdapter } from 'back-end/lib/logger/adapters';
 import Knex from 'knex';
 
-const logger = makeDomainLogger(consoleAdapter, 'migrations');
+const logger = makeDomainLogger(consoleAdapter, 'migrations', 'development');
 
 export async function up(connection: Knex): Promise<void> {
   await connection.schema.createTable('viewCounters', table => {

--- a/src/migrations/tasks/20200305134738_swu_opportunities.ts
+++ b/src/migrations/tasks/20200305134738_swu_opportunities.ts
@@ -2,7 +2,7 @@ import { makeDomainLogger } from 'back-end/lib/logger';
 import { console as consoleAdapter } from 'back-end/lib/logger/adapters';
 import Knex from 'knex';
 
-const logger = makeDomainLogger(consoleAdapter, 'migrations');
+const logger = makeDomainLogger(consoleAdapter, 'migrations', 'development');
 
 enum SWUOpportunityStatus {
   Draft = 'DRAFT',

--- a/src/migrations/tasks/20200305215313_swu_proposals.ts
+++ b/src/migrations/tasks/20200305215313_swu_proposals.ts
@@ -2,7 +2,7 @@ import { makeDomainLogger } from 'back-end/lib/logger';
 import { console as consoleAdapter } from 'back-end/lib/logger/adapters';
 import Knex from 'knex';
 
-const logger = makeDomainLogger(consoleAdapter, 'migrations');
+const logger = makeDomainLogger(consoleAdapter, 'migrations', 'development');
 
 enum SWUProposalStatus {
   Draft        = 'DRAFT',

--- a/src/migrations/tasks/20200308140217_session_cleanup_trigger.ts
+++ b/src/migrations/tasks/20200308140217_session_cleanup_trigger.ts
@@ -2,7 +2,7 @@ import { makeDomainLogger } from 'back-end/lib/logger';
 import { console as consoleAdapter } from 'back-end/lib/logger/adapters';
 import Knex from 'knex';
 
-const logger = makeDomainLogger(consoleAdapter, 'migrations');
+const logger = makeDomainLogger(consoleAdapter, 'migrations', 'development');
 
 export async function up(connection: Knex): Promise<void> {
   await connection.schema.raw(`

--- a/src/migrations/tasks/20200309204727_user_capabilities.ts
+++ b/src/migrations/tasks/20200309204727_user_capabilities.ts
@@ -2,7 +2,7 @@ import { makeDomainLogger } from 'back-end/lib/logger';
 import { console as consoleAdapter } from 'back-end/lib/logger/adapters';
 import Knex from 'knex';
 
-const logger = makeDomainLogger(consoleAdapter, 'migrations');
+const logger = makeDomainLogger(consoleAdapter, 'migrations', 'development');
 
 export async function up(connection: Knex): Promise<void> {
   await connection.schema.alterTable('users', table => {

--- a/src/migrations/tasks/20200310205432_swu_terms.ts
+++ b/src/migrations/tasks/20200310205432_swu_terms.ts
@@ -2,7 +2,7 @@ import { makeDomainLogger } from 'back-end/lib/logger';
 import { console as consoleAdapter } from 'back-end/lib/logger/adapters';
 import Knex from 'knex';
 
-const logger = makeDomainLogger(consoleAdapter, 'migrations');
+const logger = makeDomainLogger(consoleAdapter, 'migrations', 'development');
 
 export async function up(connection: Knex): Promise<void> {
   await connection.schema.alterTable('organizations', table => {

--- a/src/migrations/tasks/20200311161600_string_to_text.ts
+++ b/src/migrations/tasks/20200311161600_string_to_text.ts
@@ -2,7 +2,7 @@ import { makeDomainLogger } from 'back-end/lib/logger';
 import { console as consoleAdapter } from 'back-end/lib/logger/adapters';
 import Knex from 'knex';
 
-const logger = makeDomainLogger(consoleAdapter, 'migrations');
+const logger = makeDomainLogger(consoleAdapter, 'migrations', 'development');
 
 export async function up(connection: Knex): Promise<void> {
   await connection.schema.alterTable('cwuOpportunityAddenda', table => {

--- a/src/migrations/tasks/20200316225501_swu_subscribers.ts
+++ b/src/migrations/tasks/20200316225501_swu_subscribers.ts
@@ -2,7 +2,7 @@ import { makeDomainLogger } from 'back-end/lib/logger';
 import { console as consoleAdapter } from 'back-end/lib/logger/adapters';
 import Knex from 'knex';
 
-const logger = makeDomainLogger(consoleAdapter, 'migrations');
+const logger = makeDomainLogger(consoleAdapter, 'migrations', 'development');
 
 export async function up(connection: Knex): Promise<void> {
   await connection.schema.createTable('swuOpportunitySubscribers', table => {

--- a/src/migrations/tasks/20200317000605_swu_remove_updated_by_phases.ts
+++ b/src/migrations/tasks/20200317000605_swu_remove_updated_by_phases.ts
@@ -3,7 +3,7 @@ import { makeDomainLogger } from 'back-end/lib/logger';
 import { console as consoleAdapter } from 'back-end/lib/logger/adapters';
 import Knex from 'knex';
 
-const logger = makeDomainLogger(consoleAdapter, 'migrations');
+const logger = makeDomainLogger(consoleAdapter, 'migrations', 'development');
 
 export async function up(connection: Knex): Promise<void> {
   await connection.schema.alterTable('swuOpportunityPhases', table => {

--- a/src/migrations/tasks/20200321220025_swu_proposals_add_missing_field.ts
+++ b/src/migrations/tasks/20200321220025_swu_proposals_add_missing_field.ts
@@ -2,7 +2,7 @@ import { makeDomainLogger } from 'back-end/lib/logger';
 import { console as consoleAdapter } from 'back-end/lib/logger/adapters';
 import Knex from 'knex';
 
-const logger = makeDomainLogger(consoleAdapter, 'migrations');
+const logger = makeDomainLogger(consoleAdapter, 'migrations', 'development');
 
 export async function up(connection: Knex): Promise<void> {
   await connection.schema.alterTable('swuProposals', table => {

--- a/src/migrations/tasks/20200322120246_swu_team_members_cascade.ts
+++ b/src/migrations/tasks/20200322120246_swu_team_members_cascade.ts
@@ -2,7 +2,7 @@ import { makeDomainLogger } from 'back-end/lib/logger';
 import { console as consoleAdapter } from 'back-end/lib/logger/adapters';
 import Knex from 'knex';
 
-const logger = makeDomainLogger(consoleAdapter, 'migrations');
+const logger = makeDomainLogger(consoleAdapter, 'migrations', 'development');
 
 export async function up(connection: Knex): Promise<void> {
   await connection.schema.raw(`

--- a/src/migrations/tasks/20200329100105_swu_null_createdby.ts
+++ b/src/migrations/tasks/20200329100105_swu_null_createdby.ts
@@ -2,7 +2,7 @@ import { makeDomainLogger } from 'back-end/lib/logger';
 import { console as consoleAdapter } from 'back-end/lib/logger/adapters';
 import Knex from 'knex';
 
-const logger = makeDomainLogger(consoleAdapter, 'migrations');
+const logger = makeDomainLogger(consoleAdapter, 'migrations', 'development');
 
 export async function up(connection: Knex): Promise<void> {
   await connection.schema.alterTable('swuOpportunityStatuses', table => {

--- a/src/migrations/tasks/20200329163517_swu_proposals_attachment_cascade.ts
+++ b/src/migrations/tasks/20200329163517_swu_proposals_attachment_cascade.ts
@@ -2,7 +2,7 @@ import { makeDomainLogger } from 'back-end/lib/logger';
 import { console as consoleAdapter } from 'back-end/lib/logger/adapters';
 import Knex from 'knex';
 
-const logger = makeDomainLogger(consoleAdapter, 'migrations');
+const logger = makeDomainLogger(consoleAdapter, 'migrations', 'development');
 
 export async function up(connection: Knex): Promise<void> {
   await connection.schema.raw(`

--- a/src/migrations/tasks/20200402205816_update-proposal-status-checks.ts
+++ b/src/migrations/tasks/20200402205816_update-proposal-status-checks.ts
@@ -2,7 +2,7 @@ import { makeDomainLogger } from 'back-end/lib/logger';
 import { console as consoleAdapter } from 'back-end/lib/logger/adapters';
 import Knex from 'knex';
 
-const logger = makeDomainLogger(consoleAdapter, 'migrations');
+const logger = makeDomainLogger(consoleAdapter, 'migrations', 'development');
 
 enum SWUProposalStatus {
   Draft                     = 'DRAFT',

--- a/src/migrations/tasks/20200403095356_swu_proposal_anon_name.ts
+++ b/src/migrations/tasks/20200403095356_swu_proposal_anon_name.ts
@@ -2,7 +2,7 @@ import { makeDomainLogger } from 'back-end/lib/logger';
 import { console as consoleAdapter } from 'back-end/lib/logger/adapters';
 import Knex from 'knex';
 
-const logger = makeDomainLogger(consoleAdapter, 'migrations');
+const logger = makeDomainLogger(consoleAdapter, 'migrations', 'development');
 
 export async function up(connection: Knex): Promise<void> {
   await connection.schema.alterTable('swuProposals', table => {

--- a/src/migrations/tasks/20200407205605_remove_pending_field.ts
+++ b/src/migrations/tasks/20200407205605_remove_pending_field.ts
@@ -2,7 +2,7 @@ import { makeDomainLogger } from 'back-end/lib/logger';
 import { console as consoleAdapter } from 'back-end/lib/logger/adapters';
 import Knex from 'knex';
 
-const logger = makeDomainLogger(consoleAdapter, 'migrations');
+const logger = makeDomainLogger(consoleAdapter, 'migrations', 'development');
 
 export async function up(connection: Knex): Promise<void> {
   await connection.schema.alterTable('swuProposalTeamMembers', table => {

--- a/src/migrations/tasks/20200409141151_proposal_score_float.ts
+++ b/src/migrations/tasks/20200409141151_proposal_score_float.ts
@@ -2,7 +2,7 @@ import { makeDomainLogger } from 'back-end/lib/logger';
 import { console as consoleAdapter } from 'back-end/lib/logger/adapters';
 import Knex from 'knex';
 
-const logger = makeDomainLogger(consoleAdapter, 'migrations');
+const logger = makeDomainLogger(consoleAdapter, 'migrations', 'development');
 
 export async function up(connection: Knex): Promise<void> {
   await connection.schema.alterTable('swuProposals', table => {

--- a/src/migrations/tasks/20200413164227_fix-session-trigger-lock.ts
+++ b/src/migrations/tasks/20200413164227_fix-session-trigger-lock.ts
@@ -2,7 +2,7 @@ import { makeDomainLogger } from 'back-end/lib/logger';
 import { console as consoleAdapter } from 'back-end/lib/logger/adapters';
 import Knex from 'knex';
 
-const logger = makeDomainLogger(consoleAdapter, 'migrations');
+const logger = makeDomainLogger(consoleAdapter, 'migrations', 'development');
 
 export async function up(connection: Knex): Promise<void> {
 

--- a/src/migrations/tasks/20200414202808_swu-proposal-scores.ts
+++ b/src/migrations/tasks/20200414202808_swu-proposal-scores.ts
@@ -2,7 +2,7 @@ import { makeDomainLogger } from 'back-end/lib/logger';
 import { console as consoleAdapter } from 'back-end/lib/logger/adapters';
 import Knex from 'knex';
 
-const logger = makeDomainLogger(consoleAdapter, 'migrations');
+const logger = makeDomainLogger(consoleAdapter, 'migrations', 'development');
 
 export async function up(connection: Knex): Promise<void> {
   await connection.schema.alterTable('swuTeamQuestionResponses', table => {

--- a/src/migrations/tasks/20200415203004_session-fields.ts
+++ b/src/migrations/tasks/20200415203004_session-fields.ts
@@ -2,7 +2,7 @@ import { makeDomainLogger } from 'back-end/lib/logger';
 import { console as consoleAdapter } from 'back-end/lib/logger/adapters';
 import Knex from 'knex';
 
-const logger = makeDomainLogger(consoleAdapter, 'migrations');
+const logger = makeDomainLogger(consoleAdapter, 'migrations', 'development');
 
 export async function up(connection: Knex): Promise<void> {
   await connection.schema.raw(`

--- a/src/migrations/tasks/20200416135648_session-trigger-fix.ts
+++ b/src/migrations/tasks/20200416135648_session-trigger-fix.ts
@@ -2,7 +2,7 @@ import { makeDomainLogger } from 'back-end/lib/logger';
 import { console as consoleAdapter } from 'back-end/lib/logger/adapters';
 import Knex from 'knex';
 
-makeDomainLogger(consoleAdapter, 'migrations');
+makeDomainLogger(consoleAdapter, 'migrations', 'development');
 
 export async function up(connection: Knex): Promise<void> {
   // Drop previous trigger

--- a/src/migrations/tasks/20200416160014_min-team-members.ts
+++ b/src/migrations/tasks/20200416160014_min-team-members.ts
@@ -2,7 +2,7 @@ import { makeDomainLogger } from 'back-end/lib/logger';
 import { console as consoleAdapter } from 'back-end/lib/logger/adapters';
 import Knex from 'knex';
 
-const logger = makeDomainLogger(consoleAdapter, 'migrations');
+const logger = makeDomainLogger(consoleAdapter, 'migrations', 'development');
 
 export async function up(connection: Knex): Promise<void> {
   await connection.schema.alterTable('swuOpportunityVersions', table => {

--- a/src/migrations/tasks/20200422173628_optional-street2.ts
+++ b/src/migrations/tasks/20200422173628_optional-street2.ts
@@ -2,7 +2,7 @@ import { makeDomainLogger } from 'back-end/lib/logger';
 import { console as consoleAdapter } from 'back-end/lib/logger/adapters';
 import Knex from 'knex';
 
-const logger = makeDomainLogger(consoleAdapter, 'migrations');
+const logger = makeDomainLogger(consoleAdapter, 'migrations', 'development');
 
 export async function up(connection: Knex): Promise<void> {
   await connection.schema.alterTable('cwuProponents', table => {

--- a/src/migrations/tasks/20200427091310_subscription-cascade.ts
+++ b/src/migrations/tasks/20200427091310_subscription-cascade.ts
@@ -2,7 +2,7 @@ import { makeDomainLogger } from 'back-end/lib/logger';
 import { console as consoleAdapter } from 'back-end/lib/logger/adapters';
 import Knex from 'knex';
 
-const logger = makeDomainLogger(consoleAdapter, 'migrations');
+const logger = makeDomainLogger(consoleAdapter, 'migrations', 'development');
 
 export async function up(connection: Knex): Promise<void> {
   await connection.schema.raw(`

--- a/src/migrations/tasks/20200902153012_idp_suffix.ts
+++ b/src/migrations/tasks/20200902153012_idp_suffix.ts
@@ -1,14 +1,17 @@
 import { makeDomainLogger } from 'back-end/lib/logger';
 import { console as consoleAdapter } from 'back-end/lib/logger/adapters';
 import Knex from 'knex';
+import { UserType } from 'migrations/../shared/lib/resources/user';
 
 const logger = makeDomainLogger(consoleAdapter, 'migrations', 'development');
 
 export async function up(connection: Knex): Promise<void> {
   const results = await connection<{ id: string, idpUsername: string }>('users')
     .select('id', 'idpUsername')
-    .where('idpUsername', 'LIKE', '%@github')
-    .orWhere('idpUsername', 'LIKE', '%@idir');
+    .where(q => q.where('idpUsername', 'LIKE', '%@github').andWhere('type', '=', UserType.Vendor))
+    .orWhere(q => q.where('idpUsername', 'LIKE', '%@idir').andWhere('type', '=', UserType.Admin))
+    .orWhere(q => q.where('idpUsername', 'LIKE', '%@github').andWhere('type', '=', UserType.Admin))
+    .orWhere(q => q.where('idpUsername', 'LIKE', '%@idir').andWhere('type', '=', UserType.Government));
 
   for (const result of results) {
     const withoutSuffix = result.idpUsername.slice(0, result.idpUsername.lastIndexOf('@'));

--- a/src/migrations/tasks/20200902153012_idp_suffix.ts
+++ b/src/migrations/tasks/20200902153012_idp_suffix.ts
@@ -1,0 +1,27 @@
+import { makeDomainLogger } from 'back-end/lib/logger';
+import { console as consoleAdapter } from 'back-end/lib/logger/adapters';
+import Knex from 'knex';
+
+const logger = makeDomainLogger(consoleAdapter, 'migrations', 'development');
+
+export async function up(connection: Knex): Promise<void> {
+  const results = await connection<{ id: string, idpUsername: string }>('users')
+    .select('id', 'idpUsername')
+    .where('idpUsername', 'LIKE', '%@github')
+    .orWhere('idpUsername', 'LIKE', '%@idir');
+
+  for (const result of results) {
+    const withoutSuffix = result.idpUsername.slice(0, result.idpUsername.lastIndexOf('@'));
+    await connection('users')
+      .where({ id: result.id })
+      .update({
+        idpUsername: withoutSuffix
+      });
+    logger.info(`Changed username '${result.idpUsername}' to '${withoutSuffix}`);
+  }
+  logger.info('Completed updating users table.');
+}
+
+export async function down(connection: Knex): Promise<void> {
+  logger.info('Unable to reverse one-way migration of username modification.');
+}


### PR DESCRIPTION
This PR includes a migration to update existing usernames (needs to be tested in dev/test prior to production deployment as the migration would not be easily reversed).

Also includes modification to auth router to remove suffix on new user sign-up.