### PR TITLE
stabilize IDP auth sign-in flow

### DIFF
--- a/src/back-end/lib/db/user.ts
+++ b/src/back-end/lib/db/user.ts
@@ -73,9 +73,9 @@ export const findOneUserByTypeAndUsername = tryDb<[UserType, string], User | nul
   return valid(result ? result : null);
 });
 
-export const findOneUserByIdpId = tryDb<[string], User | null>(async (connection, idpId) => {
+export const findOneUserByTypeAndIdp = tryDb<[UserType, string], User | null>(async (connection, type, idpId) => {
   const result = await connection<User>('users')
-    .where({ idpId }).first();
+    .where({ idpId, type }).first();
   return valid(result ? result : null);
 });
 

--- a/src/back-end/lib/db/user.ts
+++ b/src/back-end/lib/db/user.ts
@@ -73,6 +73,12 @@ export const findOneUserByTypeAndUsername = tryDb<[UserType, string], User | nul
   return valid(result ? result : null);
 });
 
+export const findOneUserByIdpId = tryDb<[string], User | null>(async (connection, idpId) => {
+  const result = await connection<User>('users')
+    .where({ idpId }).first();
+  return valid(result ? result : null);
+});
+
 export const readManyUsers = tryDb<[], User[]>(async (connection) => {
   const results = await connection<RawUser>('users').select();
   return valid(await Promise.all(results.map(async raw => await rawUserToUser(connection, raw))));

--- a/src/back-end/lib/routers/admin/mocks.ts
+++ b/src/back-end/lib/routers/admin/mocks.ts
@@ -26,7 +26,8 @@ export const vendorUser: User = {
   idpUsername: 'vendor_user',
   deactivatedOn: null,
   deactivatedBy: null,
-  capabilities: []
+  capabilities: [],
+  idpId: 'vendor_user'
 };
 
 export const vendorUserSlim: UserSlim = {
@@ -47,7 +48,8 @@ export const govUser: User = {
   idpUsername: 'username',
   deactivatedOn: null,
   deactivatedBy: null,
-  capabilities: []
+  capabilities: [],
+  idpId: 'username'
 };
 
 export const adminUser: User = {
@@ -63,7 +65,8 @@ export const adminUser: User = {
   idpUsername: 'username',
   deactivatedOn: null,
   deactivatedBy: null,
-  capabilities: []
+  capabilities: [],
+  idpId: 'username'
 };
 
 export const cwuOpportunity: CWUOpportunity = {

--- a/src/back-end/lib/routers/auth.ts
+++ b/src/back-end/lib/routers/auth.ts
@@ -287,13 +287,14 @@ async function establishSessionWithClaims(connection: Connection, request: Reque
   }
 
   let username = getString(claims, 'preferred_username');
+  const idpId = getString(claims, 'idp_id');
 
   // Strip the vendor/gov suffix if present.  We want to match and store the username without suffix.
   if ((username.endsWith('@' + VENDOR_IDP_SUFFIX) && userType === UserType.Vendor) || (username.endsWith('@' + GOV_IDP_SUFFIX) && userType === UserType.Government)) {
     username = username.slice(0, username.lastIndexOf('@'));
   }
 
-  if (!username || !tokenSet.access_token || !tokenSet.refresh_token) {
+  if (!username || !idpId || !tokenSet.access_token || !tokenSet.refresh_token) {
     throw new Error('authentication failure - invalid claims');
   }
 
@@ -305,6 +306,7 @@ async function establishSessionWithClaims(connection: Connection, request: Reque
   const existingUser = !!user;
   if (!user) {
     user = getValidValue(await createUser(connection, {
+      idpId,
       type: userType,
       status: UserStatus.Active,
       name: claims.name || '',

--- a/src/back-end/lib/routers/auth.ts
+++ b/src/back-end/lib/routers/auth.ts
@@ -1,6 +1,6 @@
 import { KEYCLOAK_CLIENT_ID, KEYCLOAK_CLIENT_SECRET, KEYCLOAK_REALM, KEYCLOAK_URL, SERVICE_TOKEN_HASH } from 'back-end/config';
 import { prefixPath } from 'back-end/lib';
-import { Connection, createSession, createUser, deleteSession, findOneUserByIdpId, findOneUserByTypeAndUsername, readOneSession, updateUser } from 'back-end/lib/db';
+import { Connection, createSession, createUser, deleteSession, findOneUserByTypeAndIdp, findOneUserByTypeAndUsername, readOneSession, updateUser } from 'back-end/lib/db';
 import { accountReactivatedSelf, userAccountRegistered } from 'back-end/lib/mailer/notifications/user';
 import { authenticatePassword } from 'back-end/lib/security';
 import { makeErrorResponseBody, makeTextResponseBody, nullRequestBodyHandler, passThroughRequestBodyHandler, Request, Router, TextResponseBody } from 'back-end/lib/server';
@@ -298,7 +298,7 @@ async function establishSessionWithClaims(connection: Connection, request: Reque
     throw new Error('authentication failure - invalid claims');
   }
 
-  const dbResult = await findOneUserByIdpId(connection, idpId);
+  const dbResult = await findOneUserByTypeAndIdp(connection, userType, idpId);
   if (isInvalid(dbResult)) {
     makeAuthErrorRedirect(request);
   }

--- a/src/back-end/lib/routers/auth.ts
+++ b/src/back-end/lib/routers/auth.ts
@@ -1,6 +1,6 @@
 import { KEYCLOAK_CLIENT_ID, KEYCLOAK_CLIENT_SECRET, KEYCLOAK_REALM, KEYCLOAK_URL, SERVICE_TOKEN_HASH } from 'back-end/config';
 import { prefixPath } from 'back-end/lib';
-import { Connection, createSession, createUser, deleteSession, findOneUserByTypeAndUsername, readOneSession, updateUser } from 'back-end/lib/db';
+import { Connection, createSession, createUser, deleteSession, findOneUserByIdpId, findOneUserByTypeAndUsername, readOneSession, updateUser } from 'back-end/lib/db';
 import { accountReactivatedSelf, userAccountRegistered } from 'back-end/lib/mailer/notifications/user';
 import { authenticatePassword } from 'back-end/lib/security';
 import { makeErrorResponseBody, makeTextResponseBody, nullRequestBodyHandler, passThroughRequestBodyHandler, Request, Router, TextResponseBody } from 'back-end/lib/server';
@@ -298,7 +298,7 @@ async function establishSessionWithClaims(connection: Connection, request: Reque
     throw new Error('authentication failure - invalid claims');
   }
 
-  const dbResult = await findOneUserByTypeAndUsername(connection, userType, username);
+  const dbResult = await findOneUserByIdpId(connection, idpId);
   if (isInvalid(dbResult)) {
     makeAuthErrorRedirect(request);
   }

--- a/src/migrations/tasks/20200922153512_idp_id.ts
+++ b/src/migrations/tasks/20200922153512_idp_id.ts
@@ -1,0 +1,29 @@
+import { makeDomainLogger } from 'back-end/lib/logger';
+import { console as consoleAdapter } from 'back-end/lib/logger/adapters';
+import Knex from 'knex';
+
+const logger = makeDomainLogger(consoleAdapter, 'migrations', 'development');
+
+export async function up(connection: Knex): Promise<void> {
+  // Create the new idpId column.
+  await connection.schema.alterTable('users', table => {
+    table.text('idpId');
+  });
+
+  // Update the new column with values from the idpUsername column
+  await connection('users').update('idpId', connection.ref('idpUsername'));
+
+  // Set the idpId column as not nullable and unique on idpId and account.
+  await connection.schema.alterTable('users', table => {
+    table.text('idpId').notNullable().alter();
+    table.unique(['idpId', 'type']);
+  });
+  logger.info('Completed modifying users table.');
+}
+
+export async function down(connection: Knex): Promise<void> {
+  await connection.schema.alterTable('users', table => {
+    table.dropColumn('idpId');
+  });
+  logger.info('Completed reverting users table.');
+}

--- a/src/shared/lib/resources/user.ts
+++ b/src/shared/lib/resources/user.ts
@@ -45,6 +45,7 @@ export interface User {
   deactivatedOn: Date | null;
   deactivatedBy: Id | null;
   capabilities: string[];
+  idpId: string;
 }
 
 export interface UserSlim {


### PR DESCRIPTION
This PR does the following:

* Adds a database migration which adds a new `idpId` column and transfers values from `idpUsername`
* Modifies the auth router to store users with idpId and retrieve existing users by idpId
* Modifies the shared user model and mocks as needed