### PR TITLE
Fix deploy action

### DIFF
--- a/.github/workflows/publish_deploy_image.yml
+++ b/.github/workflows/publish_deploy_image.yml
@@ -5,6 +5,7 @@ on:
     branches: [ development ]
   pull_request:
     branches: [ development ]
+    types: [ opened, synchronize, reopened, closed ]
 
 env:
   GITHUB_REGISTRY: ghcr.io

--- a/.github/workflows/publish_deploy_image.yml
+++ b/.github/workflows/publish_deploy_image.yml
@@ -15,6 +15,9 @@ env:
 
 jobs:
   build-and-push-image:
+    if: >-
+      github.event.action != 'closed' ||
+      github.event.pull_request.merged == true
     runs-on: ubuntu-18.04
     permissions:
       contents: read


### PR DESCRIPTION
This PR closes issue: [issue #]

Includes tests? N
Updated docs? N

Proposed changes:
- By default, workflows running on pull_requests run on types: opened, synchronize, reopened
- Add `closed` to allow us to use the `github.event.pull_request.merged == true` flag
- Prevent the build workflow from running when closing a PR but not merging it.

Additional notes:
-
-
-
