### PR TITLE
move npm install back to dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,18 @@
+# local build artifacts
 node_modules
+tmp
+build
+
+# Sonarqube
+.scannerwork
+sonar-project.properties
+
+# Github
+.github
+
+# macOS 
+.DS_Store
+
+# IDE 
+.vscode
+.idea

--- a/src/front-end/Dockerfile
+++ b/src/front-end/Dockerfile
@@ -1,6 +1,10 @@
 FROM --platform=linux/amd64 docker.io/node:10-jessie
 COPY . /usr/app
 WORKDIR /usr/app
-EXPOSE 3000
+RUN npm install
+RUN NODE_ENV=production npm run front-end:build
+RUN npm run back-end:build
 RUN chmod -R 775 /usr/app
+RUN chown -R node:root /usr/app
+EXPOSE 3000
 ENTRYPOINT ["/usr/app/src/front-end/docker-entrypoint.sh"]

--- a/src/front-end/Dockerfile
+++ b/src/front-end/Dockerfile
@@ -2,7 +2,7 @@ FROM --platform=linux/amd64 docker.io/node:10-jessie
 COPY . /usr/app
 WORKDIR /usr/app
 RUN npm install
-RUN NODE_ENV=production npm run front-end:build
+RUN npm run front-end:build
 RUN npm run back-end:build
 RUN chmod -R 775 /usr/app
 RUN chown -R node:root /usr/app

--- a/src/front-end/docker-entrypoint.sh
+++ b/src/front-end/docker-entrypoint.sh
@@ -1,13 +1,8 @@
 #!/bin/bash
-npm install
-chown -R node:root /usr/app
 
 if [ "${NODE_ENV}" != "development" ]
     then
-        NODE_ENV=production npm run front-end:build
-        npm run back-end:build
         npm start
-
     else
         # to avoid git picking up file permission changes when attaching to Docker container via VS Code
         git config core.filemode false


### PR DESCRIPTION
- this moves `npm install` back to the dockerfile
- adds more restrictions to `.dockerignore` 