### PR TITLE
Dm1100 regression fixes

### DIFF
--- a/src/front-end/typescript/lib/pages/proposal/code-with-us/edit/index.tsx
+++ b/src/front-end/typescript/lib/pages/proposal/code-with-us/edit/index.tsx
@@ -92,7 +92,7 @@ function makeInit<K extends Tab.TabId>(): component_.page.Init<
           immutable({
             proposal: null,
             tab: [tabId, immutable(tabState)],
-            sidebar: sidebarState
+            sidebar: immutable(sidebarState)
           })
         ) as State_<K>,
         [

--- a/src/front-end/typescript/lib/pages/proposal/code-with-us/edit/index.tsx
+++ b/src/front-end/typescript/lib/pages/proposal/code-with-us/edit/index.tsx
@@ -185,21 +185,10 @@ function makeComponent<K extends Tab.TabId>(): component_.page.Component<
               const proposal = proposalResponse.value;
               const opportunity = opportunityResponse.value;
               const affiliations = affiliationsResponse.value;
-              const [sidebarState, sidebarCmds] = Tab.makeSidebarState(
-                tabId,
-                proposal.id,
-                opportunity.id
-              );
               const tabComponent = Tab.idToDefinition(tabId).component;
               return [
-                state
-                  .set("proposal", proposal)
-                  .set("sidebar", immutable(sidebarState)),
+                state.set("proposal", proposal),
                 [
-                  ...component_.cmd.mapMany(
-                    sidebarCmds,
-                    (msg) => adt("sidebar", msg) as Msg
-                  ),
                   component_.cmd.dispatch(
                     component_.page.mapMsg(
                       tabComponent.onInitResponse([

--- a/src/front-end/typescript/lib/pages/proposal/code-with-us/edit/index.tsx
+++ b/src/front-end/typescript/lib/pages/proposal/code-with-us/edit/index.tsx
@@ -185,10 +185,21 @@ function makeComponent<K extends Tab.TabId>(): component_.page.Component<
               const proposal = proposalResponse.value;
               const opportunity = opportunityResponse.value;
               const affiliations = affiliationsResponse.value;
+              const [sidebarState, sidebarCmds] = Tab.makeSidebarState(
+                tabId,
+                proposal.id,
+                opportunity.id
+              );
               const tabComponent = Tab.idToDefinition(tabId).component;
               return [
-                state.set("proposal", proposal),
+                state
+                  .set("proposal", proposal)
+                  .set("sidebar", immutable(sidebarState)),
                 [
+                  ...component_.cmd.mapMany(
+                    sidebarCmds,
+                    (msg) => adt("sidebar", msg) as Msg
+                  ),
                   component_.cmd.dispatch(
                     component_.page.mapMsg(
                       tabComponent.onInitResponse([

--- a/src/front-end/typescript/lib/pages/proposal/code-with-us/edit/index.tsx
+++ b/src/front-end/typescript/lib/pages/proposal/code-with-us/edit/index.tsx
@@ -106,8 +106,8 @@ function makeInit<K extends Tab.TabId>(): component_.page.Init<
               proposalId,
               (response) => response
             ),
-            api.proposals.cwu.readOne(opportunityId)(
-              proposalId,
+            api.opportunities.cwu.readOne(
+              opportunityId,
               (response) => response
             ),
             api.affiliations.readMany((response) => response),

--- a/src/front-end/typescript/lib/pages/proposal/code-with-us/view/index.tsx
+++ b/src/front-end/typescript/lib/pages/proposal/code-with-us/view/index.tsx
@@ -111,8 +111,8 @@ function makeInit<K extends Tab.TabId>(): component_.page.Init<
               proposalId,
               (response) => response
             ),
-            api.proposals.cwu.readOne(opportunityId)(
-              proposalId,
+            api.opportunities.cwu.readOne(
+              opportunityId,
               (response) => response
             ),
             (proposalResponse, opportunityResponse) =>

--- a/src/front-end/typescript/lib/pages/proposal/code-with-us/view/index.tsx
+++ b/src/front-end/typescript/lib/pages/proposal/code-with-us/view/index.tsx
@@ -97,7 +97,7 @@ function makeInit<K extends Tab.TabId>(): component_.page.Init<
           immutable({
             proposal: null,
             tab: [tabId, immutable(tabState)],
-            sidebar: sidebarState
+            sidebar: immutable(sidebarState)
           })
         ) as Valid<Immutable<ValidState<keyof Tab.Tabs>>>,
         [


### PR DESCRIPTION
This PR closes issue: DM-1099, DM-1100

Includes tests? N
Updated docs? N

Proposed changes:
- Fetch Proposals and Opportunities on the proposal editing page; fetched two instances of a proposal before.
- Set sidebar state to immutable on the editing page.

Additional notes:
- Regressions found in the big refactor