### PR TITLE
Dm1083 unsubscribe footer

### DIFF
--- a/src/back-end/lib/mailer/templates.tsx
+++ b/src/back-end/lib/mailer/templates.tsx
@@ -2,6 +2,7 @@ import { prefixPath } from "back-end/lib";
 import { CSSProperties, default as React, Fragment, ReactElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { SHOW_TEST_INDICATOR } from "shared/config";
+import { VIEWER_USER_ROUTE_PARAM } from "shared/lib/resources/user";
 
 // Styles.
 
@@ -406,6 +407,12 @@ const Layout: View<LayoutProps> = ({ title, description, children }) => {
             <Row style={styles.classes.description}>{description}</Row>
           ) : null}
           <Fragment>{children}</Fragment>
+          <Row style={{ ...styles.utilities.text.center }} >
+            <Link 
+              text="Unsubscribe"
+              url={makeUrl(`users/${VIEWER_USER_ROUTE_PARAM}?tab=notifications&unsubscribe`)}
+            />
+          </Row>
         </Container>
       </body>
     </html>

--- a/src/back-end/lib/routers/auth.ts
+++ b/src/back-end/lib/routers/auth.ts
@@ -86,7 +86,7 @@ async function makeRouter(
 
           // If redirectOnSuccess specified, include that as query parameter for callback
           if (redirectOnSuccess) {
-            authQuery.redirect_uri += `?redirectOnSuccess=${redirectOnSuccess}`;
+            authQuery.redirect_uri += `?redirectOnSuccess=${encodeURIComponent(redirectOnSuccess)}`;
           }
 
           if (provider === VENDOR_IDP_SUFFIX || provider === GOV_IDP_SUFFIX) {
@@ -136,7 +136,7 @@ async function makeRouter(
 
           // If redirectOnSuccess was provided on callback, this must also be provided on token request (redirect_uri must match for each request)
           if (redirectOnSuccess) {
-            data.redirect_uri += `?redirectOnSuccess=${redirectOnSuccess}`;
+            data.redirect_uri += `?redirectOnSuccess=${encodeURIComponent(redirectOnSuccess)}`;
           }
 
           const headers = {

--- a/src/front-end/typescript/lib/app/router.ts
+++ b/src/front-end/typescript/lib/app/router.ts
@@ -307,7 +307,6 @@ const router: router_.Router<Route> = {
           UserProfileTab.parseInvitationResponseParam(
             getString(query, "invitationResponse")
           ) || undefined;
-        const unsubscribe = "unsubscribe" in query;
         return {
           tag: "userProfile",
           value: {
@@ -317,7 +316,7 @@ const router: router_.Router<Route> = {
               affiliationId && response
                 ? { affiliationId, response }
                 : undefined,
-            unsubscribe
+            ...('unsubscribe' in query && {unsubscribe: true})
           }
         };
       }

--- a/src/front-end/typescript/lib/app/router.ts
+++ b/src/front-end/typescript/lib/app/router.ts
@@ -307,6 +307,7 @@ const router: router_.Router<Route> = {
           UserProfileTab.parseInvitationResponseParam(
             getString(query, "invitationResponse")
           ) || undefined;
+        const unsubscribe = "unsubscribe" in query;
         return {
           tag: "userProfile",
           value: {
@@ -315,7 +316,8 @@ const router: router_.Router<Route> = {
             invitation:
               affiliationId && response
                 ? { affiliationId, response }
-                : undefined
+                : undefined,
+            unsubscribe
           }
         };
       }
@@ -512,6 +514,9 @@ const router: router_.Router<Route> = {
             `invitationAffiliationId=${route.value.invitation.affiliationId}`
           );
           query.push(`invitationResponse=${route.value.invitation.response}`);
+        }
+        if (route.value.unsubscribe) {
+          query.push("unsubscribe")
         }
         let qs = "";
         if (query.length) {

--- a/src/front-end/typescript/lib/pages/user/profile/index.tsx
+++ b/src/front-end/typescript/lib/pages/user/profile/index.tsx
@@ -22,6 +22,7 @@ import {
   isAdmin,
   isPublicSectorEmployee,
   isVendor,
+  VIEWER_USER_ROUTE_PARAM,
   User
 } from "shared/lib/resources/user";
 import { adt, ADT, Id } from "shared/lib/types";
@@ -75,7 +76,10 @@ function makeInit<K extends Tab.TabId>(): component_.page.Init<
           })
         ) as State_<K>,
         [
-          api.users.readOne(routeParams.userId, (response) =>
+          api.users.readOne(routeParams.userId === VIEWER_USER_ROUTE_PARAM
+            ? viewerUser.id
+            : routeParams.userId,
+          (response) =>
             adt("onInitResponse", [routePath, routeParams, response])
           ) as component_.Cmd<Msg>
         ]

--- a/src/front-end/typescript/lib/pages/user/profile/index.tsx
+++ b/src/front-end/typescript/lib/pages/user/profile/index.tsx
@@ -50,7 +50,7 @@ export type Msg_<K extends Tab.TabId> = Tab.ParentMsg<K, InnerMsg>;
 
 export type Msg = Msg_<Tab.TabId>;
 
-export interface RouteParams extends Pick<Tab.Params, "invitation"> {
+export interface RouteParams extends Pick<Tab.Params, "invitation" | "unsubscribe"> {
   userId: Id;
   tab?: Tab.TabId;
 }
@@ -183,7 +183,8 @@ function makeComponent<K extends Tab.TabId>(): component_.page.Component<
               const [tabState, tabCmds] = tabComponent.init({
                 profileUser,
                 viewerUser: state.viewerUser,
-                invitation: routeParams.invitation
+                invitation: routeParams.invitation,
+                unsubscribe: routeParams.unsubscribe
               });
               // Everything checks out, return valid state.
               return [

--- a/src/front-end/typescript/lib/pages/user/profile/index.tsx
+++ b/src/front-end/typescript/lib/pages/user/profile/index.tsx
@@ -91,7 +91,7 @@ function makeInit<K extends Tab.TabId>(): component_.page.Init<
                 component_.global.replaceRouteMsg(
                   adt("signIn" as const, {
                     redirectOnSuccess: router.routeToUrl(
-                      adt("userProfile", { userId: routeParams.userId })
+                      adt("userProfile", routeParams)
                     )
                   })
                 )

--- a/src/front-end/typescript/lib/pages/user/profile/tab/index.ts
+++ b/src/front-end/typescript/lib/pages/user/profile/tab/index.ts
@@ -48,7 +48,7 @@ export interface Params {
     affiliationId: Id;
     response: InvitationResponseParam;
   };
-  unsubscribe?: boolean;
+  unsubscribe?: true;
 }
 
 export type InitResponse = null;

--- a/src/front-end/typescript/lib/pages/user/profile/tab/index.ts
+++ b/src/front-end/typescript/lib/pages/user/profile/tab/index.ts
@@ -48,6 +48,7 @@ export interface Params {
     affiliationId: Id;
     response: InvitationResponseParam;
   };
+  unsubscribe?: boolean;
 }
 
 export type InitResponse = null;

--- a/src/front-end/typescript/lib/pages/user/profile/tab/notifications.tsx
+++ b/src/front-end/typescript/lib/pages/user/profile/tab/notifications.tsx
@@ -31,7 +31,8 @@ export type Msg = component_.page.Msg<InnerMsg, Route>;
 
 const init: component_.base.Init<Tab.Params, State, Msg> = ({
   viewerUser,
-  profileUser
+  profileUser,
+  unsubscribe
 }) => {
   const [newOpportunitiesState, newOpportunitiesCmds] = Checkbox.init({
     errors: [],

--- a/src/front-end/typescript/lib/pages/user/profile/tab/notifications.tsx
+++ b/src/front-end/typescript/lib/pages/user/profile/tab/notifications.tsx
@@ -198,7 +198,7 @@ export const component: Tab.Component<State, Msg> = {
         return component_.page.modal.show({
           title: "Unsubscribe?",
           body: () =>
-            "Are you sure you want to unsubscribe? You will no longer receive notifications about new opportunities.",
+            `Are you sure you want to unsubscribe? ${state.profileUser.email ?? 'You'} will no longer receive notifications about new opportunities.`,
           onCloseMsg: adt("hideModal") as Msg,
           actions: [
             {

--- a/src/shared/lib/resources/user.ts
+++ b/src/shared/lib/resources/user.ts
@@ -3,6 +3,8 @@ import { FileRecord } from "shared/lib/resources/file";
 import { ADT, BodyWithErrors, Id } from "shared/lib/types";
 import { ErrorTypeFrom } from "shared/lib/validation";
 
+export const VIEWER_USER_ROUTE_PARAM = "me";
+
 export type KeyCloakIdentityProvider = string;
 
 export enum UserType {


### PR DESCRIPTION
This PR closes issue: [DM-1083]

Includes tests? [N]
Updated docs? [N]

Proposed changes:
- Redirect to viewer user profile when userId route param is "me"
- Add unsubcribe URL to email layout
- Add modal to unsubscribe users when unsubscribe query param is present on the notifications tab