### PR TITLE
Fix/twu proposal regressions

### DIFF
--- a/src/back-end/lib/db/proposal/team-with-us.ts
+++ b/src/back-end/lib/db/proposal/team-with-us.ts
@@ -193,7 +193,8 @@ async function rawTWUProposalToTWUProposal(
       team: raw.team,
       resourceQuestionResponses: raw.resourceQuestionResponses,
       questionsScore: raw.questionsScore || undefined,
-      anonymousProponentName: raw.anonymousProponentName
+      anonymousProponentName: raw.anonymousProponentName,
+      attachments: []
     };
   }
 

--- a/src/back-end/lib/permissions.ts
+++ b/src/back-end/lib/permissions.ts
@@ -812,6 +812,25 @@ export async function readOneTWUProposal(
   return false;
 }
 
+export async function readManyTWUProposals(
+  connection: Connection,
+  session: Session,
+  opportunity: TWUOpportunity
+): Promise<boolean> {
+  if (
+    isAdmin(session) ||
+    (session &&
+      (await isTWUOpportunityAuthor(connection, session.user, opportunity.id)))
+  ) {
+    // Only provide permission to admins/gov owners if opportunity is not in draft or published
+    return doesTWUOpportunityStatusAllowGovToViewProposals(opportunity.status);
+  } else if (isVendor(session)) {
+    // If a vendor, only proposals they have authored will be returned (filtered at db layer)
+    return true;
+  }
+  return false;
+}
+
 export async function readTWUProposalHistory(
   connection: Connection,
   session: Session,

--- a/src/back-end/lib/resources/proposal/sprint-with-us.ts
+++ b/src/back-end/lib/resources/proposal/sprint-with-us.ts
@@ -14,7 +14,7 @@ import {
   validateOrganizationId,
   validateSWUOpportunityId,
   validateSWUProposalId,
-  validateProposalOrganization,
+  validateDraftProposalOrganization,
   validateSWUProposalPhase,
   validateSWUProposalTeam,
   validateSWUProposalTeamMembers
@@ -606,7 +606,7 @@ const update: crud.Update<
             attachments
           } = request.body.value;
 
-          const validatedOrganization = await validateProposalOrganization(
+          const validatedOrganization = await validateDraftProposalOrganization(
             connection,
             organization,
             request.session

--- a/src/back-end/lib/resources/proposal/team-with-us.ts
+++ b/src/back-end/lib/resources/proposal/team-with-us.ts
@@ -119,13 +119,12 @@ const readMany: crud.ReadMany<Session, db.Connection> = (
       }
 
       if (
-        // TODO - add TWU permissions when ready
-        !permissions.isSignedIn(request.session)
-        // || !(await permissions.readManyTWUProposals(
-        //   connection,
-        //   request.session,
-        //   validatedTWUOpportunity.value
-        // ))
+        !permissions.isSignedIn(request.session) ||
+        !(await permissions.readManyTWUProposals(
+          connection,
+          request.session,
+          validatedTWUOpportunity.value
+        ))
       ) {
         return respond(401, [permissions.ERROR_MESSAGE]);
       }

--- a/src/back-end/lib/validation.ts
+++ b/src/back-end/lib/validation.ts
@@ -196,7 +196,7 @@ export function validateServiceAreas(
  */
 export function validateTWUProposalTeam(
   connection: db.Connection,
-  raw: any[],
+  raw: CreateTWUTeamMemberBody[],
   organization: Id
 ): Promise<
   ArrayValidation<

--- a/src/back-end/lib/validation.ts
+++ b/src/back-end/lib/validation.ts
@@ -690,7 +690,7 @@ export async function validateSWUProposalTeam(
   return validateSWUProposalTeamCapabilities(opportunity, teamMembers);
 }
 
-export async function validateProposalOrganization(
+export async function validateDraftProposalOrganization(
   connection: db.Connection,
   organization: Id | undefined,
   session: Session

--- a/src/front-end/typescript/lib/pages/proposal/team-with-us/lib/components/form.tsx
+++ b/src/front-end/typescript/lib/pages/proposal/team-with-us/lib/components/form.tsx
@@ -152,7 +152,7 @@ export const init: component_.base.Init<Params, State, Msg> = ({
     // .filter((o) => doesOrganizationMeetTWUQualification(o))
     .map(({ id, legalName }) => ({ label: legalName, value: id }));
   // TODO: hourlyRate will need to be set differently after TWU moves away from a one-and-only-one-resource world
-  const hourlyRate = proposal?.team ? proposal.team[0].hourlyRate : 0;
+  const hourlyRate = proposal?.team.length ? proposal.team[0].hourlyRate : 0;
   const selectedOrganizationOption = proposal?.organization
     ? {
         label: proposal.organization.legalName,

--- a/src/front-end/typescript/lib/pages/proposal/team-with-us/lib/components/form.tsx
+++ b/src/front-end/typescript/lib/pages/proposal/team-with-us/lib/components/form.tsx
@@ -31,7 +31,9 @@ import {
 } from "shared/lib/resources/opportunity/team-with-us";
 import {
   // doesOrganizationMeetTWUQualification,
-  OrganizationSlim
+  OrganizationSlim,
+  doesOrganizationMeetTWUQualification,
+  doesOrganizationProvideServiceArea
 } from "shared/lib/resources/organization";
 import {
   CreateRequestBody,
@@ -148,8 +150,11 @@ export const init: component_.base.Init<Params, State, Msg> = ({
   activeTab = DEFAULT_ACTIVE_TAB
 }) => {
   const organizationOptions = organizations
-    // TODO: add TWU qualification check when ready
-    // .filter((o) => doesOrganizationMeetTWUQualification(o))
+    .filter(
+      (o) =>
+        doesOrganizationMeetTWUQualification(o) &&
+        doesOrganizationProvideServiceArea(o, opportunity.serviceArea)
+    )
     .map(({ id, legalName }) => ({ label: legalName, value: id }));
   // TODO: hourlyRate will need to be set differently after TWU moves away from a one-and-only-one-resource world
   const hourlyRate = proposal?.team.length ? proposal.team[0].hourlyRate : 0;

--- a/src/front-end/typescript/lib/pages/proposal/team-with-us/lib/components/form.tsx
+++ b/src/front-end/typescript/lib/pages/proposal/team-with-us/lib/components/form.tsx
@@ -30,7 +30,6 @@ import {
   TWUOpportunity
 } from "shared/lib/resources/opportunity/team-with-us";
 import {
-  // doesOrganizationMeetTWUQualification,
   OrganizationSlim,
   doesOrganizationMeetTWUQualification,
   doesOrganizationProvideServiceArea

--- a/src/shared/lib/validation/proposal/team-with-us.ts
+++ b/src/shared/lib/validation/proposal/team-with-us.ts
@@ -7,7 +7,6 @@ import {
 } from "shared/lib/resources/opportunity/team-with-us";
 import {
   Organization,
-  OrganizationSlim,
   doesOrganizationProvideServiceArea
 } from "shared/lib/resources/organization";
 import {
@@ -176,7 +175,7 @@ export function validateTWUProposalProposedCost(
  */
 export function validateTWUProposalOrganizationServiceAreas(
   opportunity: TWUOpportunity,
-  organization?: Organization | OrganizationSlim
+  organization?: Organization
 ): ArrayValidation<TWUServiceArea, string> {
   if (
     organization &&


### PR DESCRIPTION
This PR closes issue: [DM-1180, DM-1181, DM-1182]

Includes tests? [N]
Updated docs? [N]

Proposed changes:
- Check's the length of team instead of its identity, allowing drafts to be saved without entering any input.
- Validates an organization on a `submit` update to further validate team members and service areas. This is necessary because organizations are optional and we need to pass one to `validateTWUProposalTeam`, as well as the fact that we delete `acceptedTWUProposal` if the sessions belongs to a vendor
- Filter organization's displayed in the create proposal form

Additional notes:
- We'd missed some permissions for readMany TWU proposals, so I enabled those in this PR.
