### PR TITLE
feat: create build-scan github action

### DIFF
--- a/.github/workflows/build-scan.yml
+++ b/.github/workflows/build-scan.yml
@@ -2,9 +2,8 @@ name: build-scan
 on: 
   # Since branch protection prevents pushing to development, pushes only happen when merging PRs, so this runs only on merges (there's no way to set GitHub Actions to run on merges)
   push:
-  # temporarily turning off restrictions to test action on github
-    # branches:
-    #   - development
+    branches:
+      - development
 
 jobs:
   build-scan:

--- a/.github/workflows/build-scan.yml
+++ b/.github/workflows/build-scan.yml
@@ -2,8 +2,9 @@ name: build-scan
 on: 
   # Since branch protection prevents pushing to development, pushes only happen when merging PRs, so this runs only on merges (there's no way to set GitHub Actions to run on merges)
   push:
-    branches:
-      - development
+  # temporarily turning off restrictions to test action on github
+    # branches:
+    #   - development
 
 jobs:
   build-scan:

--- a/.github/workflows/build-scan.yml
+++ b/.github/workflows/build-scan.yml
@@ -1,0 +1,19 @@
+name: build-scan
+on: 
+  # Since branch protection prevents pushing to development, pushes only happen when merging PRs, so this runs only on merges (there's no way to set GitHub Actions to run on merges)
+  push:
+    branches:
+      - development
+
+jobs:
+  build-scan:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: redhat-actions/buildah-build@v2
+      with:
+        image: dm-app-image
+        containerfiles: |
+          ../src/front-end/Dockerfile
+
+    

--- a/.github/workflows/build-scan.yml
+++ b/.github/workflows/build-scan.yml
@@ -15,6 +15,6 @@ jobs:
       with:
         image: dm-app-image
         containerfiles: |
-          ../src/front-end/Dockerfile
+          ./src/front-end/Dockerfile
 
     


### PR DESCRIPTION
This ticket addresses DM-859. It:

- Runs on merges to development branch
- Builds the app inside a container using Buildah (this is what OpenShift uses for container-building)

Note: Since the action should run only on merges, it doesn't show up with the rest of the CI below since the merge won't happen until after approval. I set it to run once on push so we could see the run: https://github.com/bcgov/digital_marketplace/actions/runs/1483304286. (I couldn't get it to run on [ACT](https://github.com/nektos/act)--its container didn't have Buildah installed)