### PR TITLE
chore: update memory limits to handle spiky workloads

### DIFF
--- a/openshift/templates/app/app-digmkt-deploy.yaml
+++ b/openshift/templates/app/app-digmkt-deploy.yaml
@@ -261,7 +261,7 @@ parameters:
 - name: MEMORY_LIMIT
   displayName: Resources Memory Limit
   required: true
-  value: 240Mi
+  value: 360Mi
 
 - name: REPLICAS
   displayName: The number of replicas to run

--- a/openshift/templates/database/patroni-digmkt-deploy.yaml
+++ b/openshift/templates/database/patroni-digmkt-deploy.yaml
@@ -239,12 +239,12 @@ parameters:
 - description: Starting amount of memory the container can use.
   displayName: Memory Request
   name: MEMORY_REQUEST
-  value: 200Mi
+  value: 220Mi
 
 - description: Maximum amount of memory the container can use.
   displayName: Memory Limit
   name: MEMORY_LIMIT
-  value: 400Mi
+  value: 660Mi
 
 - description: The OpenShift Namespace where the patroni and postgresql ImageStream
     resides.


### PR DESCRIPTION
Proposed changes:
- database migrations create spikes in memory utilization that can't be handled by the current limit, which is double the requests. This moves the limit to triple the requests which is within [community guidelines](https://docs.developer.gov.bc.ca/application-resource-tuning/) and will afford us the ability to perform DB migrations without needing to manually adjust the memory limits. 
