### PR TITLE
fix: add disabled param for summary view

### DIFF
--- a/src/front-end/typescript/lib/pages/proposal/team-with-us/lib/components/form.tsx
+++ b/src/front-end/typescript/lib/pages/proposal/team-with-us/lib/components/form.tsx
@@ -668,7 +668,11 @@ const OrganizationView: component_.base.View<Props> = ({
   );
 };
 
-const PricingView: component_.base.View<Props> = ({ state, dispatch }) => {
+const PricingView: component_.base.View<Props> = ({
+  state,
+  dispatch,
+  disabled
+}) => {
   const { maxBudget } = state.opportunity;
   return (
     <div>
@@ -683,6 +687,7 @@ const PricingView: component_.base.View<Props> = ({ state, dispatch }) => {
       <Row>
         <Col xs="12" md="6">
           <NumberField.view
+            disabled={disabled}
             extraChildProps={{ prefix: "$" }}
             label="Hourly Rate"
             placeholder="Hourly Rate"


### PR DESCRIPTION
This PR closes issue: [issue N/A]

Includes tests? [N]
Updated docs? [N]

Proposed changes:
- adds this: 
![image](https://user-images.githubusercontent.com/2048170/233220165-68120757-33ee-4cb7-9cbf-b14810957751.png)


Additional notes:
- should only occur when Admins view proposals

