### PR TITLE
DM-1082: Fix how query strings are appended to URLs in front-end CRUD library

### DIFF
--- a/src/front-end/typescript/lib/http/api/affiliation.ts
+++ b/src/front-end/typescript/lib/http/api/affiliation.ts
@@ -21,8 +21,9 @@ export function readManyForOrganization(
   organizationId: Id
 ): crud.ReadManyAction<Resource.AffiliationMember, string[], unknown> {
   return crud.makeReadManyAction(
-    `${NAMESPACE}?organization=${window.encodeURIComponent(organizationId)}`,
-    (a: Resource.AffiliationMember) => a
+    NAMESPACE,
+    (a: Resource.AffiliationMember) => a,
+    `organization=${window.encodeURIComponent(organizationId)}`
   );
 }
 

--- a/src/front-end/typescript/lib/http/api/counters.ts
+++ b/src/front-end/typescript/lib/http/api/counters.ts
@@ -7,8 +7,9 @@ export function readMany<Msg>(
   counters: string[]
 ): crud.ReadManyAction<Resource.Counter, Resource.UpdateValidationErrors, Msg> {
   return crud.makeReadManyAction(
-    `${NAMESPACE}?counters=${window.encodeURIComponent(counters.join(","))}`,
-    (a: Resource.Counter) => a
+    NAMESPACE,
+    (a: Resource.Counter) => a,
+    `counters=${window.encodeURIComponent(counters.join(","))}`
   );
 }
 

--- a/src/front-end/typescript/lib/http/api/organization/index.ts
+++ b/src/front-end/typescript/lib/http/api/organization/index.ts
@@ -32,11 +32,9 @@ export function readMany<Msg>(
 ): component.Cmd<Msg> {
   return component.cmd.httpRequest({
     method: ClientHttpMethod.Get,
-    url: crud.apiNamespace(
-      `${NAMESPACE}?page=${window.encodeURIComponent(
-        page
-      )}&pageSize=${window.encodeURIComponent(pageSize)}`
-    ),
+    url: `${crud.apiNamespace(NAMESPACE)}?page=${window.encodeURIComponent(
+      page
+    )}&pageSize=${window.encodeURIComponent(pageSize)}`,
     transformResponse: (raw: RawOrganizationReadManyResponse) => {
       return {
         ...raw,

--- a/src/front-end/typescript/lib/http/api/proposal/code-with-us.ts
+++ b/src/front-end/typescript/lib/http/api/proposal/code-with-us.ts
@@ -22,12 +22,11 @@ export function readMany<Msg>(
   opportunityId?: Id
 ): crud.ReadManyAction<Resource.CWUProposalSlim, string[], Msg> {
   return crud.makeReadManyAction(
-    `${NAMESPACE}${
-      opportunityId !== undefined
-        ? `?opportunity=${window.encodeURIComponent(opportunityId)}`
-        : ""
-    }`,
-    rawCWUProposalSlimToCWUProposalSlim
+    NAMESPACE,
+    rawCWUProposalSlimToCWUProposalSlim,
+    opportunityId !== undefined
+      ? `opportunity=${window.encodeURIComponent(opportunityId)}`
+      : ""
   );
 }
 
@@ -35,8 +34,9 @@ export function readOne<Msg>(
   opportunityId: Id
 ): crud.ReadOneAction<Resource.CWUProposal, string[], Msg> {
   return crud.makeReadOneAction(
-    `${NAMESPACE}?opportunity=${window.encodeURIComponent(opportunityId)}`,
-    rawCWUProposalToCWUProposal
+    NAMESPACE,
+    rawCWUProposalToCWUProposal,
+    `opportunity=${window.encodeURIComponent(opportunityId)}`
   );
 }
 

--- a/src/front-end/typescript/lib/http/api/proposal/sprint-with-us.ts
+++ b/src/front-end/typescript/lib/http/api/proposal/sprint-with-us.ts
@@ -18,12 +18,11 @@ export function readMany<Msg>(
   opportunityId?: Id
 ): crud.ReadManyAction<Resource.SWUProposalSlim, string[], Msg> {
   return crud.makeReadManyAction(
-    `${NAMESPACE}${
-      opportunityId !== undefined
-        ? `?opportunity=${window.encodeURIComponent(opportunityId)}`
-        : ""
-    }`,
-    rawSWUProposalSlimToSWUProposalSlim
+    NAMESPACE,
+    rawSWUProposalSlimToSWUProposalSlim,
+    opportunityId !== undefined
+      ? `opportunity=${window.encodeURIComponent(opportunityId)}`
+      : ""
   );
 }
 
@@ -31,8 +30,9 @@ export function readOne<Msg>(
   opportunityId: Id
 ): crud.ReadOneAction<Resource.SWUProposal, string[], Msg> {
   return crud.makeReadOneAction(
-    `${NAMESPACE}?opportunity=${window.encodeURIComponent(opportunityId)}`,
-    rawSWUProposalToSWUProposal
+    NAMESPACE,
+    rawSWUProposalToSWUProposal,
+    `opportunity=${window.encodeURIComponent(opportunityId)}`
   );
 }
 

--- a/src/front-end/typescript/lib/http/crud.ts
+++ b/src/front-end/typescript/lib/http/crud.ts
@@ -50,12 +50,13 @@ export function makeCreateAction<
   Msg
 >(
   path: string,
-  transformResponse: (raw: RawResponse) => ValidResponse
+  transformResponse: (raw: RawResponse) => ValidResponse,
+  query?: string
 ): CreateAction<RequestBody, ValidResponse, InvalidResponse, Msg> {
   return (body, handleResponse) =>
     component.cmd.httpRequest({
       method: ClientHttpMethod.Post,
-      url: apiNamespace(path),
+      url: `${apiNamespace(path)}${makeQueryString(query)}`,
       body,
       transformResponse,
       handleResponse
@@ -167,12 +168,13 @@ function appendInvalidCreateResult<ValidItem, InvalidItem>(
 
 export function makeReadManyAction<RawItem, ValidItem, InvalidResponse, Msg>(
   path: string,
-  transformItem: (raw: RawItem) => ValidItem
+  transformItem: (raw: RawItem) => ValidItem,
+  query?: string
 ): ReadManyAction<ValidItem, InvalidResponse, Msg> {
   return (handleResponse) =>
     component.cmd.httpRequest({
       method: ClientHttpMethod.Get,
-      url: apiNamespace(path),
+      url: `${apiNamespace(path)}${makeQueryString(query)}`,
       transformResponse: (rawItems: RawItem[]) =>
         rawItems.map((item) => transformItem(item)),
       handleResponse
@@ -188,12 +190,13 @@ export function makeReadOneAction<
   Msg
 >(
   path: string,
-  transformResponse: (raw: RawResponse) => ValidResponse
+  transformResponse: (raw: RawResponse) => ValidResponse,
+  query?: string
 ): ReadOneAction<ValidResponse, InvalidResponse, Msg> {
   return (id, handleResponse) =>
     component.cmd.httpRequest({
       method: ClientHttpMethod.Get,
-      url: apiNamespace(`${path}/${id}`),
+      url: `${apiNamespace(`${path}/${id}`)}${makeQueryString(query)}`,
       transformResponse,
       handleResponse
     });
@@ -209,12 +212,13 @@ export function makeUpdateAction<
   Msg
 >(
   path: string,
-  transformResponse: (raw: RawResponse) => ValidResponse
+  transformResponse: (raw: RawResponse) => ValidResponse,
+  query?: string
 ): UpdateAction<RequestBody, ValidResponse, InvalidResponse, Msg> {
   return (id, body, handleResponse) =>
     component.cmd.httpRequest({
       method: ClientHttpMethod.Put,
-      url: apiNamespace(`${path}/${id}`),
+      url: `${apiNamespace(`${path}/${id}`)}${makeQueryString(query)}`,
       body: body,
       transformResponse,
       handleResponse
@@ -230,13 +234,20 @@ export function makeDeleteAction<
   Msg
 >(
   path: string,
-  transformResponse: (raw: RawResponse) => ValidResponse
+  transformResponse: (raw: RawResponse) => ValidResponse,
+  query?: string
 ): DeleteAction<ValidResponse, InvalidResponse, Msg> {
   return (id, handleResponse) =>
     component.cmd.httpRequest({
       method: ClientHttpMethod.Delete,
-      url: apiNamespace(`${path}/${id}`),
+      url: `${apiNamespace(`${path}/${id}`)}${makeQueryString(query)}`,
       transformResponse,
       handleResponse
     });
+}
+
+// Helpers
+
+function makeQueryString(query?: string): string {
+  return query ? `?${query}` : "";
 }

--- a/src/front-end/typescript/lib/pages/organization/edit/tab/team.tsx
+++ b/src/front-end/typescript/lib/pages/organization/edit/tab/team.tsx
@@ -172,7 +172,7 @@ const update: component_.base.Update<State, Msg> = ({ state, msg }) => {
         successToasts: [],
         warningToasts: [],
         errorToasts: []
-      } as unknown as AddTeamMemberState);
+      } as AddTeamMemberState);
       for (const s of state.addTeamMembersEmails) {
         const userEmail = FormField.getValue(s);
         cmd = component_.cmd.join(

--- a/src/front-end/typescript/lib/pages/organization/edit/tab/team.tsx
+++ b/src/front-end/typescript/lib/pages/organization/edit/tab/team.tsx
@@ -169,9 +169,9 @@ const update: component_.base.Update<State, Msg> = ({ state, msg }) => {
     case "addTeamMembers": {
       state = startAddTeamMembersLoading(state).set("showModal", null);
       let cmd = component_.cmd.dispatch({
-        success: [],
-        warning: [],
-        error: []
+        successToasts: [],
+        warningToasts: [],
+        errorToasts: []
       } as unknown as AddTeamMemberState);
       for (const s of state.addTeamMembersEmails) {
         const userEmail = FormField.getValue(s);

--- a/src/front-end/typescript/lib/pages/proposal/sprint-with-us/create.tsx
+++ b/src/front-end/typescript/lib/pages/proposal/sprint-with-us/create.tsx
@@ -478,7 +478,7 @@ export const component: component_.page.Component<
         symbol_: leftPlacement(iconLinkSymbol("paper-plane")),
         button: true,
         loading: isSubmitLoading,
-        disabled: isLoading || isValid,
+        disabled: isLoading || !isValid,
         color: "primary",
         onClick: () => dispatch(adt("showModal", "submit" as const))
       },
@@ -508,7 +508,7 @@ export const component: component_.page.Component<
       Form.getModal(form),
       (msg) => adt("form", msg) as Msg
     );
-    if (formModal !== null) {
+    if (formModal.tag !== "hide") {
       return formModal;
     }
     const hasAcceptedTerms =

--- a/src/front-end/typescript/lib/pages/proposal/sprint-with-us/edit/index.tsx
+++ b/src/front-end/typescript/lib/pages/proposal/sprint-with-us/edit/index.tsx
@@ -40,7 +40,7 @@ export type State = State_<Tab.TabId>;
 
 export type InnerMsg_<K extends Tab.TabId> = Tab.ParentInnerMsg<
   K,
-  ADT<"onInitResponse", [User, RouteParams, SWUOpportunity, SWUProposal]>
+  ADT<"onInitResponse", [User, RouteParams, SWUProposal, SWUOpportunity]>
 >;
 
 export type InnerMsg = InnerMsg_<Tab.TabId>;
@@ -79,7 +79,7 @@ function makeInit<K extends Tab.TabId>(): component_.page.Init<
             api.proposals.swu.readOne(opportunityId)(proposalId, (response) =>
               api.isValid(response) ? response.value : null
             ) as component_.Cmd<SWUProposal | null>,
-            api.proposals.swu.readOne(opportunityId)(proposalId, (response) =>
+            api.opportunities.swu.readOne(opportunityId, (response) =>
               api.isValid(response) ? response.value : null
             ) as component_.Cmd<SWUOpportunity | null>,
             (proposal, opportunity) => {
@@ -147,7 +147,7 @@ function makeComponent<K extends Tab.TabId>(): component_.page.Component<
         extraUpdate: ({ state, msg }) => {
           switch (msg.tag) {
             case "onInitResponse": {
-              const [viewerUser, routeParams, opportunity, proposal] =
+              const [viewerUser, routeParams, proposal, opportunity] =
                 msg.value;
               // Set up the visible tab state.
               const tabId = routeParams.tab || "proposal";

--- a/src/front-end/typescript/lib/pages/proposal/sprint-with-us/edit/tab/proposal.tsx
+++ b/src/front-end/typescript/lib/pages/proposal/sprint-with-us/edit/tab/proposal.tsx
@@ -732,12 +732,13 @@ export const component: Tab.Component<State, Msg> = {
       Form.getModal(state.form),
       (msg) => adt("form", msg) as Msg
     );
-    if (formModal !== null) {
+    if (formModal !== null && formModal.tag !== "hide") {
       return formModal;
     }
     const hasAcceptedTerms =
       SubmitProposalTerms.getProposalCheckbox(state.submitTerms) &&
       SubmitProposalTerms.getAppCheckbox(state.submitTerms);
+
     switch (state.showModal) {
       case "submit":
       case "saveChangesAndSubmit":

--- a/src/front-end/typescript/lib/pages/proposal/sprint-with-us/edit/tab/proposal.tsx
+++ b/src/front-end/typescript/lib/pages/proposal/sprint-with-us/edit/tab/proposal.tsx
@@ -732,7 +732,7 @@ export const component: Tab.Component<State, Msg> = {
       Form.getModal(state.form),
       (msg) => adt("form", msg) as Msg
     );
-    if (formModal !== null && formModal.tag !== "hide") {
+    if (formModal.tag !== "hide") {
       return formModal;
     }
     const hasAcceptedTerms =

--- a/src/front-end/typescript/lib/pages/proposal/sprint-with-us/lib/components/form.tsx
+++ b/src/front-end/typescript/lib/pages/proposal/sprint-with-us/lib/components/form.tsx
@@ -1453,7 +1453,7 @@ export const getModal: component_.page.GetModal<State, Msg> = (state) => {
     Team.getModal(state.team),
     (msg) => adt("team", msg) as Msg
   );
-  if (teamModal) {
+  if (teamModal && teamModal.tag === "show") {
     return teamModal;
   }
   if (!state.showModal) {

--- a/src/front-end/typescript/lib/pages/proposal/sprint-with-us/lib/components/team.tsx
+++ b/src/front-end/typescript/lib/pages/proposal/sprint-with-us/lib/components/team.tsx
@@ -299,5 +299,11 @@ export const getModal: component_.page.GetModal<State, Msg> = (state) => {
       Phase.getModal(state.implementationPhase),
       (msg) => adt("implementationPhase", msg) as Msg
     );
-  return inceptionModal() || prototypeModal() || implementationModal();
+
+  const activeModal = [
+    inceptionModal(),
+    prototypeModal(),
+    implementationModal()
+  ].filter((modal) => modal && modal.tag === "show");
+  return activeModal[0] ?? implementationModal();
 };

--- a/src/front-end/typescript/lib/pages/proposal/sprint-with-us/view/tab/proposal.tsx
+++ b/src/front-end/typescript/lib/pages/proposal/sprint-with-us/view/tab/proposal.tsx
@@ -392,7 +392,7 @@ export const component: Tab.Component<State, Msg> = {
       Form.getModal(form),
       (msg) => adt("form", msg) as Msg
     );
-    if (formModal !== null) {
+    if (formModal.tag !== "hide") {
       return formModal;
     }
     const isDisqualifyLoading = state.disqualifyLoading > 0;


### PR DESCRIPTION
This PR closes issue: DM-1082

Includes tests? N
Updated docs? N

Proposed changes:
- The query string was being inserted to certain URLs in the middle of the path. This PR supports an optional `query` argument for the `make*Action` helper functions to ensure query strings are appended to the end of URLs.
- All relevant front-end HTTP modules have been fixed to use the new `query` parameter.

Additional notes:
- This bug was discovered by @IanFonzie when smoke testing the front-end.