### PR TITLE
Feature twu banner

### DIFF
--- a/src/front-end/sass/index.scss
+++ b/src/front-end/sass/index.scss
@@ -129,6 +129,7 @@ $c-sidebar-menu-link-active-fg: $white;
 $c-sidebar-menu-link-active-icon: $blue;
 $c-sidebar-menu-link-active-bg: $blue-dark-alt-2;
 $c-sidebar-menu-mobile-caret: $white;
+$c-banner-bg: $yellow;
 // Pages
 $c-landing-role-heading: $blue-dark;
 $c-landing-role-icon: $yellow;
@@ -948,7 +949,7 @@ nav.navbar .nav-link:hover {
 }
 
 .twu-banner {
-  background-color: #FCBA19;
+  background-color: $c-banner-bg;
   padding: 0.75rem 0 0.75rem;
   z-index: 1001; // Above nav, below modals
 }

--- a/src/front-end/sass/index.scss
+++ b/src/front-end/sass/index.scss
@@ -947,6 +947,12 @@ nav.navbar .nav-link:hover {
   }
 }
 
+.twu-banner {
+  background-color: #FCBA19;
+  padding: 0.75rem 0 0.75rem;
+  z-index: 1001; // Above nav, below modals
+}
+
 // Page-specific overrides
 
 .route-orgSWUTerms,

--- a/src/front-end/typescript/config.ts
+++ b/src/front-end/typescript/config.ts
@@ -65,3 +65,5 @@ export const CWU_PAYMENT_OPTIONS_URL =
 
 export const TWU_BC_BID_URL =
   "https://bcbid.gov.bc.ca/page.aspx/en/bpm/process_manage_extranet/164269";
+
+export const TWU_BANNER_ACKNOWLEDGED = "twu-banner-acknowledged";

--- a/src/front-end/typescript/lib/app/init.ts
+++ b/src/front-end/typescript/lib/app/init.ts
@@ -1,3 +1,4 @@
+import { TWU_BANNER_ACKNOWLEDGED } from "front-end/config";
 import { State, Msg } from "front-end/lib/app/types";
 import * as Nav from "front-end/lib/app/view/nav";
 import * as AcceptNewTerms from "front-end/lib/components/accept-new-app-terms";
@@ -15,6 +16,7 @@ const init: component.base.Init<null, State, Msg> = () => {
   const [navState, navCmds] = Nav.init(null);
   return [
     {
+      showTWUBanner: false,
       ready: false,
       incomingRoute: null,
       toasts: [],
@@ -33,7 +35,10 @@ const init: component.base.Init<null, State, Msg> = () => {
         acceptNewTermsCmds,
         (msg) => adt("acceptNewTerms", msg) as Msg
       ),
-      ...component.cmd.mapMany(navCmds, (msg) => adt("nav", msg) as Msg)
+      ...component.cmd.mapMany(navCmds, (msg) => adt("nav", msg) as Msg),
+      component.cmd.localStorage.getItem(TWU_BANNER_ACKNOWLEDGED, (msg) =>
+        adt("setShowTWUBanner", !msg)
+      )
     ]
   ];
 };

--- a/src/front-end/typescript/lib/app/types.ts
+++ b/src/front-end/typescript/lib/app/types.ts
@@ -142,6 +142,7 @@ export type ModalId = "acceptNewTerms";
 export interface State {
   //App Internal State
   ready: boolean;
+  showTWUBanner: boolean;
   incomingRoute: router.IncomingRoute<Route> | null;
   activeRoute: Route;
   //Toasts
@@ -224,6 +225,7 @@ export type InnerMsg =
   | ADT<"submitAcceptNewTerms">
   | ADT<"onAcceptNewTermsResponse", AcceptNewTerms.AcceptNewTermsResponse>
   | ADT<"nav", Nav.Msg>
+  | ADT<"setShowTWUBanner", boolean>
   | ADT<"pageLanding", PageLanding.Msg>
   | ADT<"pageDashboard", PageDashboard.Msg>
   | ADT<"pageOpportunities", PageOpportunities.Msg>

--- a/src/front-end/typescript/lib/app/update.ts
+++ b/src/front-end/typescript/lib/app/update.ts
@@ -1,4 +1,7 @@
-import { TOAST_AUTO_DISMISS_DURATION } from "front-end/config";
+import {
+  TOAST_AUTO_DISMISS_DURATION,
+  TWU_BANNER_ACKNOWLEDGED
+} from "front-end/config";
 import { makeStartLoading, makeStopLoading } from "front-end/lib";
 import router from "front-end/lib/app/router";
 import {
@@ -896,6 +899,22 @@ const update: component.base.Update<State, Msg> = ({ state, msg }) => {
         childMsg: msg.value,
         mapChildMsg: adtCurried<ADT<"nav", Nav.Msg>>("nav")
       });
+
+    case "setShowTWUBanner":
+      return [
+        state.set("showTWUBanner", msg.value),
+        [
+          ...(!msg.value
+            ? [
+                component.cmd.localStorage.setItem(
+                  TWU_BANNER_ACKNOWLEDGED,
+                  TWU_BANNER_ACKNOWLEDGED,
+                  adt("noop") as Msg
+                )
+              ]
+            : [])
+        ]
+      ];
 
     case "pageOrgEdit":
       return component.app.updatePage({

--- a/src/front-end/typescript/lib/app/update.ts
+++ b/src/front-end/typescript/lib/app/update.ts
@@ -903,17 +903,15 @@ const update: component.base.Update<State, Msg> = ({ state, msg }) => {
     case "setShowTWUBanner":
       return [
         state.set("showTWUBanner", msg.value),
-        [
-          ...(!msg.value
-            ? [
-                component.cmd.localStorage.setItem(
-                  TWU_BANNER_ACKNOWLEDGED,
-                  TWU_BANNER_ACKNOWLEDGED,
-                  adt("noop") as Msg
-                )
-              ]
-            : [])
-        ]
+        !msg.value
+          ? [
+              component.cmd.localStorage.setItem(
+                TWU_BANNER_ACKNOWLEDGED,
+                TWU_BANNER_ACKNOWLEDGED,
+                adt("noop") as Msg
+              )
+            ]
+          : []
       ];
 
     case "pageOrgEdit":

--- a/src/front-end/typescript/lib/app/view/index.tsx
+++ b/src/front-end/typescript/lib/app/view/index.tsx
@@ -88,6 +88,7 @@ import { SHOW_TEST_INDICATOR } from "shared/config";
 import { hasAcceptedTermsOrIsAnonymous } from "shared/lib/resources/session";
 import { UserType } from "shared/lib/resources/user";
 import { ADT, adt, adtCurried } from "shared/lib/types";
+import TWUBannner from "./twu-banner";
 
 function makeViewPageProps<RouteParams, PageState, PageMsg>(
   props: component_.base.ComponentViewProps<State, Msg>,
@@ -886,6 +887,7 @@ const view: component_.base.ComponentView<State, Msg> = (props) => {
           navProps.contextualActions ? "contextual-actions-visible" : ""
         } app d-flex flex-column`}
         style={{ minHeight: "100vh" }}>
+        <TWUBannner {...props} />
         <Nav.view {...navProps} />
         <ViewPage {...viewPageProps} />
         {viewPageProps.component.simpleNav ? null : <Footer />}

--- a/src/front-end/typescript/lib/app/view/index.tsx
+++ b/src/front-end/typescript/lib/app/view/index.tsx
@@ -88,7 +88,7 @@ import { SHOW_TEST_INDICATOR } from "shared/config";
 import { hasAcceptedTermsOrIsAnonymous } from "shared/lib/resources/session";
 import { UserType } from "shared/lib/resources/user";
 import { ADT, adt, adtCurried } from "shared/lib/types";
-import TWUBannner from "./twu-banner";
+import TWUBannner from "src/front-end/typescript/lib/app/view/twu-banner";
 
 function makeViewPageProps<RouteParams, PageState, PageMsg>(
   props: component_.base.ComponentViewProps<State, Msg>,
@@ -887,7 +887,10 @@ const view: component_.base.ComponentView<State, Msg> = (props) => {
           navProps.contextualActions ? "contextual-actions-visible" : ""
         } app d-flex flex-column`}
         style={{ minHeight: "100vh" }}>
-        <TWUBannner {...props} />
+        <TWUBannner
+          show={state.showTWUBanner}
+          onClose={() => dispatch(adt("setShowTWUBanner", false))}
+        />
         <Nav.view {...navProps} />
         <ViewPage {...viewPageProps} />
         {viewPageProps.component.simpleNav ? null : <Footer />}

--- a/src/front-end/typescript/lib/app/view/twu-banner.tsx
+++ b/src/front-end/typescript/lib/app/view/twu-banner.tsx
@@ -4,13 +4,14 @@ import Link, { routeDest } from "front-end/lib/views/link";
 import React from "react";
 import { Container, Row, Col } from "reactstrap";
 import { adt } from "shared/lib/types";
-import { State, Msg } from "src/front-end/typescript/lib/app/types";
 
-const TWUBannner: component.base.ComponentView<State, Msg> = ({
-  state,
-  dispatch
-}) => {
-  return state.showTWUBanner ? (
+interface Props {
+  show: boolean;
+  onClose(): void;
+}
+
+const TWUBannner: component.base.View<Props> = ({ show, onClose }) => {
+  return show ? (
     <div className="main-wrapper twu-banner">
       <div className="main">
         <Container>
@@ -32,7 +33,7 @@ const TWUBannner: component.base.ComponentView<State, Msg> = ({
                 height={1.4}
                 name="times"
                 color="black"
-                onClick={() => dispatch(adt("setShowTWUBanner", false))}
+                onClick={onClose}
               />
             </Col>
           </Row>

--- a/src/front-end/typescript/lib/app/view/twu-banner.tsx
+++ b/src/front-end/typescript/lib/app/view/twu-banner.tsx
@@ -1,0 +1,45 @@
+import { component } from "front-end/lib/framework";
+import Icon from "front-end/lib/views/icon";
+import Link, { routeDest } from "front-end/lib/views/link";
+import React from "react";
+import { Container, Row, Col } from "reactstrap";
+import { adt } from "shared/lib/types";
+import { State, Msg } from "src/front-end/typescript/lib/app/types";
+
+const TWUBannner: component.base.ComponentView<State, Msg> = ({
+  state,
+  dispatch
+}) => {
+  return state.showTWUBanner ? (
+    <div className="main-wrapper twu-banner">
+      <div className="main">
+        <Container>
+          <Row className="text-center align-items-center">
+            <Col className="flex-grow-1">
+              We are introducing <strong>Team With Us (in Beta)</strong>. Please
+              feel free to create and respond to test opportunities.{" "}
+              <Link
+                color="black"
+                className="text-decoration-underline"
+                dest={routeDest(adt("learnMoreTWU", null))}>
+                Learn more about Team With Us
+              </Link>
+            </Col>
+            <Col className="flex-grow-0">
+              <Icon
+                hover
+                width={1.4}
+                height={1.4}
+                name="times"
+                color="black"
+                onClick={() => dispatch(adt("setShowTWUBanner", false))}
+              />
+            </Col>
+          </Row>
+        </Container>
+      </div>
+    </div>
+  ) : null;
+};
+
+export default TWUBannner;

--- a/src/front-end/typescript/lib/framework/component/cmd.ts
+++ b/src/front-end/typescript/lib/framework/component/cmd.ts
@@ -158,6 +158,50 @@ export function back<Msg>(msg: Msg): Cmd<Msg> {
   });
 }
 
+function getItem<Msg>(
+  key: string,
+  toMsg: (value: string | null) => Msg
+): Cmd<Msg> {
+  return adt("async", async () => {
+    if (!window.localStorage) return toMsg(null);
+    return toMsg(window.localStorage.getItem(key));
+  });
+}
+
+function setItem<Msg>(key: string, value: string, noOpMsg: Msg): Cmd<Msg> {
+  return adt("async", async () => {
+    if (window.localStorage) {
+      window.localStorage.setItem(key, value);
+    }
+    return noOpMsg;
+  });
+}
+
+function removeItem<Msg>(key: string, noOpMsg: Msg): Cmd<Msg> {
+  return adt("async", async () => {
+    if (window.localStorage) {
+      window.localStorage.removeItem(key);
+    }
+    return noOpMsg;
+  });
+}
+
+function clear<Msg>(noOpMsg: Msg): Cmd<Msg> {
+  return adt("async", async () => {
+    if (window.localStorage) {
+      window.localStorage.clear();
+    }
+    return noOpMsg;
+  });
+}
+
+export const localStorage = {
+  getItem,
+  setItem,
+  removeItem,
+  clear
+};
+
 // Helpers
 
 export function map<A, B>(cmd: Cmd<A>, convert: (msgA: A) => B): Cmd<B> {


### PR DESCRIPTION
Includes tests? [N]
Updated docs? [N]

Proposed changes:
- Add state related to displaying a TWU banner. Check local storage to see if a user has acknowledged the banner. If they haven't acknowledged it, render the banner. The user can acknowledge the banner by clicking its close icon, which will dispatch a command to set the appropriate display state and store the value in local storage.
