### PR TITLE
Feat/automate release

### DIFF
--- a/.github/workflows/releases.yaml
+++ b/.github/workflows/releases.yaml
@@ -1,0 +1,22 @@
+name: Create Release
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  release-on-push:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - id: release
+        uses: rymndhng/release-on-push-action@v0.24.0
+        with:
+          bump_version_scheme: patch
+
+      - name: Check Output Parameters
+        run: |
+          echo "Tag Name ${{ steps.release.outputs.tag_name }}"
+          echo "Version ${{ steps.release.outputs.version }}"

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -1,0 +1,6 @@
+## Automatic Releases
+
+On push to master branch, a GitHub Action will trigger the creation of release artifacts, release notes as a list of commits, tag and publish a release. By default and with no GitHub labels associated with a Pull Request to master branch, a patch version will be created. To override this behaviour, add either the `release:major` label or `release:minor` label to the PR.
+
+## Reference
+[README.md](https://github.com/rymndhng/release-on-push-action)


### PR DESCRIPTION
Includes tests? [N]
Updated docs? [Y]

Proposed changes:
- automates the creation of artifacts, release notes, tagging and publishing a release

Additional notes:
- defaults to patch version bumps, unless overridden by appropriate GitHub labels 
