### PR TITLE
fix: update ubuntu image prior to deprecation deadline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
       - run: pre-commit run --all-files -v
   commitlint:
     if: github.actor != 'dependabot[bot]'
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/publish_deploy_image.yml
+++ b/.github/workflows/publish_deploy_image.yml
@@ -14,7 +14,7 @@ env:
 jobs:
   build-and-push-image:
     if: github.actor != 'dependabot[bot]'
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
This PR closes issue: [issue DM-1162]

Includes tests? [N]
Updated docs? [N]

Proposed changes:
- scheduled brownouts occurring, deprecation deadline is April 1, 2023



