### PR TITLE
fix: provide onToggleAccountActivationResponse adt with value or null

### DIFF
--- a/src/front-end/typescript/lib/pages/user/profile/tab/profile.tsx
+++ b/src/front-end/typescript/lib/pages/user/profile/tab/profile.tsx
@@ -241,7 +241,7 @@ const update: component_.base.Update<State, Msg> = ({ state, msg }) => {
                 (response) =>
                   adt(
                     "onToggleAccountActivationResponse",
-                    api.isValid(response)
+                    api.isValid(response) ? response.value : null
                   )
               ) as component_.Cmd<Msg>)
         ]


### PR DESCRIPTION
This PR closes issue: [DM-1105]

Includes tests? N
Updated docs? N

Proposed changes:
- Provides the response value or null instead of a boolean when reactivating a user

Additional notes:

I have some concerns with using type assertions since we're relying so heavily on our typing system. Here's an example I found while fixing this issue:
- With annotations and the incorrect type: <img width="519" alt="Screen Shot 2022-12-16 at 4 40 30 PM" src="https://user-images.githubusercontent.com/11410926/208214659-1800f71e-8fed-42d6-bb9f-933f45c606c1.png">
- With annotations and the correct type: <img width="608" alt="Screen Shot 2022-12-16 at 4 46 59 PM" src="https://user-images.githubusercontent.com/11410926/208214691-67576954-7ac4-4660-bdef-1ddb607db641.png">
- With assertions (compiler doesn't complain): <img width="534" alt="Screen Shot 2022-12-16 at 4 59 22 PM" src="https://user-images.githubusercontent.com/11410926/208214784-45a3783c-da78-4856-9f1a-013034c3b3ea.png">

As far as I'm aware, assertions should be used when we're positive that the type is what we're telling the compiler it is whereas annotations will perform an actual check. The assertions feel like they're defeating the point of the type system.
