### PR TITLE
fix: update email sender address

### DIFF
--- a/src/back-end/config.ts
+++ b/src/back-end/config.ts
@@ -14,7 +14,7 @@ export const TOTAL_AWARDED_VALUE_OFFSET = 13211500;
 
 export const DB_MIGRATIONS_TABLE_NAME = 'migrations';
 
-export const MAILER_REPLY = get('MAILER_REPLY', 'noreply_DigitalMarketplace@.gov.bc.ca');
+export const MAILER_REPLY = get('MAILER_REPLY', 'donotreply_DigitalMarketplace@gov.bc.ca');
 
 // ENV CONFIG
 

--- a/src/back-end/lib/routers/admin/mocks.ts
+++ b/src/back-end/lib/routers/admin/mocks.ts
@@ -95,7 +95,7 @@ export const cwuOpportunity: CWUOpportunity = {
   successfulProponent: {
     id: adt('individual', id),
     name: 'Successful Proponent',
-    email: 'noreply_DigitalMarketplace@gov.bc.ca',
+    email: 'donotreply_DigitalMarketplace@gov.bc.ca',
     createdBy: vendorUserSlim
   },
   status: CWUOpportunityStatus.Published,
@@ -198,7 +198,7 @@ export const swuOpportunity: SWUOpportunity = {
   successfulProponent: {
     id,
     name: 'Successful Proponent',
-    email: 'noreply_DigitalMarketplace@gov.bc.ca',
+    email: 'donotreply_DigitalMarketplace@gov.bc.ca',
     createdBy: vendorUserSlim
   },
   attachments: [],


### PR DESCRIPTION
Zenhub ticket: https://app.zenhub.com/workspaces/digital-marketplace-61d722a49f8ea7001eccc13b/issues/bcgov/digital_marketplace/216

Update the no reply sender to a valid address, donotreply_digitalmarketplace@gov.bc.ca.
As per KB0031744 (I won't link it here as I don't know whether it is a public document, but it has been posted in the Teams channel along with some other relevant files). More details in the ticket, or document.