### PR TITLE
Opportunity Data Model Changes

### DIFF
--- a/src/back-end/lib/db/index.ts
+++ b/src/back-end/lib/db/index.ts
@@ -54,3 +54,4 @@ export * from "back-end/lib/db/subscribers/code-with-us";
 export * from "back-end/lib/db/subscribers/sprint-with-us";
 export * from "back-end/lib/db/subscribers/team-with-us";
 export * from "back-end/lib/db/user";
+export * from "back-end/lib/db/serviceArea";

--- a/src/back-end/lib/db/serviceArea.ts
+++ b/src/back-end/lib/db/serviceArea.ts
@@ -1,0 +1,13 @@
+import { tryDb } from "back-end/lib/db";
+import { valid } from "shared/lib/http";
+import { TWUServiceAreaRecord } from "shared/lib/resources/serviceArea";
+import { Id } from "shared/lib/types";
+
+export const readOneServiceAreaByServiceArea = tryDb<[Id], number | null>(
+  async (connection, serviceArea) => {
+    const result = await connection<TWUServiceAreaRecord>("serviceAreas")
+      .where({ serviceArea })
+      .first();
+    return valid(result ? result.id : null);
+  }
+);

--- a/src/back-end/lib/validation.ts
+++ b/src/back-end/lib/validation.ts
@@ -51,7 +51,10 @@ import {
   validateSWUProposalTeamMemberScrumMaster
 } from "shared/lib/validation/proposal/sprint-with-us";
 import { isArray } from "util";
-import { TWUOpportunity } from "shared/lib/resources/opportunity/team-with-us";
+import {
+  parseTWUServiceArea,
+  TWUOpportunity
+} from "shared/lib/resources/opportunity/team-with-us";
 
 export async function validateTWUOpportunityId(
   connection: db.Connection,
@@ -80,6 +83,41 @@ export async function validateTWUOpportunityId(
     return invalid(["Please select a valid Team With Us opportunity."]);
   }
 }
+
+/**
+ * Takes a string from a validates it is a valid Team With Us service area in the database.
+ *
+ * @param raw - string argument
+ * @param connection - Knex connection wrapper
+ * @returns
+ */
+export async function validateServiceArea(
+  connection: db.Connection,
+  raw: string
+): Promise<Validation<number>> {
+  const parsed = parseTWUServiceArea(raw);
+  if (!parsed) {
+    return invalid([`"${raw}" is not a valid service area.`]);
+  }
+  try {
+    const dbResult = await db.readOneServiceAreaByServiceArea(
+      connection,
+      parsed
+    );
+    if (isInvalid(dbResult)) {
+      return invalid([db.ERROR_MESSAGE]);
+    }
+    const serviceArea = dbResult.value;
+    if (serviceArea) {
+      return valid(serviceArea);
+    } else {
+      return invalid(["The specified service area was not found."]);
+    }
+  } catch (e) {
+    return invalid(["Please specify a valid service area."]);
+  }
+}
+
 export async function validateUserId(
   connection: db.Connection,
   userId: Id

--- a/src/front-end/typescript/lib/pages/opportunity/team-with-us/lib/components/form.tsx
+++ b/src/front-end/typescript/lib/pages/opportunity/team-with-us/lib/components/form.tsx
@@ -359,11 +359,7 @@ export const init: component_.base.Init<Params, State, Msg> = ({
       if (!option) {
         return invalid(["Please select a Service Area."]);
       }
-
-      return mapValid(
-        opportunityValidation.validateServiceArea(option.value),
-        (serviceArea) => ({ label: option.label, value: serviceArea })
-      );
+      return valid(option);
     },
     child: {
       value: serviceArea,

--- a/src/migrations/tasks/20230315112325_service-areas-table.ts
+++ b/src/migrations/tasks/20230315112325_service-areas-table.ts
@@ -1,0 +1,107 @@
+import { makeDomainLogger } from "back-end/lib/logger";
+import { console as consoleAdapter } from "back-end/lib/logger/adapters";
+import Knex from "knex";
+
+const logger = makeDomainLogger(consoleAdapter, "migrations");
+
+enum TWUServiceArea {
+  Developer = "DEVELOPER",
+  DataSpecialist = "DATA_SPECIALIST",
+  ScrumMaster = "SCRUM_MASTER",
+  DevopsSpecialist = "DEVOPS_SPECIALIST"
+}
+
+export async function up(connection: Knex): Promise<void> {
+  // Service Areas
+  await connection.schema.createTable("serviceAreas", (table) => {
+    table.increments("id").primary().unique().notNullable();
+    table.enu("serviceArea", Object.values(TWUServiceArea)).notNullable();
+    table.string("name").notNullable();
+  });
+  Object.keys(TWUServiceArea).forEach(async (key) => {
+    await connection("serviceAreas").insert({
+      serviceArea: TWUServiceArea[key as keyof typeof TWUServiceArea],
+      name: key
+    });
+  });
+  logger.info("Created serviceAreas table");
+
+  // Organization Service Areas
+  await connection.schema.createTable(
+    "twuOrganizationServiceAreas",
+    (table) => {
+      table.integer("serviceArea").references("id").inTable("serviceAreas");
+      table.uuid("organization").references("id").inTable("organizations");
+      table.primary(["serviceArea", "organization"]);
+    }
+  );
+  logger.info("Created twuOrganizationServiceAreas table");
+
+  await connection.schema.createTable("twuResources", (table) => {
+    table.uuid("id").primary().unique().notNullable();
+    table.integer("serviceArea").references("id").inTable("serviceAreas");
+    table
+      .uuid("opportunityVersion")
+      .references("id")
+      .inTable("twuOpportunityVersions");
+    table.integer("targetAllocation").notNullable();
+    table.specificType("mandatorySkills", "text ARRAY").notNullable();
+    table.specificType("optionalSkills", "text ARRAY").notNullable();
+  });
+  logger.info("Created twuResources table");
+
+  await connection.schema.alterTable("twuOpportunityVersions", (table) => {
+    table.dropColumn("serviceArea");
+    table.dropColumn("targetAllocation");
+    table.dropColumn("mandatorySkills");
+    table.dropColumn("optionalSkills");
+  });
+  logger.info(
+    "Removed serviceArea, targetAllocation, mandatorySkills, and optionalSkills from twuOpportunityVersions"
+  );
+}
+
+export async function down(connection: Knex): Promise<void> {
+  await connection.schema.alterTable("twuOpportunityVersions", (table) => {
+    table
+      .enu("serviceArea", Object.values(TWUServiceArea))
+      .defaultTo(TWUServiceArea.Developer)
+      .notNullable();
+    table.integer("targetAllocation").defaultTo(100).notNullable();
+    table
+      .specificType("mandatorySkills", "text ARRAY")
+      .defaultTo("{}")
+      .notNullable();
+    table
+      .specificType("optionalSkills", "text ARRAY")
+      .defaultTo("{}")
+      .notNullable();
+  });
+  // Populate a twuOpportunityVersion with any related resource's details.
+  await connection.raw(`
+    UPDATE
+      "twuOpportunityVersions" tov
+    SET
+      "serviceArea" = sa."serviceArea",
+      "targetAllocation" = tr."targetAllocation",
+      "mandatorySkills" = tr."mandatorySkills",
+      "optionalSkills" = tr."optionalSkills"
+    FROM
+      "serviceAreas" sa
+      JOIN "twuResources" tr ON sa.id = tr."serviceArea"
+    WHERE
+      tov.id = tr."opportunityVersion";
+  `);
+  logger.info(
+    "Reverted removing serviceArea, targetAllocation, mandatorySkills, and optionalSkills from twuOpportunityVersions"
+  );
+
+  await connection.schema.dropTable("twuResources");
+  logger.info("Dropped table twuResources");
+
+  await connection.schema.dropTable("twuOrganizationServiceAreas");
+  logger.info("Dropped table twuOrganizationServiceAreas");
+
+  await connection.schema.dropTable("serviceAreas");
+  logger.info("Dropped table serviceAreas");
+}

--- a/src/shared/lib/resources/serviceArea.ts
+++ b/src/shared/lib/resources/serviceArea.ts
@@ -1,0 +1,7 @@
+import { TWUServiceArea } from "./opportunity/team-with-us";
+
+export interface TWUServiceAreaRecord {
+  id: number;
+  serviceArea: TWUServiceArea;
+  name: string;
+}

--- a/src/shared/lib/validation/opportunity/team-with-us.ts
+++ b/src/shared/lib/validation/opportunity/team-with-us.ts
@@ -9,9 +9,7 @@ import {
   MAX_RESOURCE_QUESTIONS,
   parseTWUOpportunityStatus,
   TWUOpportunity,
-  TWUOpportunityStatus,
-  TWUServiceArea,
-  parseTWUServiceArea
+  TWUOpportunityStatus
 } from "shared/lib/resources/opportunity/team-with-us";
 import {
   allValid,
@@ -178,21 +176,6 @@ export function validateChallengeWeight(
 
 export function validatePriceWeight(raw: string | number): Validation<number> {
   return validateNumber(raw, 0, 100, "price weight", "a");
-}
-
-/**
- * Takes a string from the form and validates that its a parsable Team With Us
- * service area.
- *
- * @param raw - string argument
- * @returns
- */
-export function validateServiceArea(raw: string): Validation<TWUServiceArea> {
-  const parsed = parseTWUServiceArea(raw);
-  if (!parsed) {
-    return invalid([`"${raw}" is not a valid service area.`]);
-  }
-  return valid(parsed);
 }
 
 /**


### PR DESCRIPTION
This PR closes issue: [DM-1169]

Includes tests? [N]
Updated docs? [N]

Proposed changes:
- Adds twuResources and serviceAreas tables. twuResources are M:1 with twuOpportunityVersions and also have a FK to serviceAreas. Organizations are M:M with serviceAreas and has a corresponding twuOrganizationServiceAreas link table.

Additional notes:
- Most changes are at the DB layer as a temporary stop gap, but we will not need to do any complex data migrations as a result.
- Would appreciate a second set of eyes to look at the migration, I wasn't sure if we needed to handle deletion logic, i.e. if a twuOpportunityVersion gets deleted, should we clear out the corresponding rows in twuOrganizationServiceAreas. I also wasn't sure about enforcing these relationships i.e. a twuOpportunityVersion must have at least one twuResources, but I guess that can be enforced in the application code.