### PR TITLE
fix: service area selected option displays on view draft

### DIFF
--- a/src/front-end/typescript/lib/components/form-field/lib/select.tsx
+++ b/src/front-end/typescript/lib/components/form-field/lib/select.tsx
@@ -38,9 +38,11 @@ export function stringsToOptions(values: string[]): ADT<"options", Option[]> {
 /**
  * Converts an object with strings for both keys and values into the format
  * needed for a select list. For example, labels and values.
+ * For label/key it converts `CamelCase` words to something
+ * more readable, i.e. `Camel Case`.
  *
- * @param values
- * @returns adt
+ * @param values - key/value object
+ * @returns adt - options for a select list
  */
 export function objectToOptions(
   values: Record<string, string>

--- a/src/front-end/typescript/lib/pages/opportunity/team-with-us/lib/components/form.tsx
+++ b/src/front-end/typescript/lib/pages/opportunity/team-with-us/lib/components/form.tsx
@@ -17,7 +17,7 @@ import {
 } from "front-end/lib/framework";
 import * as api from "front-end/lib/http/api";
 import * as ResourceQuestions from "front-end/lib/pages/opportunity/team-with-us/lib/components/resource-questions";
-import { flatten } from "lodash";
+import { camelCase, flatten, startCase } from "lodash";
 import React from "react";
 import { Col, Row } from "reactstrap";
 import { arrayFromRange, getNumber } from "shared/lib";
@@ -148,7 +148,24 @@ function resetAssignmentDate(state: Immutable<State>): Immutable<State> {
     );
   });
 }
+/**
+ * Local helper function to obtain and modify the key of
+ * (enum) TWUServiceArea if given the value.
+ *
+ * @see {@link TWUServiceAreas}
+ *
+ * @param v - a value from the key/value pair of TWUServiceArea
+ * @returns - a single label/vale pair for a select list
+ */
+function getSingleKeyValueOption(v: TWUServiceAreas): Select.Option {
+  const keyIndex = Object.values(TWUServiceAreas).indexOf(v as TWUServiceAreas);
+  const k = Object.keys(TWUServiceAreas)[keyIndex];
 
+  return {
+    label: startCase(camelCase(k)),
+    value: String(v)
+  };
+}
 /**
  * Initializes components on the page
  */
@@ -179,12 +196,20 @@ export const init: component_.base.Init<Params, State, Msg> = ({
         value: String(opportunity.targetAllocation)
       }
     : null;
-  const serviceArea = opportunity?.serviceArea
-    ? {
-        label: opportunity.serviceArea,
-        value: opportunity.serviceArea
-      }
-    : null;
+
+  /**
+   * Sets a single key/value pair for service area, or null
+   *
+   * @see {@link getSingleKeyValueOption}
+   */
+  const serviceArea: Select.Option | null = (() => {
+    const v = opportunity?.serviceArea ? opportunity.serviceArea : null;
+    if (!v) {
+      return null;
+    }
+    return getSingleKeyValueOption(v as TWUServiceAreas);
+  })();
+
   const [tabbedFormState, tabbedFormCmds] = TabbedFormComponent.init({
     tabs: [
       "Overview",

--- a/src/front-end/typescript/lib/pages/opportunity/team-with-us/lib/components/form.tsx
+++ b/src/front-end/typescript/lib/pages/opportunity/team-with-us/lib/components/form.tsx
@@ -17,7 +17,7 @@ import {
 } from "front-end/lib/framework";
 import * as api from "front-end/lib/http/api";
 import * as ResourceQuestions from "front-end/lib/pages/opportunity/team-with-us/lib/components/resource-questions";
-import { camelCase, flatten, startCase } from "lodash";
+import { flatten, startCase } from "lodash";
 import React from "react";
 import { Col, Row } from "reactstrap";
 import { arrayFromRange, getNumber } from "shared/lib";
@@ -34,7 +34,7 @@ import {
   DEFAULT_QUESTIONS_WEIGHT,
   TWUOpportunity,
   TWUOpportunityStatus,
-  TWUServiceAreas,
+  TWUServiceArea as TWUServiceArea,
   UpdateEditValidationErrors
 } from "shared/lib/resources/opportunity/team-with-us";
 import { isAdmin, User } from "shared/lib/resources/user";
@@ -152,17 +152,17 @@ function resetAssignmentDate(state: Immutable<State>): Immutable<State> {
  * Local helper function to obtain and modify the key of
  * (enum) TWUServiceArea if given the value.
  *
- * @see {@link TWUServiceAreas}
+ * @see {@link TWUServiceArea}
  *
  * @param v - a value from the key/value pair of TWUServiceArea
  * @returns - a single label/vale pair for a select list
  */
-function getSingleKeyValueOption(v: TWUServiceAreas): Select.Option {
-  const keyIndex = Object.values(TWUServiceAreas).indexOf(v as TWUServiceAreas);
-  const k = Object.keys(TWUServiceAreas)[keyIndex];
+function getSingleKeyValueOption(v: TWUServiceArea): Select.Option {
+  const keyIndex = Object.values(TWUServiceArea).indexOf(v as TWUServiceArea);
+  const k = Object.keys(TWUServiceArea)[keyIndex];
 
   return {
-    label: startCase(camelCase(k)),
+    label: startCase(k),
     value: String(v)
   };
 }
@@ -207,7 +207,7 @@ export const init: component_.base.Init<Params, State, Msg> = ({
     if (!v) {
       return null;
     }
-    return getSingleKeyValueOption(v as TWUServiceAreas);
+    return getSingleKeyValueOption(v as TWUServiceArea);
   })();
 
   const [tabbedFormState, tabbedFormCmds] = TabbedFormComponent.init({
@@ -328,7 +328,7 @@ export const init: component_.base.Init<Params, State, Msg> = ({
     child: {
       value: serviceArea,
       id: "twu-service-area",
-      options: Select.objectToOptions(TWUServiceAreas)
+      options: Select.objectToOptions(TWUServiceArea)
     }
   });
   const [targetAllocationState, targetAllocationCmds] = Select.init({

--- a/src/shared/lib/resources/opportunity/team-with-us.ts
+++ b/src/shared/lib/resources/opportunity/team-with-us.ts
@@ -33,7 +33,7 @@ export enum TWUOpportunityEvent {
   NoteAdded = "NOTE_ADDED"
 }
 
-export enum TWUServiceAreas {
+export enum TWUServiceArea {
   Developer = "DEVELOPER",
   DataSpecialist = "DATA_SPECIALIST",
   ScrumMaster = "SCRUM_MASTER",

--- a/src/shared/lib/validation/opportunity/team-with-us.ts
+++ b/src/shared/lib/validation/opportunity/team-with-us.ts
@@ -11,7 +11,7 @@ import {
   parseTWUOpportunityStatus,
   TWUOpportunity,
   TWUOpportunityStatus,
-  TWUServiceAreas
+  TWUServiceArea
 } from "shared/lib/resources/opportunity/team-with-us";
 import {
   allValid,
@@ -58,7 +58,7 @@ export function validateCreateTWUOpportunityStatus(
 }
 
 export function validateFullTime(raw: any): Validation<boolean> {
-  return typeof raw === 'boolean'
+  return typeof raw === "boolean"
     ? valid(raw)
     : invalid(["You must provide a boolean value."]);
 }
@@ -157,7 +157,7 @@ export function validateTeaser(raw: string): Validation<string> {
 }
 
 export function validateRemoteOk(raw: any): Validation<boolean> {
-  return typeof raw === 'boolean'
+  return typeof raw === "boolean"
     ? valid(raw)
     : invalid(["Invalid remote option provided."]);
 }
@@ -178,10 +178,8 @@ export function validateLocation(raw: string): Validation<string> {
   return validateGenericString(raw, "Location", 1);
 }
 
-export function validateMaxBudget(
-  raw: string | number
-): Validation<number> {
-  return validateNumber(raw, 1, undefined, "Maximum Budget")
+export function validateMaxBudget(raw: string | number): Validation<number> {
+  return validateNumber(raw, 1, undefined, "Maximum Budget");
 }
 
 export function validateMandatorySkills(
@@ -262,7 +260,7 @@ export function validateNote(raw: string): Validation<string> {
  */
 export function validateServiceArea(raw: string): Validation<string> {
   const service_area: Immutable.Set<string> = Set(
-    Object.values(TWUServiceAreas)
+    Object.values(TWUServiceArea)
   );
   return validateStringInArray(raw, service_area, "Service Area");
 }
@@ -273,8 +271,6 @@ export function validateServiceArea(raw: string): Validation<string> {
  * @param raw
  * @returns
  */
-export function validateTargetAllocation(
-  raw: number
-): Validation<number> {
-  return validateNumber(raw, 1, 100, "Target Allocation")
+export function validateTargetAllocation(raw: number): Validation<number> {
+  return validateNumber(raw, 1, 100, "Target Allocation");
 }


### PR DESCRIPTION
Includes tests? [N]
Updated docs? [N]

Proposed changes:

    saved service area value now displays when viewing the draft of a TWU opp

