### PR TITLE
Refactor/rename disqualified

### DIFF
--- a/src/back-end/lib/mailer/notifications/proposal/code-with-us.tsx
+++ b/src/back-end/lib/mailer/notifications/proposal/code-with-us.tsx
@@ -353,9 +353,9 @@ export async function disqualifiedCWUProposalSubmissionT(
   opportunity: CWUOpportunity,
   proposal: CWUProposal | CWUProposalSlim
 ): Promise<Emails> {
-  const title = "Your Code With Us Proposal Has Been Disqualified";
+  const title = "Your Code With Us Proposal Has Been Deemed Non-Compliant";
   const description =
-    "The proposal that you submitted for the following Digital Marketplace opportunity has been disqualified:";
+    "The proposal that you submitted for the following Digital Marketplace opportunity was deemed non-compliant and will not be considered any further:";
   return [
     {
       to: recipient.email || [],
@@ -366,6 +366,10 @@ export async function disqualifiedCWUProposalSubmissionT(
         descriptionLists: [makeCWUOpportunityInformation(opportunity)],
         body: (
           <div>
+            <p>
+              We appreciate the time and effort you put into creating your
+              proposal. Thank you for your interest in this opportunity.
+            </p>
             <p>
               If you have any questions, please send an email to{" "}
               <templates.Link text={CONTACT_EMAIL} url={CONTACT_EMAIL} />.

--- a/src/back-end/lib/mailer/notifications/proposal/sprint-with-us.tsx
+++ b/src/back-end/lib/mailer/notifications/proposal/sprint-with-us.tsx
@@ -362,9 +362,9 @@ export async function disqualifiedSWUProposalSubmissionT(
   opportunity: SWUOpportunity,
   proposal: SWUProposal | SWUProposalSlim
 ): Promise<Emails> {
-  const title = "Your Sprint With Us Proposal Has Been Disqualified";
+  const title = "Your Sprint With Us Proposal Has Been Deemed Non-Compliant";
   const description =
-    "The proposal that you submitted for the following Digital Marketplace opportunity has been disqualified:";
+    "The proposal that you submitted for the following Digital Marketplace opportunity was deemed non-compliant and will not be considered any further:";
   return [
     {
       to: recipient.email || [],
@@ -375,6 +375,10 @@ export async function disqualifiedSWUProposalSubmissionT(
         descriptionLists: [makeSWUOpportunityInformation(opportunity)],
         body: (
           <div>
+            <p>
+              We appreciate the time and effort you put into creating your
+              proposal. Thank you for your interest in this opportunity.
+            </p>
             <p>
               If you have any questions, please send an email to{" "}
               <templates.Link text={CONTACT_EMAIL} url={CONTACT_EMAIL} />.

--- a/src/back-end/lib/mailer/notifications/proposal/team-with-us.tsx
+++ b/src/back-end/lib/mailer/notifications/proposal/team-with-us.tsx
@@ -362,9 +362,9 @@ export async function disqualifiedTWUProposalSubmissionT(
   opportunity: TWUOpportunity,
   proposal: TWUProposal | TWUProposalSlim
 ): Promise<Emails> {
-  const title = "Your Team With Us Proposal Has Been Disqualified";
+  const title = "Your Team With Us Proposal Has Been Deemed Non-Compliant";
   const description =
-    "The proposal that you submitted for the following Digital Marketplace opportunity has been disqualified:";
+    "The proposal that you submitted for the following Digital Marketplace opportunity was deemed non-compliant and will not be considered any further:";
   return [
     {
       to: recipient.email || [],
@@ -375,6 +375,10 @@ export async function disqualifiedTWUProposalSubmissionT(
         descriptionLists: [makeTWUOpportunityInformation(opportunity)],
         body: (
           <div>
+            <p>
+              We appreciate the time and effort you put into creating your
+              proposal. Thank you for your interest in this opportunity.
+            </p>
             <p>
               If you have any questions, please send an email to{" "}
               <templates.Link text={CONTACT_EMAIL} url={CONTACT_EMAIL} />.

--- a/src/front-end/typescript/lib/pages/proposal/code-with-us/lib/index.ts
+++ b/src/front-end/typescript/lib/pages/proposal/code-with-us/lib/index.ts
@@ -47,7 +47,7 @@ export function cwuProposalStatusToTitleCase(
     case CWUProposalStatus.NotAwarded:
       return "Not Awarded";
     case CWUProposalStatus.Disqualified:
-      return "Disqualified";
+      return "Non-compliant";
     case CWUProposalStatus.Withdrawn:
       return "Withdrawn";
   }
@@ -92,6 +92,6 @@ export function cwuProposalStatusToPastTenseVerb(s: CWUProposalStatus): string {
     case CWUProposalStatus.Evaluated:
       return "Scored";
     default:
-      return "Update";
+      return "Updated";
   }
 }

--- a/src/front-end/typescript/lib/pages/proposal/sprint-with-us/lib/index.ts
+++ b/src/front-end/typescript/lib/pages/proposal/sprint-with-us/lib/index.ts
@@ -69,7 +69,7 @@ export function swuProposalStatusToTitleCase(
     case SWUProposalStatus.NotAwarded:
       return "Not Awarded";
     case SWUProposalStatus.Disqualified:
-      return "Disqualified";
+      return "Non-compliant";
     case SWUProposalStatus.Withdrawn:
       return "Withdrawn";
   }
@@ -116,6 +116,6 @@ export function swuProposalStatusToPastTenseVerb(s: SWUProposalStatus): string {
     case SWUProposalStatus.Withdrawn:
       return "Withdrawn";
     default:
-      return "Update";
+      return "Updated";
   }
 }

--- a/src/front-end/typescript/lib/pages/proposal/team-with-us/lib/index.ts
+++ b/src/front-end/typescript/lib/pages/proposal/team-with-us/lib/index.ts
@@ -59,7 +59,7 @@ export function twuProposalStatusToTitleCase(
     case TWUProposalStatus.NotAwarded:
       return "Not Awarded";
     case TWUProposalStatus.Disqualified:
-      return "Disqualified";
+      return "Non-compliant";
     case TWUProposalStatus.Withdrawn:
       return "Withdrawn";
   }
@@ -107,6 +107,6 @@ export function twuProposalStatusToPastTenseVerb(s: TWUProposalStatus): string {
     case TWUProposalStatus.EvaluatedChallenge:
       return "Scored";
     default:
-      return "Update";
+      return "Updated";
   }
 }


### PR DESCRIPTION
This PR closes issue: [DMM-131]

Includes tests? [N]
Updated docs? [N]

Proposed changes:
- Rename disqualified labels to non-compliant
- Remove disqualification language from email templates

Additional notes:
- Modified email language provided by Jason Taylor