### PR TITLE
Dm 900 Fix deployment to prevent override of origin url

### DIFF
--- a/openshift/README.md
+++ b/openshift/README.md
@@ -104,6 +104,9 @@ oc -n ccc866-test process -f templates/app/app-digmkt-deploy.yaml \
 -p KEYCLOAK_CLIENT_SECRET=<secret> \
 -p KEYCLOAK_URL=https://test.oidc.gov.bc.ca \
 -p SHOW_TEST_INDICATOR=1 \
+-p ORIGIN=https://digital-gov-frontend-test-c0cce6-test.apps.silver.devops.gov.bc.ca/marketplace \
+-p BASIC_AUTH_USERNAME=<username> \
+-p BASIC_AUTH_PASSWORD_HASH=<hashed_password> \
 -p DATABASE_SERVICE_NAME=postgresql | oc create -f -
 ```
 
@@ -113,6 +116,7 @@ oc -n ccc866-prod process -f templates/app/app-digmkt-deploy.yaml \
 -p KEYCLOAK_CLIENT_SECRET=<secret> \
 -p KEYCLOAK_URL=https://oidc.gov.bc.ca \
 -p SHOW_TEST_INDICATOR=0 \
+-p ORIGIN=https://digital.gov.bc.ca/marketplace \
 -p DATABASE_SERVICE_NAME=patroni | oc create -f -
 ```
 
@@ -126,6 +130,9 @@ oc -n ccc866-dev process -f templates/app/app-digmkt-deploy.yaml \
 -p KEYCLOAK_CLIENT_SECRET=<secret> \
 -p KEYCLOAK_URL=https://dev.oidc.gov.bc.ca \
 -p SHOW_TEST_INDICATOR=1 \
+-p BASIC_AUTH_USERNAME=<username> \
+-p BASIC_AUTH_PASSWORD_HASH=<hashed_password> \
+-p ORIGIN=https://app-digmkt-dev.apps.silver.devops.gov.bc.ca \
 -p DATABASE_SERVICE_NAME=postgresql | oc apply -f -
 ```
 ```
@@ -134,6 +141,9 @@ oc -n ccc866-test process -f templates/app/app-digmkt-deploy.yaml \
 -p KEYCLOAK_CLIENT_SECRET=<secret> \
 -p KEYCLOAK_URL=https://test.oidc.gov.bc.ca \
 -p SHOW_TEST_INDICATOR=1 \
+-p BASIC_AUTH_USERNAME=<username> \
+-p BASIC_AUTH_PASSWORD_HASH=<hashed_password> \
+-p ORIGIN=https://digital-gov-frontend-test-c0cce6-test.apps.silver.devops.gov.bc.ca/marketplace \
 -p DATABASE_SERVICE_NAME=postgresql | oc apply -f -
 ```
 
@@ -143,12 +153,13 @@ oc -n ccc866-prod process -f templates/app/app-digmkt-deploy.yaml \
 -p KEYCLOAK_CLIENT_SECRET=<secret> \
 -p KEYCLOAK_URL=https://oidc.gov.bc.ca \
 -p SHOW_TEST_INDICATOR=0 \
+-p ORIGIN=https://digital.gov.bc.ca/marketplace \
 -p DATABASE_SERVICE_NAME=patroni | oc apply -f -
 ```
 
 Note 1: When `apply` is used the deployment will not be automatically triggered.  That is done with the command:
 
-`oc -n ccc866-dev rollout latest dc/<deploymentconfig_name>`
+`oc -n ccc866-<dev,test,prod> rollout latest dc/<deploymentconfig_name>`
 
 Note 2: the `apply` command will not override an existing `KEYCLOAK_CLIENT_SECRET` stored in the OCP namespace.  
 If the `KEYCLOAK_CLIENT_SECRET` needs to be changed, the previous one will need to be deleted (in the namespace) before generating the new one.

--- a/openshift/README.md
+++ b/openshift/README.md
@@ -87,6 +87,8 @@ Replace `<secret>` with the KeyCloak client secret for the target environment.
 
 To password protect the dev and test namespace deployments, replace `BASIC_AUTH_USERNAME` and `BASIC_AUTH_PASSWORD_HASH` with the basic auth credentials desired. Leaving these parameters off the deployment command will deactivate login. The hashed password can be generated using the npm library bcrypt `bcrypt.hash('<password>',10)`. (NOTE:  This login is unrelated to keycloak authentication.)
 
+The `ORIGIN` parameter specifies the url Keycloak will redirect the browser to after a user logs into the app. 
+
 ```
 oc -n ccc866-dev process -f templates/app/app-digmkt-deploy.yaml \
 -p TAG_NAME=dev \

--- a/openshift/README.md
+++ b/openshift/README.md
@@ -97,6 +97,7 @@ oc -n ccc866-dev process -f templates/app/app-digmkt-deploy.yaml \
 -p SHOW_TEST_INDICATOR=1 \
 -p BASIC_AUTH_USERNAME=<username> \
 -p BASIC_AUTH_PASSWORD_HASH=<hashed_password> \
+-p ORIGIN=https://app-digmkt-dev.apps.silver.devops.gov.bc.ca \
 -p DATABASE_SERVICE_NAME=postgresql | oc create -f -
 ```
 

--- a/openshift/templates/app/app-digmkt-deploy.yaml
+++ b/openshift/templates/app/app-digmkt-deploy.yaml
@@ -259,3 +259,4 @@ parameters:
 - name: ORIGIN
   displayName: The vanity url for the deployment
   value: https://${NAME}-${APP_GROUP}-${TAG_NAME}.apps.silver.devops.gov.bc.ca
+  required: true

--- a/openshift/templates/app/app-digmkt-deploy.yaml
+++ b/openshift/templates/app/app-digmkt-deploy.yaml
@@ -18,7 +18,7 @@ objects:
     SERVER_PORT: '3000'
     DATABASE_SERVICE_NAME: ${DATABASE_SERVICE_NAME}-${APP_GROUP}-${TAG_NAME}
     FILE_STORAGE_DIR: "/usr/app"
-    ORIGIN: https://${NAME}-${APP_GROUP}-${TAG_NAME}.apps.silver.devops.gov.bc.ca
+    ORIGIN: ${ORIGIN}
     KEYCLOAK_CLIENT_ID: ${KEYCLOAK_CLIENT_ID}
     KEYCLOAK_URL: ${KEYCLOAK_URL}
     KEYCLOAK_REALM: ${KEYCLOAK_REALM}
@@ -255,3 +255,7 @@ parameters:
 - name: BASIC_AUTH_USERNAME
   displayName: The username for basic auth protection on test environments.
   required: false
+
+- name: ORIGIN
+  displayName: The vanity url for the deployment
+  value: https://${NAME}-${APP_GROUP}-${TAG_NAME}.apps.silver.devops.gov.bc.ca


### PR DESCRIPTION
Previous deployments were overriding the setting of the origin url (a vanity url that allows keycloak to redirect the app users to the correct url.)  Documentation has been updated,

Test cases
 - Build and deploy development to dev. Confirm that simple auth login works
 - Build and deploy master to test.  Confirm login (both keycloak and simple auth work)