### PR TITLE
Feat/remove form of contract and add pricing info

### DIFF
--- a/src/front-end/sass/index.scss
+++ b/src/front-end/sass/index.scss
@@ -954,6 +954,29 @@ nav.navbar .nav-link:hover {
   z-index: 1001; // Above nav, below modals
 }
 
+.li-paren {
+  counter-reset: list;
+  & > li {
+    list-style: none;
+  }
+  & > li:before {
+    font-weight: $font-weight-bold;
+    counter-increment: list;
+  }
+  &-lower-roman {
+    @extend .li-paren;
+    & > li:before {
+      content: counter(list, lower-roman) ") ";
+    }
+  }
+  &-lower-alpha {
+    @extend .li-paren;
+    & > li:before {
+      content: counter(list, lower-alpha) ") ";
+    }
+  }
+}
+
 // Page-specific overrides
 
 .route-orgSWUTerms,

--- a/src/front-end/typescript/lib/pages/opportunity/team-with-us/lib/components/form.tsx
+++ b/src/front-end/typescript/lib/pages/opportunity/team-with-us/lib/components/form.tsx
@@ -1473,7 +1473,7 @@ const DescriptionView: component_.base.View<Props> = ({
       <Col xs="12">
         <RichMarkdownEditor.view
           required
-          label="Description"
+          label="Description and Contract Details"
           placeholder="Describe this opportunity."
           help="Provide a complete description of the opportunity. For example, you may choose to include background information, a description of what you are attempting to accomplish by offering the opportunity, etc. You can format this description with Markdown."
           extraChildProps={{

--- a/src/front-end/typescript/lib/pages/opportunity/team-with-us/view.tsx
+++ b/src/front-end/typescript/lib/pages/opportunity/team-with-us/view.tsx
@@ -1,8 +1,4 @@
-import {
-  EMPTY_STRING,
-  TWU_OPPORTUNITY_SCOPE_CONTENT_ID,
-  TWU_QUALIFICATION_TERMS_ID
-} from "front-end/config";
+import { EMPTY_STRING, TWU_QUALIFICATION_TERMS_ID } from "front-end/config";
 import {
   makePageMetadata,
   makeStartLoading,
@@ -49,12 +45,7 @@ import {
   doesOrganizationProvideServiceArea
 } from "shared/lib/resources/organization";
 
-type InfoTab =
-  | "details"
-  | "scope"
-  | "competitionRules"
-  | "attachments"
-  | "addenda";
+type InfoTab = "details" | "competitionRules" | "attachments" | "addenda";
 
 type Qualification =
   | "notQualified"
@@ -68,7 +59,6 @@ export interface State {
   viewerUser: User | null;
   activeInfoTab: InfoTab;
   routePath: string;
-  scopeContent: string;
   competitionRulesContent: string;
   qualification: Qualification;
 }
@@ -81,7 +71,6 @@ export type InnerMsg =
         string,
         api.ResponseValidation<TWUOpportunity, string[]>,
         TWUProposalSlim | null,
-        api.ResponseValidation<Content, string[]>,
         api.ResponseValidation<Content, string[]>,
         api.ResponseValidation<OrganizationSlim[], string[]>
       ]
@@ -113,7 +102,6 @@ const init: component_.page.Init<
       existingProposal: null,
       activeInfoTab: "details",
       routePath,
-      scopeContent: "",
       competitionRulesContent: "",
       qualification: "notQualified"
     },
@@ -123,7 +111,7 @@ const init: component_.page.Init<
         null,
         () => adt("noop")
       ),
-      component_.cmd.join5(
+      component_.cmd.join4(
         api.opportunities.twu.readOne()(opportunityId, (response) => response),
         viewerUser && isVendor(viewerUser)
           ? api.proposals.twu.readExistingProposalForOpportunity(
@@ -132,10 +120,6 @@ const init: component_.page.Init<
             )
           : component_.cmd.dispatch(null),
         api.content.readOne()(
-          TWU_OPPORTUNITY_SCOPE_CONTENT_ID,
-          (response) => response
-        ),
-        api.content.readOne()(
           TWU_QUALIFICATION_TERMS_ID,
           (response) => response
         ),
@@ -143,7 +127,6 @@ const init: component_.page.Init<
         (
           opportunityResponse,
           proposalResponse,
-          scopeContentResponse,
           competitionRulesContentResponse,
           organizationsResponse
         ) =>
@@ -151,7 +134,6 @@ const init: component_.page.Init<
             routePath,
             opportunityResponse,
             proposalResponse,
-            scopeContentResponse,
             competitionRulesContentResponse,
             organizationsResponse
           ]) as Msg
@@ -173,7 +155,6 @@ const update: component_.page.Update<State, InnerMsg, Route> = ({
         routePath,
         opportunityResponse,
         proposalResponse,
-        scopeContentResponse,
         competitionRulesContentResponse,
         organizationsResponse
       ] = msg.value;
@@ -194,9 +175,6 @@ const update: component_.page.Update<State, InnerMsg, Route> = ({
 
       if (proposalResponse) {
         state = state.set("existingProposal", proposalResponse);
-      }
-      if (scopeContentResponse && api.isValid(scopeContentResponse)) {
-        state = state.set("scopeContent", scopeContentResponse.value.body);
       }
       if (
         competitionRulesContentResponse &&
@@ -500,19 +478,6 @@ const InfoDetails: component_.base.ComponentView<State, Msg> = ({ state }) => {
   );
 };
 
-const InfoScope: component_.base.ComponentView<State, Msg> = ({ state }) => {
-  return (
-    <Row>
-      <Col xs="12">
-        <h3 className="mb-0">Form of Contract</h3>
-      </Col>
-      <Col xs="12" className="mt-4">
-        <Markdown source={state.scopeContent} openLinksInNewTabs />
-      </Col>
-    </Row>
-  );
-};
-
 const InfoCompetitionRules: component_.base.ComponentView<State, Msg> = ({
   state
 }) => {
@@ -585,10 +550,6 @@ const InfoTabs: component_.base.ComponentView<State, Msg> = ({
       text: "Details"
     },
     {
-      ...getTabInfo("scope"),
-      text: "Form of Contract"
-    },
-    {
       ...getTabInfo("competitionRules"),
       text: "Competition Rules"
     },
@@ -619,8 +580,6 @@ const Info: component_.base.ComponentView<State, Msg> = (props) => {
     switch (state.activeInfoTab) {
       case "details":
         return <InfoDetails {...props} />;
-      case "scope":
-        return <InfoScope {...props} />;
       case "competitionRules":
         return <InfoCompetitionRules {...props} />;
       case "attachments":

--- a/src/front-end/typescript/lib/pages/opportunity/team-with-us/view.tsx
+++ b/src/front-end/typescript/lib/pages/opportunity/team-with-us/view.tsx
@@ -459,7 +459,10 @@ const InfoDetails: component_.base.ComponentView<State, Msg> = ({ state }) => {
         ) : null}
       </Col>
       <Col xs="12" className="mt-5">
-        <InfoDetailsHeading icon="info-circle-outline" text="Description" />
+        <InfoDetailsHeading
+          icon="info-circle-outline"
+          text="Description and Contract Details"
+        />
         <Markdown
           source={opp.description || EMPTY_STRING}
           smallerHeadings

--- a/src/front-end/typescript/lib/pages/proposal/team-with-us/lib/components/form.tsx
+++ b/src/front-end/typescript/lib/pages/proposal/team-with-us/lib/components/form.tsx
@@ -762,6 +762,28 @@ const ResourceQuestionsView: component_.base.View<Props> = ({
   return (
     <Row>
       <Col xs="12">
+        <p className="font-weight-bold">
+          General Instructions for Team with Us Proposal Response Form:
+        </p>
+        <ul>
+          <li>
+            This Proposal Response Form includes response guidelines which are
+            intended to assist Proponents in the development of their Proposals.
+          </li>
+          <li>
+            The response guidelines are not intended to be comprehensive.
+            Proponents should use their own judgement in determining what
+            information to provide to demonstrate that the Proponent meets or,
+            if applicable exceeds the Province’s expectations with respect to a
+            particular response guideline.
+          </li>
+          <li>
+            Proposals should not contain links to information that is not set
+            down directly in the Proponent’s Proposal. Should this occur, the
+            Province may disregard any referred to source of information that is
+            not contained in the Proposal being evaluated.
+          </li>
+        </ul>
         <p className="mb-4">
           Provide a response to each of the team questions below. Please note
           that responses that exceed the word limit will receive a score of

--- a/src/front-end/typescript/lib/pages/proposal/team-with-us/lib/components/form.tsx
+++ b/src/front-end/typescript/lib/pages/proposal/team-with-us/lib/components/form.tsx
@@ -676,6 +676,56 @@ const PricingView: component_.base.View<Props> = ({
     <div>
       <Row>
         <Col xs="12" className="mb-4">
+          <p className="font-weight-bold">
+            Proponents take note of the following pricing rules and
+            requirements:
+          </p>
+          <ol className="li-paren-lower-alpha">
+            <li>
+              Proponent pricing quoted will be taken to mean and deemed to be:
+              <ol className="li-paren-lower-roman">
+                <li>in Canadian dollars;</li>
+                <li>
+                  inclusive of all costs or expenses that may be incurred with
+                  respect to the services specified by the Competition Notice;
+                </li>
+                <li>exclusive of any applicable taxes.</li>
+              </ol>
+            </li>
+            <li>
+              In addition, the following rules apply to pricing bid by
+              Proponents:
+              <ol className="li-paren-lower-roman">
+                <li>
+                  Team With Us Terms & Conditions section 1.8 regarding pricing
+                  and its provisions are incorporated herein by this reference.
+                </li>
+                <li>
+                  All pricing bid is required to be unconditional and
+                  unqualified. If any pricing bid does not meet this
+                  requirement, the Proponent’s Proposal may be rejected
+                  resulting in the Proponent being eliminated from the
+                  Competition Notice competition.
+                </li>
+                <li>
+                  Failure to provide pricing where required by the Competition
+                  Notice will result in the Proponent being unable to submit a
+                  Proposal.
+                </li>
+                <li>
+                  Entering the numerical figure of “$0”, “$zero”, or the like in
+                  response to a call for a specific dollar amount will result in
+                  the Proponent being unable to submit a Proposal.
+                </li>
+                <li>
+                  The Contract will provide that the Contractor may request an
+                  increase in the bid pricing for any extension term of the
+                  Contract, limited to any increases, if any, as supported by
+                  the Canadian Consumer Price Index or 3% whichever is lower.
+                </li>
+              </ol>
+            </li>
+          </ol>
           <p>
             Please provide the hourly rate you are proposing for this
             opportunity.


### PR DESCRIPTION
This PR closes issues: [DMM-128, DMM-130, DMM-132]

Includes tests? [N]
Updated docs? [N]

Proposed changes:
- Remove Form of Contract tab
- Rename Description field to Description and Contract in TWU
- Add pricing information to TWU proposal form
- Add general information to TWU proposal form

Additional notes:
- May revert Form of Contract tab deletion in the future