### PR TITLE
Pre-req for getting project added to bcgov sonarcloud

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,7 @@
 name: CI
 on: 
   push:
-  pull_request:
-    branches:
-      - development
-
+    branches: [development, master]
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -35,3 +32,15 @@ jobs:
           node-version: '10'
       - run: npm ci
       - run: npm audit --audit-level=moderate
+  sonarcloud:
+    name: sonarCloud 
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+      - name: SonarCloud Scan
+        uses: SonarSource/sonarcloud-github-action@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -4,4 +4,4 @@ sonar.sourceEncoding=UTF-8
 
 sonar.organization=bcgov-sonarcloud
 sonar.projectKey=digital_marketplace
-sonar.host.url=http://localhost:9000
+sonar.host.url=https://sonarcloud.io/

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,6 @@
+sonar.projectName=digital-marketplace
+sonar.sources=.
+sonar.sourceEncoding=UTF-8
+
+sonar.organization=<replace with your SonarCloud organization key>
+sonar.projectKey=<replace with the key generated when setting up the project on SonarCloud>

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,8 @@
 sonar.projectName=digital-marketplace
-sonar.sources=.
+sonar.sources=src/front-end,src/back-end
 sonar.sourceEncoding=UTF-8
 
-sonar.organization=<replace with your SonarCloud organization key>
-sonar.projectKey=<replace with the key generated when setting up the project on SonarCloud>
+sonar.organization=bcgov-sonarcloud
+sonar.projectKey=digital_marketplace
+# not sure about this
+sonar.host.url=http://localhost:9000

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -4,5 +4,4 @@ sonar.sourceEncoding=UTF-8
 
 sonar.organization=bcgov-sonarcloud
 sonar.projectKey=digital_marketplace
-# not sure about this
 sonar.host.url=http://localhost:9000

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -3,5 +3,5 @@ sonar.sources=src/front-end,src/back-end
 sonar.sourceEncoding=UTF-8
 
 sonar.organization=bcgov-sonarcloud
-sonar.projectKey=digital_marketplace
+sonar.projectKey=bcgov_digital-marketplace
 sonar.host.url=https://sonarcloud.io/


### PR DESCRIPTION
There's a [step-by-step process](https://github.com/BCDevOps/sonarqube/tree/master#sonarcloud) for getting our project added to sonarcloud so we can set up an github action. This PR addresses step 4.

The `sonar-project.properties` is based on the example in the link above and additionally includes a couple lines from the [github sonarqube action](https://github.com/marketplace/actions/sonarcloud-scan). 