### PR TITLE
fix: display addenda history in edit tab

### DIFF
--- a/src/front-end/typescript/lib/pages/opportunity/code-with-us/edit/tab/addenda.tsx
+++ b/src/front-end/typescript/lib/pages/opportunity/code-with-us/edit/tab/addenda.tsx
@@ -13,7 +13,6 @@ import { Col, Row } from "reactstrap";
 import { CWUOpportunity } from "shared/lib/resources/opportunity/code-with-us";
 import { adt, ADT } from "shared/lib/types";
 import { invalid, valid } from "shared/lib/validation";
-import { AddendaList } from "front-end/lib/components/addenda";
 
 export interface State extends Tab.Params {
   opportunity: CWUOpportunity | null;
@@ -125,7 +124,7 @@ const view: component_.page.View<State, InnerMsg, Route> = ({
               // let Addenda.view display a list of existing addenda,
               // otherwise this list will display
               !state.addenda.existingAddenda.length ? (
-                <AddendaList addenda={existingAddenda} />
+                <Addenda.AddendaList addenda={existingAddenda} />
               ) : (
                 ""
               )

--- a/src/front-end/typescript/lib/pages/opportunity/code-with-us/edit/tab/addenda.tsx
+++ b/src/front-end/typescript/lib/pages/opportunity/code-with-us/edit/tab/addenda.tsx
@@ -13,6 +13,7 @@ import { Col, Row } from "reactstrap";
 import { CWUOpportunity } from "shared/lib/resources/opportunity/code-with-us";
 import { adt, ADT } from "shared/lib/types";
 import { invalid, valid } from "shared/lib/validation";
+import { AddendaList } from "front-end/lib/components/addenda";
 
 export interface State extends Tab.Params {
   opportunity: CWUOpportunity | null;
@@ -97,6 +98,7 @@ const view: component_.page.View<State, InnerMsg, Route> = ({
   dispatch
 }) => {
   if (!state.opportunity || !state.addenda) return null;
+  const existingAddenda = state.opportunity.addenda;
   return (
     <div>
       <EditTabHeader
@@ -117,6 +119,17 @@ const view: component_.page.View<State, InnerMsg, Route> = ({
               )}
               state={state.addenda}
             />
+            {
+              // if existingAddenda in state is set, as is only the case
+              // immediately after publishing new addenda, render nothing and
+              // let Addenda.view display a list of existing addenda,
+              // otherwise this list will display
+              !state.addenda.existingAddenda.length ? (
+                <AddendaList addenda={existingAddenda} />
+              ) : (
+                ""
+              )
+            }
           </Col>
         </Row>
       </div>

--- a/src/front-end/typescript/lib/pages/opportunity/code-with-us/edit/tab/addenda.tsx
+++ b/src/front-end/typescript/lib/pages/opportunity/code-with-us/edit/tab/addenda.tsx
@@ -43,8 +43,9 @@ const update: component_.page.Update<State, InnerMsg, Route> = ({
   switch (msg.tag) {
     case "onInitResponse": {
       const opportunity = msg.value[0];
+      const existingAddenda = opportunity.addenda;
       const [addendaState, addendaCmds] = Addenda.init({
-        existingAddenda: [],
+        existingAddenda: existingAddenda,
         publishNewAddendum(value) {
           return api.opportunities.cwu.update(
             opportunity.id,
@@ -97,7 +98,6 @@ const view: component_.page.View<State, InnerMsg, Route> = ({
   dispatch
 }) => {
   if (!state.opportunity || !state.addenda) return null;
-  const existingAddenda = state.opportunity.addenda;
   return (
     <div>
       <EditTabHeader
@@ -118,17 +118,6 @@ const view: component_.page.View<State, InnerMsg, Route> = ({
               )}
               state={state.addenda}
             />
-            {
-              // if existingAddenda in state is set, as is only the case
-              // immediately after publishing new addenda, render nothing and
-              // let Addenda.view display a list of existing addenda,
-              // otherwise this list will display
-              !state.addenda.existingAddenda.length ? (
-                <Addenda.AddendaList addenda={existingAddenda} />
-              ) : (
-                ""
-              )
-            }
           </Col>
         </Row>
       </div>

--- a/src/front-end/typescript/lib/pages/opportunity/sprint-with-us/edit/tab/addenda.tsx
+++ b/src/front-end/typescript/lib/pages/opportunity/sprint-with-us/edit/tab/addenda.tsx
@@ -13,7 +13,6 @@ import { Col, Row } from "reactstrap";
 import { SWUOpportunity } from "shared/lib/resources/opportunity/sprint-with-us";
 import { adt, ADT } from "shared/lib/types";
 import { invalid, valid } from "shared/lib/validation";
-import { AddendaList } from "front-end/lib/components/addenda";
 
 export interface State extends Tab.Params {
   opportunity: SWUOpportunity | null;
@@ -125,7 +124,7 @@ const view: component_.page.View<State, InnerMsg, Route> = ({
               // let Addenda.view display a list of existing addenda,
               // otherwise this list will display
               !state.addenda.existingAddenda.length ? (
-                <AddendaList addenda={existingAddenda} />
+                <Addenda.AddendaList addenda={existingAddenda} />
               ) : (
                 ""
               )

--- a/src/front-end/typescript/lib/pages/opportunity/sprint-with-us/edit/tab/addenda.tsx
+++ b/src/front-end/typescript/lib/pages/opportunity/sprint-with-us/edit/tab/addenda.tsx
@@ -43,8 +43,9 @@ const update: component_.page.Update<State, InnerMsg, Route> = ({
   switch (msg.tag) {
     case "onInitResponse": {
       const opportunity = msg.value[0];
+      const existingAddenda = opportunity.addenda;
       const [addendaState, addendaCmds] = Addenda.init({
-        existingAddenda: [],
+        existingAddenda: existingAddenda,
         publishNewAddendum(value) {
           return api.opportunities.swu.update(
             opportunity.id,
@@ -97,7 +98,6 @@ const view: component_.page.View<State, InnerMsg, Route> = ({
   dispatch
 }) => {
   if (!state.opportunity || !state.addenda) return null;
-  const existingAddenda = state.opportunity.addenda;
   return (
     <div>
       <EditTabHeader
@@ -118,17 +118,6 @@ const view: component_.page.View<State, InnerMsg, Route> = ({
               )}
               state={state.addenda}
             />
-            {
-              // if existingAddenda in state is set, as is only the case
-              // immediately after publishing new addenda, render nothing and
-              // let Addenda.view display a list of existing addenda,
-              // otherwise this list will display
-              !state.addenda.existingAddenda.length ? (
-                <Addenda.AddendaList addenda={existingAddenda} />
-              ) : (
-                ""
-              )
-            }
           </Col>
         </Row>
       </div>

--- a/src/front-end/typescript/lib/pages/opportunity/sprint-with-us/edit/tab/addenda.tsx
+++ b/src/front-end/typescript/lib/pages/opportunity/sprint-with-us/edit/tab/addenda.tsx
@@ -13,6 +13,7 @@ import { Col, Row } from "reactstrap";
 import { SWUOpportunity } from "shared/lib/resources/opportunity/sprint-with-us";
 import { adt, ADT } from "shared/lib/types";
 import { invalid, valid } from "shared/lib/validation";
+import { AddendaList } from "front-end/lib/components/addenda";
 
 export interface State extends Tab.Params {
   opportunity: SWUOpportunity | null;
@@ -97,6 +98,7 @@ const view: component_.page.View<State, InnerMsg, Route> = ({
   dispatch
 }) => {
   if (!state.opportunity || !state.addenda) return null;
+  const existingAddenda = state.opportunity.addenda;
   return (
     <div>
       <EditTabHeader
@@ -117,6 +119,17 @@ const view: component_.page.View<State, InnerMsg, Route> = ({
               )}
               state={state.addenda}
             />
+            {
+              // if existingAddenda in state is set, as is only the case
+              // immediately after publishing new addenda, render nothing and
+              // let Addenda.view display a list of existing addenda,
+              // otherwise this list will display
+              !state.addenda.existingAddenda.length ? (
+                <AddendaList addenda={existingAddenda} />
+              ) : (
+                ""
+              )
+            }
           </Col>
         </Row>
       </div>


### PR DESCRIPTION
This PR closes issue: [issue DM-1121]

Includes tests? [N]
Updated docs? [N]

Proposed changes:
- fixes regression in addenda edit tab where history was not rendering

Additional notes:

**View addenda tab**

<img width="660" alt="image" src="https://user-images.githubusercontent.com/2048170/220486784-9ba42eaf-ed7a-43c6-8d49-9399bd748b2d.png">

**Add Addenda state**

<img width="649" alt="image" src="https://user-images.githubusercontent.com/2048170/220486851-ffc8475a-0cc2-4696-99a6-74781b46bf70.png">

**Publish new Addenda**

<img width="624" alt="image" src="https://user-images.githubusercontent.com/2048170/220486918-1ac2f0d8-33b8-4365-9950-0d010da548ee.png">

