### PR TITLE
fix: removes background-color property

### DIFF
--- a/src/front-end/sass/index.scss
+++ b/src/front-end/sass/index.scss
@@ -737,7 +737,6 @@ nav.navbar .nav-link:hover {
         left: 0;
         width: 100%;
         height: 100%;
-        background-color: inherit;
         background: inherit;
       }
     }


### PR DESCRIPTION
Removes superfluous `background-color` property. Removing `background-color` as opposed to `background` because the value is `inherit` and without digging into the code I am unaware of other background property values it may be inheriting.