### PR TITLE
fix: update noreply email address

### DIFF
--- a/src/back-end/config.ts
+++ b/src/back-end/config.ts
@@ -14,7 +14,7 @@ export const TOTAL_AWARDED_VALUE_OFFSET = 13211500;
 
 export const DB_MIGRATIONS_TABLE_NAME = 'migrations';
 
-export const MAILER_REPLY = get('MAILER_REPLY', 'noreply@digitalmarketplace.gov.bc.ca');
+export const MAILER_REPLY = get('MAILER_REPLY', 'noreply@digital.gov.bc.ca');
 
 // ENV CONFIG
 


### PR DESCRIPTION
Addresses DM-754.

The `MAILER_REPLY` variable is used to create the `MAILER_FROM` variable, which is used in the `send` function (in `transport.ts`).

Note: `MAILER_REPLY` is additionally used as a recipient in four of the CWU and SWU functions. In these functions, the mail is sent to `MAILER_REPLY` with the user bcc'd, while in all the other functions, it appears to go straight to the user. Couldn't think of a reason for this.

