### PR TITLE
fix: block notifications during edit of suspended opp

### DIFF
--- a/src/back-end/lib/resources/opportunity/code-with-us.ts
+++ b/src/back-end/lib/resources/opportunity/code-with-us.ts
@@ -861,6 +861,10 @@ const update: crud.Update<
       valid: async (request) => {
         let dbResult: Validation<CWUOpportunity, null>;
         const { session, body } = request.body;
+        const doNotNotify = [
+          CWUOpportunityStatus.Draft,
+          CWUOpportunityStatus.Suspended
+        ];
         switch (body.tag) {
           case "edit":
             dbResult = await db.updateCWUOpportunityVersion(
@@ -868,10 +872,11 @@ const update: crud.Update<
               { ...body.value, id: request.params.id },
               session
             );
-            // Notify all subscribed users on the opportunity of the update (only if not draft)
+            // Notify all subscribed users on the opportunity of the update
+            // (only if not either draft or suspended)
             if (
               isValid(dbResult) &&
-              dbResult.value.status !== CWUOpportunityStatus.Draft
+              !Object.values(doNotNotify).includes(dbResult.value.status)
             ) {
               cwuOpportunityNotifications.handleCWUUpdated(
                 connection,

--- a/src/back-end/lib/resources/opportunity/code-with-us.ts
+++ b/src/back-end/lib/resources/opportunity/code-with-us.ts
@@ -863,7 +863,8 @@ const update: crud.Update<
         const { session, body } = request.body;
         const doNotNotify = [
           CWUOpportunityStatus.Draft,
-          CWUOpportunityStatus.Suspended
+          CWUOpportunityStatus.Suspended,
+          CWUOpportunityStatus.Canceled
         ];
         switch (body.tag) {
           case "edit":
@@ -960,8 +961,14 @@ const update: crud.Update<
               body.value,
               session
             );
-            // Notify all subscribed users on the opportunity of the update
-            if (isValid(dbResult)) {
+            /**
+             * Notify all subscribed users on the opportunity of the update
+             * unless it's been cancelled
+             */
+            if (
+              isValid(dbResult) &&
+              !Object.values(doNotNotify).includes(dbResult.value.status)
+            ) {
               cwuOpportunityNotifications.handleCWUUpdated(
                 connection,
                 dbResult.value

--- a/src/back-end/lib/resources/opportunity/code-with-us.ts
+++ b/src/back-end/lib/resources/opportunity/code-with-us.ts
@@ -872,8 +872,10 @@ const update: crud.Update<
               { ...body.value, id: request.params.id },
               session
             );
-            // Notify all subscribed users on the opportunity of the update
-            // (only if not either draft or suspended)
+            /**
+             * Notify all subscribed users on the opportunity of the update
+             * (only if not draft or suspended status)
+             */
             if (
               isValid(dbResult) &&
               !Object.values(doNotNotify).includes(dbResult.value.status)

--- a/src/back-end/lib/resources/opportunity/sprint-with-us.ts
+++ b/src/back-end/lib/resources/opportunity/sprint-with-us.ts
@@ -1576,7 +1576,8 @@ const update: crud.Update<
         const { session, body } = request.body;
         const doNotNotify = [
           SWUOpportunityStatus.Draft,
-          SWUOpportunityStatus.Suspended
+          SWUOpportunityStatus.Suspended,
+          SWUOpportunityStatus.Canceled
         ];
         switch (body.tag) {
           case "edit":
@@ -1698,8 +1699,14 @@ const update: crud.Update<
               body.value,
               session
             );
-            // Notify all subscribed users on the opportunity of the addendum
-            if (isValid(dbResult)) {
+            /**
+             * Notify all subscribed users on the opportunity of the update
+             * unless it's been cancelled
+             */
+            if (
+              isValid(dbResult) &&
+              !Object.values(doNotNotify).includes(dbResult.value.status)
+            ) {
               swuOpportunityNotifications.handleSWUUpdated(
                 connection,
                 dbResult.value

--- a/src/back-end/lib/resources/opportunity/sprint-with-us.ts
+++ b/src/back-end/lib/resources/opportunity/sprint-with-us.ts
@@ -1574,6 +1574,10 @@ const update: crud.Update<
       valid: async (request) => {
         let dbResult: Validation<SWUOpportunity, null>;
         const { session, body } = request.body;
+        const doNotNotify = [
+          SWUOpportunityStatus.Draft,
+          SWUOpportunityStatus.Suspended
+        ];
         switch (body.tag) {
           case "edit":
             dbResult = await db.updateSWUOpportunityVersion(
@@ -1581,10 +1585,11 @@ const update: crud.Update<
               { ...body.value, id: request.params.id },
               session
             );
-            // Notify all subscribed users on the opportunity of the update (only if not draft status)
+            // Notify all subscribed users on the opportunity of the update
+            // (only if not either draft or suspended)
             if (
               isValid(dbResult) &&
-              dbResult.value.status !== SWUOpportunityStatus.Draft
+              !Object.values(doNotNotify).includes(dbResult.value.status)
             ) {
               swuOpportunityNotifications.handleSWUUpdated(
                 connection,

--- a/src/back-end/lib/resources/opportunity/sprint-with-us.ts
+++ b/src/back-end/lib/resources/opportunity/sprint-with-us.ts
@@ -1585,8 +1585,10 @@ const update: crud.Update<
               { ...body.value, id: request.params.id },
               session
             );
-            // Notify all subscribed users on the opportunity of the update
-            // (only if not either draft or suspended)
+            /**
+             * Notify all subscribed users on the opportunity of the update
+             * (only if not draft or suspended status)
+             */
             if (
               isValid(dbResult) &&
               !Object.values(doNotNotify).includes(dbResult.value.status)

--- a/src/front-end/typescript/lib/pages/opportunity/code-with-us/edit/tab/addenda.tsx
+++ b/src/front-end/typescript/lib/pages/opportunity/code-with-us/edit/tab/addenda.tsx
@@ -10,7 +10,10 @@ import * as Tab from "front-end/lib/pages/opportunity/code-with-us/edit/tab";
 import EditTabHeader from "front-end/lib/pages/opportunity/code-with-us/lib/views/edit-tab-header";
 import React from "react";
 import { Col, Row } from "reactstrap";
-import { CWUOpportunity } from "shared/lib/resources/opportunity/code-with-us";
+import {
+  CWUOpportunity,
+  CWUOpportunityStatus
+} from "shared/lib/resources/opportunity/code-with-us";
 import { adt, ADT } from "shared/lib/types";
 import { invalid, valid } from "shared/lib/validation";
 
@@ -141,8 +144,20 @@ export const component: Tab.Component<State, InnerMsg> = {
     );
   },
 
-  getActions({ state, dispatch }) {
-    if (!state.addenda) return component_.page.actions.none();
+  /**
+   * Checks to see if state = isEditing and produces Publish and Cancel
+   * actions (via buttons), otherwise an 'Add Addendum' action/button. Produces
+   * nothing if the opportunity status is 'Canceled' or if addenda is not set.
+   *
+   * @param state
+   * @param dispatch
+   */
+  getActions: function ({ state, dispatch }) {
+    if (
+      !state.addenda ||
+      state.opportunity?.status === CWUOpportunityStatus.Canceled
+    )
+      return component_.page.actions.none();
     return Addenda.getActions({
       state: state.addenda,
       dispatch: component_.base.mapDispatch(dispatch, (msg) =>

--- a/src/front-end/typescript/lib/pages/opportunity/sprint-with-us/edit/tab/addenda.tsx
+++ b/src/front-end/typescript/lib/pages/opportunity/sprint-with-us/edit/tab/addenda.tsx
@@ -10,7 +10,10 @@ import * as Tab from "front-end/lib/pages/opportunity/sprint-with-us/edit/tab";
 import EditTabHeader from "front-end/lib/pages/opportunity/sprint-with-us/lib/views/edit-tab-header";
 import React from "react";
 import { Col, Row } from "reactstrap";
-import { SWUOpportunity } from "shared/lib/resources/opportunity/sprint-with-us";
+import {
+  SWUOpportunity,
+  SWUOpportunityStatus
+} from "shared/lib/resources/opportunity/sprint-with-us";
 import { adt, ADT } from "shared/lib/types";
 import { invalid, valid } from "shared/lib/validation";
 
@@ -141,8 +144,20 @@ export const component: Tab.Component<State, InnerMsg> = {
     );
   },
 
+  /**
+   * Checks to see if state = isEditing and produces Publish and Cancel
+   * actions (via buttons), otherwise an 'Add Addendum' action/button. Produces
+   * nothing if the opportunity status is 'Canceled' or if addenda is not set.
+   *
+   * @param state
+   * @param dispatch
+   */
   getActions({ state, dispatch }) {
-    if (!state.addenda) return component_.page.actions.none();
+    if (
+      !state.addenda ||
+      state.opportunity?.status === SWUOpportunityStatus.Canceled
+    )
+      return component_.page.actions.none();
     return Addenda.getActions({
       state: state.addenda,
       dispatch: component_.base.mapDispatch(dispatch, (msg) =>


### PR DESCRIPTION
This PR closes issue: [issue DM-1150]

Includes tests? [N]
Updated docs? [Y]

Proposed changes:
- blocks email notifications when 'Suspended' opportunities are edited
- blocks email notifications when 'Cancelled' status
- prevents 'Add Addendum' button from appearing during 'Cancelled' status

