### PR TITLE
Dm1091 regression fixes

### DIFF
--- a/src/front-end/typescript/lib/pages/opportunity/sprint-with-us/edit/index.tsx
+++ b/src/front-end/typescript/lib/pages/opportunity/sprint-with-us/edit/index.tsx
@@ -72,7 +72,7 @@ function makeInit<K extends Tab.TabId>(): component_.page.Init<
   return isUserType({
     userType: [UserType.Government, UserType.Admin],
     success({ routePath, routeParams, shared }) {
-      const tabId = routeParams.tab || "summary";
+      const tabId = routeParams.tab ?? "summary";
       const [sidebarState, sidebarCmds] = Tab.makeSidebarState(tabId);
       const tabComponent = Tab.idToDefinition(tabId).component;
       const [tabState, tabCmds] = tabComponent.init({
@@ -97,7 +97,7 @@ function makeInit<K extends Tab.TabId>(): component_.page.Init<
               routeParams.opportunityId,
               (response) => response
             ),
-            tabId === "proposals"
+            (["proposals", "teamQuestions", "codeChallenge", "teamScenario"] as Tab.TabId[]).includes(tabId)
               ? api.proposals.swu.readMany(routeParams.opportunityId)(
                   (response) => response
                 )

--- a/src/front-end/typescript/lib/pages/opportunity/sprint-with-us/edit/index.tsx
+++ b/src/front-end/typescript/lib/pages/opportunity/sprint-with-us/edit/index.tsx
@@ -97,7 +97,7 @@ function makeInit<K extends Tab.TabId>(): component_.page.Init<
               routeParams.opportunityId,
               (response) => response
             ),
-            (["proposals", "teamQuestions", "codeChallenge", "teamScenario"] as Tab.TabId[]).includes(tabId)
+            Tab.shouldLoadProposalsForTab(tabId)
               ? api.proposals.swu.readMany(routeParams.opportunityId)(
                   (response) => response
                 )

--- a/src/front-end/typescript/lib/pages/opportunity/sprint-with-us/edit/tab/index.ts
+++ b/src/front-end/typescript/lib/pages/opportunity/sprint-with-us/edit/tab/index.ts
@@ -226,3 +226,8 @@ export function makeSidebarState(
       : []
   });
 }
+
+export function shouldLoadProposalsForTab(tabId: TabId): boolean {
+  const proposalTabs: TabId[] = ["proposals", "teamQuestions", "codeChallenge", "teamScenario"];
+  return proposalTabs.includes(tabId)
+}

--- a/src/front-end/typescript/lib/pages/proposal/sprint-with-us/view/index.tsx
+++ b/src/front-end/typescript/lib/pages/proposal/sprint-with-us/view/index.tsx
@@ -40,7 +40,7 @@ export type State = State_<Tab.TabId>;
 
 export type InnerMsg_<K extends Tab.TabId> = Tab.ParentInnerMsg<
   K,
-  ADT<"onInitResponse", [User, RouteParams, SWUOpportunity, SWUProposal]>
+  ADT<"onInitResponse", [User, RouteParams, SWUProposal, SWUOpportunity]>
 >;
 
 export type InnerMsg = InnerMsg_<Tab.TabId>;
@@ -79,7 +79,7 @@ function makeInit<K extends Tab.TabId>(): component_.page.Init<
             api.proposals.swu.readOne(opportunityId)(proposalId, (response) =>
               api.isValid(response) ? response.value : null
             ) as component_.Cmd<SWUProposal | null>,
-            api.proposals.swu.readOne(opportunityId)(proposalId, (response) =>
+            api.opportunities.swu.readOne(opportunityId, (response) =>
               api.isValid(response) ? response.value : null
             ) as component_.Cmd<SWUOpportunity | null>,
             (proposal, opportunity) => {
@@ -139,7 +139,7 @@ function makeComponent<K extends Tab.TabId>(): component_.page.Component<
         extraUpdate: ({ state, msg }) => {
           switch (msg.tag) {
             case "onInitResponse": {
-              const [viewerUser, routeParams, opportunity, proposal] =
+              const [viewerUser, routeParams, proposal, opportunity] =
                 msg.value;
               // Set up the visible tab state.
               const tabId = routeParams.tab || "proposal";

--- a/src/front-end/typescript/lib/pages/user/profile/tab/profile.tsx
+++ b/src/front-end/typescript/lib/pages/user/profile/tab/profile.tsx
@@ -321,7 +321,8 @@ const update: component_.base.Update<State, Msg> = ({ state, msg }) => {
                   "updateAdminPermissions",
                   FormField.getValue(state.adminCheckbox)
                 ),
-                (response) => adt("onToggleAdmin", api.isValid(response))
+                (response) =>
+                  adt("onToggleAdmin", api.getValidValue(response, null))
               ) as component_.Cmd<Msg>
             ]
           ];


### PR DESCRIPTION
This PR closes issue: [DM-1090] [DM-1091][DM-1092]

Proposed changes:
- Fix regression where a submitted proposal was not viewable by the admin user [DM-1090]
- Fix regression where the user profile admin view was incomplete after toggling the admin checkbox [DM-1091]
- Fix regression where proposals are not fetched for team questions, code challenge, and team scenario phases of evaluation

