### PR TITLE
fix: ocp v4.11 requires scc workaround

### DIFF
--- a/openshift/templates/database/patroni-digmkt-deploy.yaml
+++ b/openshift/templates/database/patroni-digmkt-deploy.yaml
@@ -146,6 +146,8 @@ objects:
           imagePullPolicy: Always
           imagePullSecrets: artifacts-default-rbehd
           name: postgresql
+          securityContext:
+            allowPrivilegeEscalation: true
           ports:
           - containerPort: 8008
             protocol: TCP


### PR DESCRIPTION
This PR closes issue: [issue DM-1129]

Includes tests? [N]
Updated docs? [N]

Proposed changes:
- config change required for upgrade from 4.10 to 4.11

Additional notes:
- known issue: https://docs.openshift.com/container-platform/4.11/security/seccomp-profiles.html#upgraded_cluster_configuring-seccomp-profiles

