### PR TITLE
Dm 703

### DIFF
--- a/grunt-configs/watch.js
+++ b/grunt-configs/watch.js
@@ -6,6 +6,7 @@ module.exports = {
   frontEndTS: {
     files: [
       `${gruntConfig.frontEnd.src.ts}/**`,
+      `${gruntConfig.frontEnd.src.tsx}/**`,
       `${gruntConfig.shared.src.dir}/**`
     ],
     tasks: [

--- a/src/front-end/typescript/lib/pages/organization/edit/tab/team.tsx
+++ b/src/front-end/typescript/lib/pages/organization/edit/tab/team.tsx
@@ -17,7 +17,7 @@ import React from 'react';
 import { Col, Row } from 'reactstrap';
 import CAPABILITIES from 'shared/lib/data/capabilities';
 import { AffiliationMember, memberIsOwner, memberIsPending, membersHaveCapability, MembershipType } from 'shared/lib/resources/affiliation';
-import { isVendor } from 'shared/lib/resources/user';
+import { isAdmin, isVendor } from 'shared/lib/resources/user';
 import { adt, ADT, Id } from 'shared/lib/types';
 import { validateUserEmail } from 'shared/lib/validation/affiliation';
 
@@ -273,20 +273,21 @@ function membersTableBodyRows(props: ComponentViewProps<State, Msg>): Table.Body
       },
       {
         showOnHover: !isMemberLoading,
-        children: memberIsOwner(m) || !isVendor(state.viewerUser)
+        //TODO FIX THIS LOGIC BRO!!!!
+        children: (memberIsOwner(m) || !isVendor(state.viewerUser)) && !isAdmin(state.viewerUser)
           ? null
           : (
-              <Link
-                button
-                disabled={isLoading}
-                loading={isMemberLoading}
-                size='sm'
-                symbol_={leftPlacement(iconLinkSymbol('user-times'))}
-                onClick={() => dispatch(adt('showModal', adt('removeTeamMember', m)) as Msg)}
-                color='danger'>
-                Remove
-              </Link>
-            ),
+            <Link
+              button
+              disabled={isLoading}
+              loading={isMemberLoading}
+              size='sm'
+              symbol_={leftPlacement(iconLinkSymbol('user-times'))}
+              onClick={() => dispatch(adt('showModal', adt('removeTeamMember', m)) as Msg)}
+              color='danger'>
+              Remove
+            </Link>
+          ),
         className: 'text-right align-middle'
       }
     ];
@@ -306,10 +307,10 @@ const view: ComponentView<State, Msg> = props => {
           <p className='mb-4'>Add team members to your organization by clicking on the "Add Team Member(s)" button above. Please ensure team members have already signed up for a Digital Marketplace Vendor account before adding them to your organization.</p>
           {state.affiliations.length
             ? (<Table.view
-                headCells={membersTableHeadCells(state)}
-                bodyRows={membersTableBodyRows(props)}
-                state={state.membersTable}
-                dispatch={mapComponentDispatch(dispatch, v => adt('membersTable' as const, v))} />)
+              headCells={membersTableHeadCells(state)}
+              bodyRows={membersTableBodyRows(props)}
+              state={state.membersTable}
+              dispatch={mapComponentDispatch(dispatch, v => adt('membersTable' as const, v))} />)
             : null}
         </Col>
       </Row>
@@ -378,13 +379,13 @@ export const component: Tab.Component<State, Msg> = {
                           {state.addTeamMembersEmails.length === 1
                             ? null
                             : (<Icon
-                                hover
-                                name='trash'
-                                color='info'
-                                className='ml-2'
-                                width={0.9}
-                                height={0.9}
-                                onClick={() => dispatch(adt('addTeamMembersEmailsRemoveField', i))} />)}
+                              hover
+                              name='trash'
+                              color='info'
+                              className='ml-2'
+                              width={0.9}
+                              height={0.9}
+                              onClick={() => dispatch(adt('addTeamMembersEmailsRemoveField', i))} />)}
                           <Icon
                             hover={isLast}
                             name='plus'
@@ -444,7 +445,7 @@ export const component: Tab.Component<State, Msg> = {
     }
   },
   getContextualActions: ({ state, dispatch }) => {
-    if (!isVendor(state.viewerUser)) { return null; }
+    if (!isVendor(state.viewerUser) && !isAdmin(state.viewerUser)) { return null; }
     const isAddTeamMembersLoading = state.addTeamMembersLoading > 0;
     const isRemoveTeamMemberLoading = !!state.removeTeamMemberLoading;
     const isLoading = isAddTeamMembersLoading || isRemoveTeamMemberLoading;

--- a/src/front-end/typescript/lib/pages/organization/edit/tab/team.tsx
+++ b/src/front-end/typescript/lib/pages/organization/edit/tab/team.tsx
@@ -16,7 +16,7 @@ import Link, { iconLinkSymbol, imageLinkSymbol, leftPlacement } from 'front-end/
 import React from 'react';
 import { Col, Row } from 'reactstrap';
 import CAPABILITIES from 'shared/lib/data/capabilities';
-import { AffiliationSlim, AffiliationMember, memberIsOwner, memberIsPending, membersHaveCapability, MembershipType } from 'shared/lib/resources/affiliation';
+import { AffiliationMember, memberIsOwner, memberIsPending, membersHaveCapability, MembershipType } from 'shared/lib/resources/affiliation';
 import { isAdmin, isVendor } from 'shared/lib/resources/user';
 import { adt, ADT, Id } from 'shared/lib/types';
 import { validateUserEmail } from 'shared/lib/validation/affiliation';
@@ -25,7 +25,7 @@ type ModalId
   = ADT<'addTeamMembers'>
   | ADT<'viewTeamMember', AffiliationMember>
   | ADT<'removeTeamMember', AffiliationMember>
-  | ADT<'approveAffiliation', AffiliationSlim>;
+  | ADT<'approveAffiliation', AffiliationMember>;
 
 
 export interface State extends Tab.Params {
@@ -41,7 +41,7 @@ export interface State extends Tab.Params {
 export type InnerMsg
   = ADT<'addTeamMembers'>
   | ADT<'removeTeamMember', AffiliationMember> //Id of affiliation, not user
-  | ADT<'approveAffiliation', AffiliationSlim>
+  | ADT<'approveAffiliation', AffiliationMember>
   | ADT<'showModal', ModalId>
   | ADT<'hideModal'>
   | ADT<'membersTable', Table.Msg>
@@ -179,12 +179,12 @@ const update: Update<State, Msg> = ({ state, msg }) => {
           // console.log(msg.value.id)
           const result = await api.affiliations.update(msg.value.id, null);
           if (!api.isValid(result)) {
-            dispatch(toast(adt('error', toasts.approvedOrganizationRequest.error(msg.value))));
+            dispatch(toast(adt('error', toasts.approvedTeamMember.error(msg.value))));
             return state;
           }
           const params = await Tab.initParams(state.organization.id, state.viewerUser);
           // console.log('the params are')
-          // console.log(params)
+          // console.log(params?.organization)
           if (params) {
             state = state
               .set('organization', params.organization)
@@ -192,7 +192,10 @@ const update: Update<State, Msg> = ({ state, msg }) => {
               .set('viewerUser', params.viewerUser)
               .set('swuQualified', params.swuQualified);
           }
-          dispatch(toast(adt('success', toasts.approvedOrganizationRequest.success(msg.value))));
+          console.log(`the message value is: ${msg.value}`)
+          console.log(msg.value)
+
+          dispatch(toast(adt('success', toasts.approvedTeamMember.success(msg.value))));
           return resetCapabilities(state);
         }
       ];
@@ -216,6 +219,8 @@ const update: Update<State, Msg> = ({ state, msg }) => {
               .set('viewerUser', params.viewerUser)
               .set('swuQualified', params.swuQualified);
           }
+          console.log(`the message value is: ${msg.value}`)
+          console.log(msg.value)
           dispatch(toast(adt('success', toasts.removedTeamMember.success(msg.value))));
           return resetCapabilities(state);
         }
@@ -357,10 +362,13 @@ function membersTableBodyRows(props: ComponentViewProps<State, Msg>): Table.Body
 
 const view: ComponentView<State, Msg> = props => {
   const { state, dispatch } = props;
+  // console.log("The legal name is")
+  // console.log(state.organization)
+  // console.log(state.organization.legalName)
   return (
     <div>
       <EditTabHeader
-        legalName={state.organization.legalName}
+        legalName={state.organization?.legalName}
         swuQualified={state.swuQualified} />
       <Row className='mt-5'>
         <Col xs='12'>

--- a/src/front-end/typescript/lib/pages/organization/lib/toasts.tsx
+++ b/src/front-end/typescript/lib/pages/organization/lib/toasts.tsx
@@ -89,6 +89,17 @@ export const removedTeamMember = {
   })
 };
 
+export const approvedTeamMember = {
+  success: (aff: AffiliationMember) => ({
+    title: 'Approved Team Member',
+    body: `You have successfully approved ${aff.user.name} for this organization.`
+  }),
+  error: (aff: AffiliationMember) => ({
+    title: 'Unable to Approve Team Member',
+    body: `${aff.user.name} could not be approved for this organization.`
+  })
+};
+
 export const acceptedSWUTerms = {
   success: (organization: Organization) => ({
     title: 'Accepted Terms & Conditions',


### PR DESCRIPTION
This PR allows an admin to add team members to an organization an approve (set them from pending to active).
It also allows the hot reloading to track .tsx files
- Only admins should be able to do this  

testing notes:  The following conditions were tested:

- [x] gov non admin - cannot access the page
- [x] gov admin - can add users to the team, can approve them (remove the pending flag)
- [x] vendor team owner - can add new team memeber, cannot remove the pending flag
- [x] (vendor non team member,vendor team member pending, vendor team member active) -cannot access the team member page
