### PR TITLE
dm1103: fix incorrect button text when a proposal has already been submitted

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,5 +1,5 @@
 {
-  "version": "1.3.0",
+  "version": "1.4.0",
   "plugins_used": [
     {
       "name": "ArtifactoryDetector"

--- a/src/front-end/typescript/lib/pages/opportunity/code-with-us/view.tsx
+++ b/src/front-end/typescript/lib/pages/opportunity/code-with-us/view.tsx
@@ -37,7 +37,6 @@ import {
 import { CWUProposalSlim } from "shared/lib/resources/proposal/code-with-us";
 import { isVendor, User, UserType } from "shared/lib/resources/user";
 import { adt, ADT, Id } from "shared/lib/types";
-import { valid } from "shared/lib/validation";
 
 type InfoTab = "details" | "attachments" | "addenda";
 
@@ -57,7 +56,7 @@ export type InnerMsg =
       [
         string,
         api.ResponseValidation<CWUOpportunity, string[]>,
-        api.ResponseValidation<CWUProposalSlim, string[]> | null
+        CWUProposalSlim | null
       ]
     >
   | ADT<"toggleWatch">
@@ -99,7 +98,7 @@ const init: component_.page.Init<
         viewerUser && isVendor(viewerUser)
           ? api.proposals.cwu.readExistingProposalForOpportunity(
               opportunityId,
-              (response) => valid(response)
+              (response) => response
             )
           : component_.cmd.dispatch(null),
         (opportunityResponse, proposalResponse) =>
@@ -137,8 +136,8 @@ const update: component_.page.Update<State, InnerMsg, Route> = ({
       } else {
         state = state.set("opportunity", opportunityResponse.value);
       }
-      if (proposalResponse && api.isValid(proposalResponse)) {
-        state = state.set("existingProposal", proposalResponse.value);
+      if (proposalResponse) {
+        state = state.set("existingProposal", proposalResponse);
       }
       return [state, [component_.cmd.dispatch(component_.page.readyMsg())]];
     }

--- a/src/front-end/typescript/lib/pages/opportunity/code-with-us/view.tsx
+++ b/src/front-end/typescript/lib/pages/opportunity/code-with-us/view.tsx
@@ -37,6 +37,7 @@ import {
 import { CWUProposalSlim } from "shared/lib/resources/proposal/code-with-us";
 import { isVendor, User, UserType } from "shared/lib/resources/user";
 import { adt, ADT, Id } from "shared/lib/types";
+import { valid } from "shared/lib/validation";
 
 type InfoTab = "details" | "attachments" | "addenda";
 
@@ -98,7 +99,7 @@ const init: component_.page.Init<
         viewerUser && isVendor(viewerUser)
           ? api.proposals.cwu.readExistingProposalForOpportunity(
               opportunityId,
-              (response) => response
+              (response) => valid(response)
             )
           : component_.cmd.dispatch(null),
         (opportunityResponse, proposalResponse) =>

--- a/src/front-end/typescript/lib/pages/opportunity/sprint-with-us/view.tsx
+++ b/src/front-end/typescript/lib/pages/opportunity/sprint-with-us/view.tsx
@@ -78,7 +78,7 @@ type InnerMsg =
       [
         string,
         api.ResponseValidation<SWUOpportunity, string[]>,
-        api.ResponseValidation<SWUProposalSlim, string[]> | null,
+        SWUProposalSlim | null,
         api.ResponseValidation<Content, string[]>,
         boolean
       ]
@@ -137,7 +137,7 @@ const init: component_.page.Init<
         viewerUser && isVendor(viewerUser)
           ? api.proposals.swu.readExistingProposalForOpportunity(
               opportunityId,
-              (response) => valid(response)
+              (response) => response
             )
           : component_.cmd.dispatch(null),
 
@@ -196,8 +196,8 @@ const update: component_.page.Update<State, InnerMsg, Route> = updateValid(
         } else {
           state = state.set("opportunity", opportunityResponse.value);
         }
-        if (proposalResponse && api.isValid(proposalResponse)) {
-          state = state.set("existingProposal", proposalResponse.value);
+        if (proposalResponse) {
+          state = state.set("existingProposal", proposalResponse);
         }
         if (contentResponse && api.isValid(contentResponse)) {
           state = state.set("scopeContent", contentResponse.value.body);

--- a/src/front-end/typescript/lib/pages/opportunity/sprint-with-us/view.tsx
+++ b/src/front-end/typescript/lib/pages/opportunity/sprint-with-us/view.tsx
@@ -137,7 +137,7 @@ const init: component_.page.Init<
         viewerUser && isVendor(viewerUser)
           ? api.proposals.swu.readExistingProposalForOpportunity(
               opportunityId,
-              (response) => response
+              (response) => valid(response)
             )
           : component_.cmd.dispatch(null),
 

--- a/src/front-end/typescript/lib/pages/proposal/sprint-with-us/edit/tab/proposal.tsx
+++ b/src/front-end/typescript/lib/pages/proposal/sprint-with-us/edit/tab/proposal.tsx
@@ -214,6 +214,7 @@ const update: component_.base.Update<State, Msg> = ({ state, msg }) => {
       const [formState, formCmds] = Form.init({
         viewerUser: state.viewerUser,
         opportunity: state.opportunity,
+        proposal: state.proposal,
         organizations,
         evaluationContent
       });


### PR DESCRIPTION
This PR closes issue: [DM-1103]

Proposed changes:
- The http crud api was intending to return a `ResponseValidation` wrapping a `CWUOpportunityProposal`, but it was actually just returning the unwrapped proposal object. This was the root cause of the failed `isValid` check when determining whether an existing proposal was present or not.
- The fix was to ensure the http crud api wrapped the proposal object in a `ResponseValidation`. Validation was already being performed by the `readMany` crud action

