### PR TITLE
fix: try to prevent double building on merge

### DIFF
--- a/.github/workflows/publish_deploy_image.yml
+++ b/.github/workflows/publish_deploy_image.yml
@@ -5,7 +5,6 @@ on:
     branches: [ development ]
   pull_request:
     branches: [ development ]
-    types: [ opened, synchronize, reopened, closed ]
 
 env:
   GITHUB_REGISTRY: ghcr.io
@@ -15,9 +14,6 @@ env:
 
 jobs:
   build-and-push-image:
-    if: >-
-      github.event.action != 'closed' ||
-      github.event.pull_request.merged == true
     runs-on: ubuntu-18.04
     permissions:
       contents: read
@@ -51,7 +47,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
 
   deploy-to-openshift-development:
-    if: github.event.pull_request.merged == true
+    if: github.event_name == 'push' && github.event.push.base.ref == 'development'
     needs: [build-and-push-image]
     runs-on: ubuntu-latest
     environment:


### PR DESCRIPTION
Attempt to fix the build action running twice when a branch is merged, and have the deploy happen from the development branch rather than the branch being merged.

Ultimately the way the deployment works right now is fine, it only deploys on merge as intended, but the deploy happens from the feature branch (with the final commit) rather than from the development branch. 

If this doesn't work as I think it will then I'll simply revert the rule, and remove "push" from the rules. That way we'll build and deploy on merge, but not run the extra build.

Includes tests? N
Updated docs? N

Proposed changes:
-
-
-

Additional notes:
-
-
-
