### PR TITLE
Feat/add user friendly guide routes

### DIFF
--- a/src/front-end/typescript/lib/app/router.ts
+++ b/src/front-end/typescript/lib/app/router.ts
@@ -584,6 +584,12 @@ const router: router_.Router<Route> = {
       }
     },
     {
+      path: prefixPath("/twu/vendor-guide"),
+      makeRoute() {
+        return adt("twuVendorGuide", null);
+      }
+    },
+    {
       path: "(.*)",
       makeRoute({ path }) {
         return adt("notFound", { path });
@@ -817,6 +823,8 @@ const router: router_.Router<Route> = {
         })();
       case "twuMinistryGuide":
         return prefixPath("/twu/ministry-guide");
+      case "twuVendorGuide":
+        return prefixPath("/twu/vendor-guide");
       case "notFound":
         return route.value.path || prefixPath("/not-found");
     }

--- a/src/front-end/typescript/lib/app/router.ts
+++ b/src/front-end/typescript/lib/app/router.ts
@@ -602,6 +602,12 @@ const router: router_.Router<Route> = {
       }
     },
     {
+      path: prefixPath("/swu/ministry-guide"),
+      makeRoute() {
+        return adt("swuMinistryGuide", null);
+      }
+    },
+    {
       path: "(.*)",
       makeRoute({ path }) {
         return adt("notFound", { path });
@@ -841,6 +847,8 @@ const router: router_.Router<Route> = {
         return prefixPath("/cwu/ministry-guide");
       case "cwuVendorGuide":
         return prefixPath("/cwu/vendor-guide");
+      case "swuMinistryGuide":
+        return prefixPath("/swu/ministry-guide");
       case "notFound":
         return route.value.path || prefixPath("/not-found");
     }

--- a/src/front-end/typescript/lib/app/router.ts
+++ b/src/front-end/typescript/lib/app/router.ts
@@ -2,6 +2,7 @@ import { prefixPath } from "front-end/lib";
 import { Route } from "front-end/lib/app/types";
 import { component, router as router_ } from "front-end/lib/framework";
 import * as PageNotice from "front-end/lib/pages/notice";
+import * as PageGuide from "front-end/lib/pages/guide/view";
 import * as CWUOpportunityEditTab from "front-end/lib/pages/opportunity/code-with-us/edit/tab";
 import * as SWUOpportunityEditTab from "front-end/lib/pages/opportunity/sprint-with-us/edit/tab";
 import * as TWUOpportunityEditTab from "front-end/lib/pages/opportunity/team-with-us/edit/tab";
@@ -578,39 +579,27 @@ const router: router_.Router<Route> = {
       }
     },
     {
-      path: prefixPath("/twu/ministry-guide"),
-      makeRoute() {
-        return adt("twuMinistryGuide", null);
+      path: prefixPath("/cwu/:guideAudience"),
+      makeRoute({ path, params }) {
+        return PageGuide.isGuideAudience(params.guideAudience)
+          ? adt("cwuGuide", { guideAudience: params.guideAudience })
+          : adt("notFound", { path });
       }
     },
     {
-      path: prefixPath("/twu/vendor-guide"),
-      makeRoute() {
-        return adt("twuVendorGuide", null);
+      path: prefixPath("/swu/:guideAudience"),
+      makeRoute({ path, params }) {
+        return PageGuide.isGuideAudience(params.guideAudience)
+          ? adt("swuGuide", { guideAudience: params.guideAudience })
+          : adt("notFound", { path });
       }
     },
     {
-      path: prefixPath("/cwu/ministry-guide"),
-      makeRoute() {
-        return adt("cwuMinistryGuide", null);
-      }
-    },
-    {
-      path: prefixPath("/cwu/vendor-guide"),
-      makeRoute() {
-        return adt("cwuVendorGuide", null);
-      }
-    },
-    {
-      path: prefixPath("/swu/ministry-guide"),
-      makeRoute() {
-        return adt("swuMinistryGuide", null);
-      }
-    },
-    {
-      path: prefixPath("/swu/vendor-guide"),
-      makeRoute() {
-        return adt("swuVendorGuide", null);
+      path: prefixPath("/twu/:guideAudience"),
+      makeRoute({ path, params }) {
+        return PageGuide.isGuideAudience(params.guideAudience)
+          ? adt("twuGuide", { guideAudience: params.guideAudience })
+          : adt("notFound", { path });
       }
     },
     {
@@ -845,18 +834,12 @@ const router: router_.Router<Route> = {
               return prefixPath(`/notice/${route.value.tag}`);
           }
         })();
-      case "twuMinistryGuide":
-        return prefixPath("/twu/ministry-guide");
-      case "twuVendorGuide":
-        return prefixPath("/twu/vendor-guide");
-      case "cwuMinistryGuide":
-        return prefixPath("/cwu/ministry-guide");
-      case "cwuVendorGuide":
-        return prefixPath("/cwu/vendor-guide");
-      case "swuMinistryGuide":
-        return prefixPath("/swu/ministry-guide");
-      case "swuVendorGuide":
-        return prefixPath("/swu/vendor-guide");
+      case "cwuGuide":
+        return prefixPath(`/cwu/${route.value.guideAudience}`);
+      case "swuGuide":
+        return prefixPath(`/swu/${route.value.guideAudience}`);
+      case "twuGuide":
+        return prefixPath(`/twu/${route.value.guideAudience}`);
       case "notFound":
         return route.value.path || prefixPath("/not-found");
     }

--- a/src/front-end/typescript/lib/app/router.ts
+++ b/src/front-end/typescript/lib/app/router.ts
@@ -608,6 +608,12 @@ const router: router_.Router<Route> = {
       }
     },
     {
+      path: prefixPath("/swu/vendor-guide"),
+      makeRoute() {
+        return adt("swuVendorGuide", null);
+      }
+    },
+    {
       path: "(.*)",
       makeRoute({ path }) {
         return adt("notFound", { path });
@@ -849,6 +855,8 @@ const router: router_.Router<Route> = {
         return prefixPath("/cwu/vendor-guide");
       case "swuMinistryGuide":
         return prefixPath("/swu/ministry-guide");
+      case "swuVendorGuide":
+        return prefixPath("/swu/vendor-guide");
       case "notFound":
         return route.value.path || prefixPath("/not-found");
     }

--- a/src/front-end/typescript/lib/app/router.ts
+++ b/src/front-end/typescript/lib/app/router.ts
@@ -596,6 +596,12 @@ const router: router_.Router<Route> = {
       }
     },
     {
+      path: prefixPath("/cwu/vendor-guide"),
+      makeRoute() {
+        return adt("cwuVendorGuide", null);
+      }
+    },
+    {
       path: "(.*)",
       makeRoute({ path }) {
         return adt("notFound", { path });
@@ -833,6 +839,8 @@ const router: router_.Router<Route> = {
         return prefixPath("/twu/vendor-guide");
       case "cwuMinistryGuide":
         return prefixPath("/cwu/ministry-guide");
+      case "cwuVendorGuide":
+        return prefixPath("/cwu/vendor-guide");
       case "notFound":
         return route.value.path || prefixPath("/not-found");
     }

--- a/src/front-end/typescript/lib/app/router.ts
+++ b/src/front-end/typescript/lib/app/router.ts
@@ -590,6 +590,12 @@ const router: router_.Router<Route> = {
       }
     },
     {
+      path: prefixPath("/cwu/ministry-guide"),
+      makeRoute() {
+        return adt("cwuMinistryGuide", null);
+      }
+    },
+    {
       path: "(.*)",
       makeRoute({ path }) {
         return adt("notFound", { path });
@@ -825,6 +831,8 @@ const router: router_.Router<Route> = {
         return prefixPath("/twu/ministry-guide");
       case "twuVendorGuide":
         return prefixPath("/twu/vendor-guide");
+      case "cwuMinistryGuide":
+        return prefixPath("/cwu/ministry-guide");
       case "notFound":
         return route.value.path || prefixPath("/not-found");
     }

--- a/src/front-end/typescript/lib/app/router.ts
+++ b/src/front-end/typescript/lib/app/router.ts
@@ -578,6 +578,12 @@ const router: router_.Router<Route> = {
       }
     },
     {
+      path: prefixPath("/twu/ministry-guide"),
+      makeRoute() {
+        return adt("twuMinistryGuide", null);
+      }
+    },
+    {
       path: "(.*)",
       makeRoute({ path }) {
         return adt("notFound", { path });
@@ -809,6 +815,8 @@ const router: router_.Router<Route> = {
               return prefixPath(`/notice/${route.value.tag}`);
           }
         })();
+      case "twuMinistryGuide":
+        return prefixPath("/twu/ministry-guide");
       case "notFound":
         return route.value.path || prefixPath("/not-found");
     }

--- a/src/front-end/typescript/lib/app/types.ts
+++ b/src/front-end/typescript/lib/app/types.ts
@@ -114,7 +114,8 @@ export type Route =
   | ADT<"twuMinistryGuide", null>
   | ADT<"twuVendorGuide", null>
   | ADT<"cwuMinistryGuide", null>
-  | ADT<"cwuVendorGuide", null>;
+  | ADT<"cwuVendorGuide", null>
+  | ADT<"swuMinistryGuide", null>;
 
 /**
  * Used when users sign up but have yet to complete step 2 which involves accepting general app terms.

--- a/src/front-end/typescript/lib/app/types.ts
+++ b/src/front-end/typescript/lib/app/types.ts
@@ -115,7 +115,8 @@ export type Route =
   | ADT<"twuVendorGuide", null>
   | ADT<"cwuMinistryGuide", null>
   | ADT<"cwuVendorGuide", null>
-  | ADT<"swuMinistryGuide", null>;
+  | ADT<"swuMinistryGuide", null>
+  | ADT<"swuVendorGuide", null>;
 
 /**
  * Used when users sign up but have yet to complete step 2 which involves accepting general app terms.

--- a/src/front-end/typescript/lib/app/types.ts
+++ b/src/front-end/typescript/lib/app/types.ts
@@ -113,7 +113,8 @@ export type Route =
   | ADT<"proposalList", PageProposalList.RouteParams>
   | ADT<"twuMinistryGuide", null>
   | ADT<"twuVendorGuide", null>
-  | ADT<"cwuMinistryGuide", null>;
+  | ADT<"cwuMinistryGuide", null>
+  | ADT<"cwuVendorGuide", null>;
 
 /**
  * Used when users sign up but have yet to complete step 2 which involves accepting general app terms.

--- a/src/front-end/typescript/lib/app/types.ts
+++ b/src/front-end/typescript/lib/app/types.ts
@@ -110,7 +110,8 @@ export type Route =
   | ADT<"proposalCWUView", PageProposalCWUView.RouteParams>
   | ADT<"proposalCWUExportOne", PageProposalCWUExportOne.RouteParams>
   | ADT<"proposalCWUExportAll", PageProposalCWUExportAll.RouteParams>
-  | ADT<"proposalList", PageProposalList.RouteParams>;
+  | ADT<"proposalList", PageProposalList.RouteParams>
+  | ADT<"twuMinistryGuide", null>;
 
 /**
  * Used when users sign up but have yet to complete step 2 which involves accepting general app terms.

--- a/src/front-end/typescript/lib/app/types.ts
+++ b/src/front-end/typescript/lib/app/types.ts
@@ -6,6 +6,7 @@ import * as api from "front-end/lib/http/api";
 import * as PageContentEdit from "front-end/lib/pages/content/edit";
 import * as PageContentList from "front-end/lib/pages/content/list";
 import * as PageContentView from "front-end/lib/pages/content/view";
+import * as PageGuideView from "front-end/lib/pages/guide/view";
 import * as PageDashboard from "front-end/lib/pages/dashboard";
 import * as PageLanding from "front-end/lib/pages/landing";
 import * as PageLearnMoreCWU from "front-end/lib/pages/learn-more/code-with-us";
@@ -111,12 +112,9 @@ export type Route =
   | ADT<"proposalCWUExportOne", PageProposalCWUExportOne.RouteParams>
   | ADT<"proposalCWUExportAll", PageProposalCWUExportAll.RouteParams>
   | ADT<"proposalList", PageProposalList.RouteParams>
-  | ADT<"twuMinistryGuide", null>
-  | ADT<"twuVendorGuide", null>
-  | ADT<"cwuMinistryGuide", null>
-  | ADT<"cwuVendorGuide", null>
-  | ADT<"swuMinistryGuide", null>
-  | ADT<"swuVendorGuide", null>;
+  | ADT<"cwuGuide", PageGuideView.RouteParams>
+  | ADT<"swuGuide", PageGuideView.RouteParams>
+  | ADT<"twuGuide", PageGuideView.RouteParams>;
 
 /**
  * Used when users sign up but have yet to complete step 2 which involves accepting general app terms.

--- a/src/front-end/typescript/lib/app/types.ts
+++ b/src/front-end/typescript/lib/app/types.ts
@@ -112,7 +112,8 @@ export type Route =
   | ADT<"proposalCWUExportAll", PageProposalCWUExportAll.RouteParams>
   | ADT<"proposalList", PageProposalList.RouteParams>
   | ADT<"twuMinistryGuide", null>
-  | ADT<"twuVendorGuide", null>;
+  | ADT<"twuVendorGuide", null>
+  | ADT<"cwuMinistryGuide", null>;
 
 /**
  * Used when users sign up but have yet to complete step 2 which involves accepting general app terms.

--- a/src/front-end/typescript/lib/app/types.ts
+++ b/src/front-end/typescript/lib/app/types.ts
@@ -111,7 +111,8 @@ export type Route =
   | ADT<"proposalCWUExportOne", PageProposalCWUExportOne.RouteParams>
   | ADT<"proposalCWUExportAll", PageProposalCWUExportAll.RouteParams>
   | ADT<"proposalList", PageProposalList.RouteParams>
-  | ADT<"twuMinistryGuide", null>;
+  | ADT<"twuMinistryGuide", null>
+  | ADT<"twuVendorGuide", null>;
 
 /**
  * Used when users sign up but have yet to complete step 2 which involves accepting general app terms.

--- a/src/front-end/typescript/lib/app/update.ts
+++ b/src/front-end/typescript/lib/app/update.ts
@@ -557,6 +557,18 @@ function initPage(
         }
       });
 
+    case "twuMinistryGuide":
+      return component.app.initPage({
+        ...defaultPageInitParams,
+        pageStatePath: ["pages", "contentView"],
+        pageRouteParams: "team-with-us-opportunity-guide",
+        pageInit: PageContentView.component.init,
+        pageGetMetadata: PageContentView.component.getMetadata,
+        mapPageMsg(value) {
+          return adt("pageContentView", value);
+        }
+      });
+
     case "contentView":
       return component.app.initPage({
         ...defaultPageInitParams,

--- a/src/front-end/typescript/lib/app/update.ts
+++ b/src/front-end/typescript/lib/app/update.ts
@@ -19,6 +19,7 @@ import * as PageContentCreate from "front-end/lib/pages/content/create";
 import * as PageContentEdit from "front-end/lib/pages/content/edit";
 import * as PageContentList from "front-end/lib/pages/content/list";
 import * as PageContentView from "front-end/lib/pages/content/view";
+import * as PageGuideView from "front-end/lib/pages/guide/view";
 import * as PageDashboard from "front-end/lib/pages/dashboard";
 import * as PageLanding from "front-end/lib/pages/landing";
 import * as PageLearnMoreCWU from "front-end/lib/pages/learn-more/code-with-us";
@@ -557,72 +558,14 @@ function initPage(
         }
       });
 
-    case "twuMinistryGuide":
+    case "cwuGuide":
+    case "swuGuide":
+    case "twuGuide":
       return component.app.initPage({
         ...defaultPageInitParams,
         pageStatePath: ["pages", "contentView"],
-        pageRouteParams: "team-with-us-opportunity-guide",
-        pageInit: PageContentView.component.init,
-        pageGetMetadata: PageContentView.component.getMetadata,
-        mapPageMsg(value) {
-          return adt("pageContentView", value);
-        }
-      });
-
-    case "twuVendorGuide":
-      return component.app.initPage({
-        ...defaultPageInitParams,
-        pageStatePath: ["pages", "contentView"],
-        pageRouteParams: "team-with-us-proposal-guide",
-        pageInit: PageContentView.component.init,
-        pageGetMetadata: PageContentView.component.getMetadata,
-        mapPageMsg(value) {
-          return adt("pageContentView", value);
-        }
-      });
-
-    case "cwuMinistryGuide":
-      return component.app.initPage({
-        ...defaultPageInitParams,
-        pageStatePath: ["pages", "contentView"],
-        pageRouteParams: "code-with-us-opportunity-guide",
-        pageInit: PageContentView.component.init,
-        pageGetMetadata: PageContentView.component.getMetadata,
-        mapPageMsg(value) {
-          return adt("pageContentView", value);
-        }
-      });
-
-    case "cwuVendorGuide":
-      return component.app.initPage({
-        ...defaultPageInitParams,
-        pageStatePath: ["pages", "contentView"],
-        pageRouteParams: "code-with-us-proposal-guide",
-        pageInit: PageContentView.component.init,
-        pageGetMetadata: PageContentView.component.getMetadata,
-        mapPageMsg(value) {
-          return adt("pageContentView", value);
-        }
-      });
-
-    case "swuMinistryGuide":
-      return component.app.initPage({
-        ...defaultPageInitParams,
-        pageStatePath: ["pages", "contentView"],
-        pageRouteParams: "sprint-with-us-opportunity-guide",
-        pageInit: PageContentView.component.init,
-        pageGetMetadata: PageContentView.component.getMetadata,
-        mapPageMsg(value) {
-          return adt("pageContentView", value);
-        }
-      });
-
-    case "swuVendorGuide":
-      return component.app.initPage({
-        ...defaultPageInitParams,
-        pageStatePath: ["pages", "contentView"],
-        pageRouteParams: "sprint-with-us-proposal-guide",
-        pageInit: PageContentView.component.init,
+        pageRouteParams: route.value,
+        pageInit: PageGuideView.init,
         pageGetMetadata: PageContentView.component.getMetadata,
         mapPageMsg(value) {
           return adt("pageContentView", value);

--- a/src/front-end/typescript/lib/app/update.ts
+++ b/src/front-end/typescript/lib/app/update.ts
@@ -593,6 +593,18 @@ function initPage(
         }
       });
 
+    case "cwuVendorGuide":
+      return component.app.initPage({
+        ...defaultPageInitParams,
+        pageStatePath: ["pages", "contentView"],
+        pageRouteParams: "code-with-us-proposal-guide",
+        pageInit: PageContentView.component.init,
+        pageGetMetadata: PageContentView.component.getMetadata,
+        mapPageMsg(value) {
+          return adt("pageContentView", value);
+        }
+      });
+
     case "contentView":
       return component.app.initPage({
         ...defaultPageInitParams,

--- a/src/front-end/typescript/lib/app/update.ts
+++ b/src/front-end/typescript/lib/app/update.ts
@@ -581,6 +581,18 @@ function initPage(
         }
       });
 
+    case "cwuMinistryGuide":
+      return component.app.initPage({
+        ...defaultPageInitParams,
+        pageStatePath: ["pages", "contentView"],
+        pageRouteParams: "code-with-us-opportunity-guide",
+        pageInit: PageContentView.component.init,
+        pageGetMetadata: PageContentView.component.getMetadata,
+        mapPageMsg(value) {
+          return adt("pageContentView", value);
+        }
+      });
+
     case "contentView":
       return component.app.initPage({
         ...defaultPageInitParams,

--- a/src/front-end/typescript/lib/app/update.ts
+++ b/src/front-end/typescript/lib/app/update.ts
@@ -617,6 +617,18 @@ function initPage(
         }
       });
 
+    case "swuVendorGuide":
+      return component.app.initPage({
+        ...defaultPageInitParams,
+        pageStatePath: ["pages", "contentView"],
+        pageRouteParams: "sprint-with-us-proposal-guide",
+        pageInit: PageContentView.component.init,
+        pageGetMetadata: PageContentView.component.getMetadata,
+        mapPageMsg(value) {
+          return adt("pageContentView", value);
+        }
+      });
+
     case "contentView":
       return component.app.initPage({
         ...defaultPageInitParams,

--- a/src/front-end/typescript/lib/app/update.ts
+++ b/src/front-end/typescript/lib/app/update.ts
@@ -569,6 +569,18 @@ function initPage(
         }
       });
 
+    case "twuVendorGuide":
+      return component.app.initPage({
+        ...defaultPageInitParams,
+        pageStatePath: ["pages", "contentView"],
+        pageRouteParams: "team-with-us-proposal-guide",
+        pageInit: PageContentView.component.init,
+        pageGetMetadata: PageContentView.component.getMetadata,
+        mapPageMsg(value) {
+          return adt("pageContentView", value);
+        }
+      });
+
     case "contentView":
       return component.app.initPage({
         ...defaultPageInitParams,

--- a/src/front-end/typescript/lib/app/update.ts
+++ b/src/front-end/typescript/lib/app/update.ts
@@ -605,6 +605,18 @@ function initPage(
         }
       });
 
+    case "swuMinistryGuide":
+      return component.app.initPage({
+        ...defaultPageInitParams,
+        pageStatePath: ["pages", "contentView"],
+        pageRouteParams: "sprint-with-us-opportunity-guide",
+        pageInit: PageContentView.component.init,
+        pageGetMetadata: PageContentView.component.getMetadata,
+        mapPageMsg(value) {
+          return adt("pageContentView", value);
+        }
+      });
+
     case "contentView":
       return component.app.initPage({
         ...defaultPageInitParams,

--- a/src/front-end/typescript/lib/app/view/index.tsx
+++ b/src/front-end/typescript/lib/app/view/index.tsx
@@ -173,6 +173,7 @@ function pageToViewPageProps(
     case "twuMinistryGuide":
     case "twuVendorGuide":
     case "cwuMinistryGuide":
+    case "cwuVendorGuide":
     case "contentView":
       return makeViewPageProps(
         props,

--- a/src/front-end/typescript/lib/app/view/index.tsx
+++ b/src/front-end/typescript/lib/app/view/index.tsx
@@ -171,6 +171,7 @@ function pageToViewPageProps(
       );
 
     case "twuMinistryGuide":
+    case "twuVendorGuide":
     case "contentView":
       return makeViewPageProps(
         props,

--- a/src/front-end/typescript/lib/app/view/index.tsx
+++ b/src/front-end/typescript/lib/app/view/index.tsx
@@ -172,6 +172,7 @@ function pageToViewPageProps(
 
     case "twuMinistryGuide":
     case "twuVendorGuide":
+    case "cwuMinistryGuide":
     case "contentView":
       return makeViewPageProps(
         props,

--- a/src/front-end/typescript/lib/app/view/index.tsx
+++ b/src/front-end/typescript/lib/app/view/index.tsx
@@ -170,12 +170,9 @@ function pageToViewPageProps(
         (value) => ({ tag: "pageLearnMoreSWU", value })
       );
 
-    case "twuMinistryGuide":
-    case "twuVendorGuide":
-    case "cwuMinistryGuide":
-    case "cwuVendorGuide":
-    case "swuMinistryGuide":
-    case "swuVendorGuide":
+    case "cwuGuide":
+    case "swuGuide":
+    case "twuGuide":
     case "contentView":
       return makeViewPageProps(
         props,

--- a/src/front-end/typescript/lib/app/view/index.tsx
+++ b/src/front-end/typescript/lib/app/view/index.tsx
@@ -175,6 +175,7 @@ function pageToViewPageProps(
     case "cwuMinistryGuide":
     case "cwuVendorGuide":
     case "swuMinistryGuide":
+    case "swuVendorGuide":
     case "contentView":
       return makeViewPageProps(
         props,

--- a/src/front-end/typescript/lib/app/view/index.tsx
+++ b/src/front-end/typescript/lib/app/view/index.tsx
@@ -170,6 +170,7 @@ function pageToViewPageProps(
         (value) => ({ tag: "pageLearnMoreSWU", value })
       );
 
+    case "twuMinistryGuide":
     case "contentView":
       return makeViewPageProps(
         props,

--- a/src/front-end/typescript/lib/app/view/index.tsx
+++ b/src/front-end/typescript/lib/app/view/index.tsx
@@ -174,6 +174,7 @@ function pageToViewPageProps(
     case "twuVendorGuide":
     case "cwuMinistryGuide":
     case "cwuVendorGuide":
+    case "swuMinistryGuide":
     case "contentView":
       return makeViewPageProps(
         props,

--- a/src/front-end/typescript/lib/pages/guide/view.ts
+++ b/src/front-end/typescript/lib/pages/guide/view.ts
@@ -1,0 +1,68 @@
+import { Route, SharedState } from "front-end/lib/app/types";
+import { immutable, component } from "front-end/lib/framework";
+import * as api from "front-end/lib/http/api";
+import { adt } from "shared/lib/types";
+import { valid } from "shared/lib/validation";
+import { InnerMsg, Msg, State } from "../content/view";
+import { ProgramType } from "front-end/lib/views/program-type";
+
+export const GUIDE_AUDIENCE = {
+  Vendor: "vendor-guide",
+  Ministry: "ministry-guide"
+} as const;
+export type GuideAudience = typeof GUIDE_AUDIENCE[keyof typeof GUIDE_AUDIENCE];
+
+export type RouteParams = {
+  guideAudience: GuideAudience;
+};
+
+export function isGuideAudience(
+  guideAudience?: string
+): guideAudience is GuideAudience {
+  return Object.values(GUIDE_AUDIENCE).includes(guideAudience as GuideAudience);
+}
+
+function programTypeToFirstProgramWord(programType: ProgramType): string {
+  switch (programType) {
+    case "cwu":
+      return "code";
+    case "swu":
+      return "sprint";
+    case "twu":
+      return "team";
+  }
+}
+
+function guideAudienceToProcurementArtifactType(
+  guideAudience: GuideAudience
+): string {
+  switch (guideAudience) {
+    case "ministry-guide":
+      return "opportunity";
+    case "vendor-guide":
+      return "proposal";
+  }
+}
+
+export const init: component.page.Init<
+  RouteParams,
+  SharedState,
+  State,
+  InnerMsg,
+  Route
+> = ({ routePath, routeParams }) => {
+  const contentSlug = `${programTypeToFirstProgramWord(
+    routePath.split("/")[1] as ProgramType
+  )}-with-us-${guideAudienceToProcurementArtifactType(
+    routeParams.guideAudience
+  )}-guide`;
+
+  return [
+    valid(immutable({ routePath, content: null })),
+    [
+      api.content.readOne<Msg>()(contentSlug, (msg) =>
+        adt("onContentResponse", msg)
+      )
+    ]
+  ];
+};

--- a/src/front-end/typescript/lib/pages/learn-more/code-with-us.tsx
+++ b/src/front-end/typescript/lib/pages/learn-more/code-with-us.tsx
@@ -13,6 +13,7 @@ import React from "react";
 import { Col, Container, Row } from "reactstrap";
 import { COPY } from "shared/config";
 import { ADT, adt } from "shared/lib/types";
+import { GUIDE_AUDIENCE } from "front-end/lib/pages/guide/view";
 
 export interface State {
   isVendorAccordionOpen: boolean;
@@ -123,7 +124,11 @@ const VendorView: component_.page.View<State, InnerMsg, Route> = ({
               <div className="d-flex flex-column flex-sm-row mt-5 flex-nowrap align-items-start align-items-sm-center">
                 <Link
                   button
-                  dest={routeDest(adt("cwuVendorGuide", null))}
+                  dest={routeDest(
+                    adt("cwuGuide", {
+                      guideAudience: GUIDE_AUDIENCE.Vendor
+                    })
+                  )}
                   color="info"
                   outline
                   symbol_={leftPlacement(iconLinkSymbol("book-user"))}
@@ -225,7 +230,11 @@ const PublicSectorView: component_.page.View<State, InnerMsg, Route> = ({
               <div className="d-flex flex-row mt-5 flex-nowrap">
                 <Link
                   button
-                  dest={routeDest(adt("cwuMinistryGuide", null))}
+                  dest={routeDest(
+                    adt("cwuGuide", {
+                      guideAudience: GUIDE_AUDIENCE.Ministry
+                    })
+                  )}
                   color="info"
                   outline
                   symbol_={leftPlacement(iconLinkSymbol("book-user"))}

--- a/src/front-end/typescript/lib/pages/learn-more/code-with-us.tsx
+++ b/src/front-end/typescript/lib/pages/learn-more/code-with-us.tsx
@@ -227,9 +227,7 @@ const PublicSectorView: component_.page.View<State, InnerMsg, Route> = ({
               <div className="d-flex flex-row mt-5 flex-nowrap">
                 <Link
                   button
-                  dest={routeDest(
-                    adt("contentView", "code-with-us-opportunity-guide")
-                  )}
+                  dest={routeDest(adt("cwuMinistryGuide", null))}
                   color="info"
                   outline
                   symbol_={leftPlacement(iconLinkSymbol("book-user"))}

--- a/src/front-end/typescript/lib/pages/learn-more/code-with-us.tsx
+++ b/src/front-end/typescript/lib/pages/learn-more/code-with-us.tsx
@@ -123,9 +123,7 @@ const VendorView: component_.page.View<State, InnerMsg, Route> = ({
               <div className="d-flex flex-column flex-sm-row mt-5 flex-nowrap align-items-start align-items-sm-center">
                 <Link
                   button
-                  dest={routeDest(
-                    adt("contentView", "code-with-us-proposal-guide")
-                  )}
+                  dest={routeDest(adt("cwuVendorGuide", null))}
                   color="info"
                   outline
                   symbol_={leftPlacement(iconLinkSymbol("book-user"))}

--- a/src/front-end/typescript/lib/pages/learn-more/team-with-us.tsx
+++ b/src/front-end/typescript/lib/pages/learn-more/team-with-us.tsx
@@ -122,9 +122,7 @@ const VendorView: component_.page.View<State, InnerMsg, Route> = ({
               <div className="d-flex flex-column flex-sm-row mt-5 flex-nowrap align-items-start align-items-sm-center">
                 <Link
                   button
-                  dest={routeDest(
-                    adt("contentView", "team-with-us-proposal-guide")
-                  )}
+                  dest={routeDest(adt("twuVendorGuide", null))}
                   color="info"
                   outline
                   symbol_={leftPlacement(iconLinkSymbol("book-user"))}
@@ -321,9 +319,7 @@ const PublicSectorView: component_.page.View<State, InnerMsg, Route> = ({
               <div className="d-flex flex-row mt-5 flex-nowrap">
                 <Link
                   button
-                  dest={routeDest(
-                    adt("contentView", "team-with-us-opportunity-guide")
-                  )}
+                  dest={routeDest(adt("twuMinistryGuide", null))}
                   color="info"
                   outline
                   symbol_={leftPlacement(iconLinkSymbol("book-user"))}

--- a/src/front-end/typescript/lib/pages/learn-more/team-with-us.tsx
+++ b/src/front-end/typescript/lib/pages/learn-more/team-with-us.tsx
@@ -16,6 +16,7 @@ import { Col, Container, Row } from "reactstrap";
 import { CONTACT_EMAIL, COPY, VENDOR_IDP_NAME } from "shared/config";
 import ALL_SERVICE_AREAS from "shared/lib/data/service-areas";
 import { ADT, adt } from "shared/lib/types";
+import { GUIDE_AUDIENCE } from "front-end/lib/pages/guide/view";
 
 export interface State {
   isVendorAccordionOpen: boolean;
@@ -122,7 +123,11 @@ const VendorView: component_.page.View<State, InnerMsg, Route> = ({
               <div className="d-flex flex-column flex-sm-row mt-5 flex-nowrap align-items-start align-items-sm-center">
                 <Link
                   button
-                  dest={routeDest(adt("twuVendorGuide", null))}
+                  dest={routeDest(
+                    adt("twuGuide", {
+                      guideAudience: GUIDE_AUDIENCE.Vendor
+                    })
+                  )}
                   color="info"
                   outline
                   symbol_={leftPlacement(iconLinkSymbol("book-user"))}
@@ -319,7 +324,11 @@ const PublicSectorView: component_.page.View<State, InnerMsg, Route> = ({
               <div className="d-flex flex-row mt-5 flex-nowrap">
                 <Link
                   button
-                  dest={routeDest(adt("twuMinistryGuide", null))}
+                  dest={routeDest(
+                    adt("twuGuide", {
+                      guideAudience: GUIDE_AUDIENCE.Ministry
+                    })
+                  )}
                   color="info"
                   outline
                   symbol_={leftPlacement(iconLinkSymbol("book-user"))}

--- a/src/front-end/typescript/lib/pages/opportunity/code-with-us/create.tsx
+++ b/src/front-end/typescript/lib/pages/opportunity/code-with-us/create.tsx
@@ -32,6 +32,7 @@ import {
 import { UserType } from "shared/lib/resources/user";
 import { adt, ADT } from "shared/lib/types";
 import { invalid, valid, Validation } from "shared/lib/validation";
+import { GUIDE_AUDIENCE } from "front-end/lib/pages/guide/view";
 
 type ModalId = "publish" | "cancel";
 
@@ -299,7 +300,13 @@ export const component: component_.page.Component<
       getFooter: () => (
         <span>
           Need help?{" "}
-          <Link newTab dest={routeDest(adt("cwuMinistryGuide", null))}>
+          <Link
+            newTab
+            dest={routeDest(
+              adt("cwuGuide", {
+                guideAudience: GUIDE_AUDIENCE.Ministry
+              })
+            )}>
             Read the guide
           </Link>{" "}
           to learn how to create and manage a <em>Code With Us</em> opportunity.

--- a/src/front-end/typescript/lib/pages/opportunity/code-with-us/create.tsx
+++ b/src/front-end/typescript/lib/pages/opportunity/code-with-us/create.tsx
@@ -299,11 +299,7 @@ export const component: component_.page.Component<
       getFooter: () => (
         <span>
           Need help?{" "}
-          <Link
-            newTab
-            dest={routeDest(
-              adt("contentView", "code-with-us-opportunity-guide")
-            )}>
+          <Link newTab dest={routeDest(adt("cwuMinistryGuide", null))}>
             Read the guide
           </Link>{" "}
           to learn how to create and manage a <em>Code With Us</em> opportunity.

--- a/src/front-end/typescript/lib/pages/opportunity/code-with-us/edit/tab/index.ts
+++ b/src/front-end/typescript/lib/pages/opportunity/code-with-us/edit/tab/index.ts
@@ -173,9 +173,7 @@ export function makeSidebarState(
             text: "Read Guide",
             active: false,
             newTab: true,
-            dest: routeDest(
-              adt("contentView", "code-with-us-opportunity-guide")
-            )
+            dest: routeDest(adt("cwuMinistryGuide", null))
           })
         ]
       : []

--- a/src/front-end/typescript/lib/pages/opportunity/code-with-us/edit/tab/index.ts
+++ b/src/front-end/typescript/lib/pages/opportunity/code-with-us/edit/tab/index.ts
@@ -14,6 +14,7 @@ import {
 import { User } from "shared/lib/resources/user";
 import { adt, Id } from "shared/lib/types";
 import { CWUProposalSlim } from "shared/lib/resources/proposal/code-with-us";
+import { GUIDE_AUDIENCE } from "front-end/lib/pages/guide/view";
 
 // Parent page types & functions.
 
@@ -173,7 +174,11 @@ export function makeSidebarState(
             text: "Read Guide",
             active: false,
             newTab: true,
-            dest: routeDest(adt("cwuMinistryGuide", null))
+            dest: routeDest(
+              adt("cwuGuide", {
+                guideAudience: GUIDE_AUDIENCE.Ministry
+              })
+            )
           })
         ]
       : []

--- a/src/front-end/typescript/lib/pages/opportunity/create.tsx
+++ b/src/front-end/typescript/lib/pages/opportunity/create.tsx
@@ -11,6 +11,7 @@ import * as cwu from "shared/lib/resources/opportunity/code-with-us";
 import * as swu from "shared/lib/resources/opportunity/sprint-with-us";
 import { UserType } from "shared/lib/resources/user";
 import { adt, ADT } from "shared/lib/types";
+import { GUIDE_AUDIENCE } from "front-end/lib/pages/guide/view";
 
 export interface State {
   empty: true;
@@ -83,7 +84,11 @@ const view: component_.page.View<State, InnerMsg, Route> = () => {
           links={[
             {
               button: true,
-              dest: routeDest(adt("cwuMinistryGuide", null)),
+              dest: routeDest(
+                adt("cwuGuide", {
+                  guideAudience: GUIDE_AUDIENCE.Ministry
+                })
+              ),
               children: ["Read Guide"],
               color: "info" as TextColor,
               outline: true
@@ -111,7 +116,11 @@ const view: component_.page.View<State, InnerMsg, Route> = () => {
           links={[
             {
               button: true,
-              dest: routeDest(adt("twuMinistryGuide", null)),
+              dest: routeDest(
+                adt("twuGuide", {
+                  guideAudience: GUIDE_AUDIENCE.Ministry
+                })
+              ),
               children: ["Read Guide"],
               color: "info" as TextColor,
               outline: true
@@ -138,7 +147,11 @@ const view: component_.page.View<State, InnerMsg, Route> = () => {
           links={[
             {
               button: true,
-              dest: routeDest(adt("swuMinistryGuide", null)),
+              dest: routeDest(
+                adt("swuGuide", {
+                  guideAudience: GUIDE_AUDIENCE.Ministry
+                })
+              ),
               children: ["Read Guide"],
               color: "info" as TextColor,
               outline: true

--- a/src/front-end/typescript/lib/pages/opportunity/create.tsx
+++ b/src/front-end/typescript/lib/pages/opportunity/create.tsx
@@ -138,9 +138,7 @@ const view: component_.page.View<State, InnerMsg, Route> = () => {
           links={[
             {
               button: true,
-              dest: routeDest(
-                adt("contentView", "sprint-with-us-opportunity-guide")
-              ),
+              dest: routeDest(adt("swuMinistryGuide", null)),
               children: ["Read Guide"],
               color: "info" as TextColor,
               outline: true

--- a/src/front-end/typescript/lib/pages/opportunity/create.tsx
+++ b/src/front-end/typescript/lib/pages/opportunity/create.tsx
@@ -83,9 +83,7 @@ const view: component_.page.View<State, InnerMsg, Route> = () => {
           links={[
             {
               button: true,
-              dest: routeDest(
-                adt("contentView", "code-with-us-opportunity-guide")
-              ),
+              dest: routeDest(adt("cwuMinistryGuide", null)),
               children: ["Read Guide"],
               color: "info" as TextColor,
               outline: true

--- a/src/front-end/typescript/lib/pages/opportunity/create.tsx
+++ b/src/front-end/typescript/lib/pages/opportunity/create.tsx
@@ -113,9 +113,7 @@ const view: component_.page.View<State, InnerMsg, Route> = () => {
           links={[
             {
               button: true,
-              dest: routeDest(
-                adt("contentView", "team-with-us-opportunity-guide")
-              ),
+              dest: routeDest(adt("twuMinistryGuide", null)),
               children: ["Read Guide"],
               color: "info" as TextColor,
               outline: true

--- a/src/front-end/typescript/lib/pages/opportunity/sprint-with-us/create.tsx
+++ b/src/front-end/typescript/lib/pages/opportunity/sprint-with-us/create.tsx
@@ -31,6 +31,7 @@ import {
 import { isAdmin, User, UserType } from "shared/lib/resources/user";
 import { adt, ADT } from "shared/lib/types";
 import { invalid, valid, Validation } from "shared/lib/validation";
+import { GUIDE_AUDIENCE } from "front-end/lib/pages/guide/view";
 
 type SWUCreateSubmitStatus =
   | SWUOpportunityStatus.Published
@@ -308,7 +309,13 @@ export const component: component_.page.Component<
       getFooter: () => (
         <span>
           Need help?{" "}
-          <Link newTab dest={routeDest(adt("swuMinistryGuide", null))}>
+          <Link
+            newTab
+            dest={routeDest(
+              adt("swuGuide", {
+                guideAudience: GUIDE_AUDIENCE.Ministry
+              })
+            )}>
             Read the guide
           </Link>{" "}
           to learn how to create and manage a <em>Sprint With Us</em>{" "}

--- a/src/front-end/typescript/lib/pages/opportunity/sprint-with-us/create.tsx
+++ b/src/front-end/typescript/lib/pages/opportunity/sprint-with-us/create.tsx
@@ -308,11 +308,7 @@ export const component: component_.page.Component<
       getFooter: () => (
         <span>
           Need help?{" "}
-          <Link
-            newTab
-            dest={routeDest(
-              adt("contentView", "sprint-with-us-opportunity-guide")
-            )}>
+          <Link newTab dest={routeDest(adt("swuMinistryGuide", null))}>
             Read the guide
           </Link>{" "}
           to learn how to create and manage a <em>Sprint With Us</em>{" "}

--- a/src/front-end/typescript/lib/pages/opportunity/sprint-with-us/edit/tab/index.ts
+++ b/src/front-end/typescript/lib/pages/opportunity/sprint-with-us/edit/tab/index.ts
@@ -17,6 +17,7 @@ import {
 import { User } from "shared/lib/resources/user";
 import { adt, Id } from "shared/lib/types";
 import { SWUProposalSlim } from "shared/lib/resources/proposal/sprint-with-us";
+import { GUIDE_AUDIENCE } from "front-end/lib/pages/guide/view";
 
 // Parent page types & functions.
 
@@ -218,7 +219,11 @@ export function makeSidebarState(
             text: "Read Guide",
             active: false,
             newTab: true,
-            dest: routeDest(adt("swuMinistryGuide", null))
+            dest: routeDest(
+              adt("swuGuide", {
+                guideAudience: GUIDE_AUDIENCE.Ministry
+              })
+            )
           })
         ]
       : []

--- a/src/front-end/typescript/lib/pages/opportunity/sprint-with-us/edit/tab/index.ts
+++ b/src/front-end/typescript/lib/pages/opportunity/sprint-with-us/edit/tab/index.ts
@@ -218,9 +218,7 @@ export function makeSidebarState(
             text: "Read Guide",
             active: false,
             newTab: true,
-            dest: routeDest(
-              adt("contentView", "sprint-with-us-opportunity-guide")
-            )
+            dest: routeDest(adt("swuMinistryGuide", null))
           })
         ]
       : []

--- a/src/front-end/typescript/lib/pages/opportunity/team-with-us/create.tsx
+++ b/src/front-end/typescript/lib/pages/opportunity/team-with-us/create.tsx
@@ -28,6 +28,7 @@ import { TWUOpportunityStatus } from "shared/lib/resources/opportunity/team-with
 import { isAdmin, User, UserType } from "shared/lib/resources/user";
 import { adt, ADT } from "shared/lib/types";
 import { invalid, valid, Validation } from "shared/lib/validation";
+import { GUIDE_AUDIENCE } from "front-end/lib/pages/guide/view";
 
 type TWUCreateSubmitStatus =
   | TWUOpportunityStatus.Published
@@ -305,7 +306,13 @@ export const component: component_.page.Component<
       getFooter: () => (
         <span>
           Need help?{" "}
-          <Link newTab dest={routeDest(adt("twuMinistryGuide", null))}>
+          <Link
+            newTab
+            dest={routeDest(
+              adt("twuGuide", {
+                guideAudience: GUIDE_AUDIENCE.Ministry
+              })
+            )}>
             Read the guide
           </Link>{" "}
           to learn how to create and manage a <em>Team With Us</em> opportunity.

--- a/src/front-end/typescript/lib/pages/opportunity/team-with-us/create.tsx
+++ b/src/front-end/typescript/lib/pages/opportunity/team-with-us/create.tsx
@@ -305,11 +305,7 @@ export const component: component_.page.Component<
       getFooter: () => (
         <span>
           Need help?{" "}
-          <Link
-            newTab
-            dest={routeDest(
-              adt("contentView", "team-with-us-opportunity-guide")
-            )}>
+          <Link newTab dest={routeDest(adt("twuMinistryGuide", null))}>
             Read the guide
           </Link>{" "}
           to learn how to create and manage a <em>Team With Us</em> opportunity.

--- a/src/front-end/typescript/lib/pages/opportunity/team-with-us/edit/tab/index.tsx
+++ b/src/front-end/typescript/lib/pages/opportunity/team-with-us/edit/tab/index.tsx
@@ -16,6 +16,7 @@ import {
 import { User } from "shared/lib/resources/user";
 import { adt, Id } from "shared/lib/types";
 import { TWUProposalSlim } from "shared/lib/resources/proposal/team-with-us";
+import { GUIDE_AUDIENCE } from "front-end/lib/pages/guide/view";
 
 // Parent page types & functions.
 
@@ -203,7 +204,11 @@ export function makeSidebarState(
             text: "Read Guide",
             active: false,
             newTab: true,
-            dest: routeDest(adt("twuMinistryGuide", null))
+            dest: routeDest(
+              adt("twuGuide", {
+                guideAudience: GUIDE_AUDIENCE.Ministry
+              })
+            )
           })
         ]
       : []

--- a/src/front-end/typescript/lib/pages/opportunity/team-with-us/edit/tab/index.tsx
+++ b/src/front-end/typescript/lib/pages/opportunity/team-with-us/edit/tab/index.tsx
@@ -203,9 +203,7 @@ export function makeSidebarState(
             text: "Read Guide",
             active: false,
             newTab: true,
-            dest: routeDest(
-              adt("contentView", "team-with-us-opportunity-guide")
-            )
+            dest: routeDest(adt("twuMinistryGuide", null))
           })
         ]
       : []

--- a/src/front-end/typescript/lib/pages/proposal/code-with-us/create.tsx
+++ b/src/front-end/typescript/lib/pages/proposal/code-with-us/create.tsx
@@ -40,6 +40,7 @@ import { User, UserType } from "shared/lib/resources/user";
 import { adt, ADT } from "shared/lib/types";
 import { invalid, valid, Validation } from "shared/lib/validation";
 import { AffiliationSlim } from "shared/lib/resources/affiliation";
+import { GUIDE_AUDIENCE } from "front-end/lib/pages/guide/view";
 
 type ModalId = "submit" | "cancel";
 
@@ -453,7 +454,12 @@ export const component: component_.page.Component<
       getFooter: () => (
         <span>
           Need help?{" "}
-          <Link dest={routeDest(adt("cwuVendorGuide", null))}>
+          <Link
+            dest={routeDest(
+              adt("cwuGuide", {
+                guideAudience: GUIDE_AUDIENCE.Vendor
+              })
+            )}>
             Read the guide
           </Link>{" "}
           to learn how to create and manage a <em>Code With Us</em> proposal.

--- a/src/front-end/typescript/lib/pages/proposal/code-with-us/create.tsx
+++ b/src/front-end/typescript/lib/pages/proposal/code-with-us/create.tsx
@@ -453,8 +453,7 @@ export const component: component_.page.Component<
       getFooter: () => (
         <span>
           Need help?{" "}
-          <Link
-            dest={routeDest(adt("contentView", "code-with-us-proposal-guide"))}>
+          <Link dest={routeDest(adt("cwuVendorGuide", null))}>
             Read the guide
           </Link>{" "}
           to learn how to create and manage a <em>Code With Us</em> proposal.

--- a/src/front-end/typescript/lib/pages/proposal/code-with-us/edit/tab/index.ts
+++ b/src/front-end/typescript/lib/pages/proposal/code-with-us/edit/tab/index.ts
@@ -8,6 +8,7 @@ import { User } from "shared/lib/resources/user";
 import { adt, Id } from "shared/lib/types";
 import { CWUOpportunity } from "shared/lib/resources/opportunity/code-with-us";
 import { AffiliationSlim } from "shared/lib/resources/affiliation";
+import { GUIDE_AUDIENCE } from "front-end/lib/pages/guide/view";
 
 // Parent page types & functions.
 
@@ -107,7 +108,11 @@ export function makeSidebarState(
         text: "Read Guide",
         active: false,
         newTab: true,
-        dest: routeDest(adt("cwuVendorGuide", null))
+        dest: routeDest(
+          adt("cwuGuide", {
+            guideAudience: GUIDE_AUDIENCE.Vendor
+          })
+        )
       })
     ]
   });

--- a/src/front-end/typescript/lib/pages/proposal/code-with-us/edit/tab/index.ts
+++ b/src/front-end/typescript/lib/pages/proposal/code-with-us/edit/tab/index.ts
@@ -107,7 +107,7 @@ export function makeSidebarState(
         text: "Read Guide",
         active: false,
         newTab: true,
-        dest: routeDest(adt("contentView", "code-with-us-proposal-guide"))
+        dest: routeDest(adt("cwuVendorGuide", null))
       })
     ]
   });

--- a/src/front-end/typescript/lib/pages/proposal/sprint-with-us/create.tsx
+++ b/src/front-end/typescript/lib/pages/proposal/sprint-with-us/create.tsx
@@ -451,10 +451,7 @@ export const component: component_.page.Component<
       getFooter: () => (
         <span>
           Need help?{" "}
-          <Link
-            dest={routeDest(
-              adt("contentView", "sprint-with-us-proposal-guide")
-            )}>
+          <Link dest={routeDest(adt("swuVendorGuide", null))}>
             Read the guide
           </Link>{" "}
           to learn how to create and manage a <em>Sprint With Us</em> proposal.

--- a/src/front-end/typescript/lib/pages/proposal/sprint-with-us/create.tsx
+++ b/src/front-end/typescript/lib/pages/proposal/sprint-with-us/create.tsx
@@ -42,6 +42,7 @@ import { User, UserType } from "shared/lib/resources/user";
 import { ADT, adt, Id } from "shared/lib/types";
 import { invalid, valid, Validation } from "shared/lib/validation";
 import { OrganizationSlim } from "shared/lib/resources/organization";
+import { GUIDE_AUDIENCE } from "front-end/lib/pages/guide/view";
 
 type ModalId = "submit" | "cancel";
 
@@ -451,7 +452,12 @@ export const component: component_.page.Component<
       getFooter: () => (
         <span>
           Need help?{" "}
-          <Link dest={routeDest(adt("swuVendorGuide", null))}>
+          <Link
+            dest={routeDest(
+              adt("swuGuide", {
+                guideAudience: GUIDE_AUDIENCE.Vendor
+              })
+            )}>
             Read the guide
           </Link>{" "}
           to learn how to create and manage a <em>Sprint With Us</em> proposal.

--- a/src/front-end/typescript/lib/pages/proposal/sprint-with-us/edit/tab/index.ts
+++ b/src/front-end/typescript/lib/pages/proposal/sprint-with-us/edit/tab/index.ts
@@ -1,6 +1,7 @@
 import * as MenuSidebar from "front-end/lib/components/sidebar/menu";
 import * as TabbedPage from "front-end/lib/components/sidebar/menu/tabbed-page";
 import { component } from "front-end/lib/framework";
+import { GUIDE_AUDIENCE } from "front-end/lib/pages/guide/view";
 import * as ProposalTab from "front-end/lib/pages/proposal/sprint-with-us/edit/tab/proposal";
 import * as ScoresheetTab from "front-end/lib/pages/proposal/sprint-with-us/edit/tab/scoresheet";
 import { routeDest } from "front-end/lib/views/link";
@@ -127,7 +128,11 @@ export function makeSidebarState(
         text: "Read Guide",
         active: false,
         newTab: true,
-        dest: routeDest(adt("swuVendorGuide", null))
+        dest: routeDest(
+          adt("swuGuide", {
+            guideAudience: GUIDE_AUDIENCE.Vendor
+          })
+        )
       })
     ]
   });

--- a/src/front-end/typescript/lib/pages/proposal/sprint-with-us/edit/tab/index.ts
+++ b/src/front-end/typescript/lib/pages/proposal/sprint-with-us/edit/tab/index.ts
@@ -127,7 +127,7 @@ export function makeSidebarState(
         text: "Read Guide",
         active: false,
         newTab: true,
-        dest: routeDest(adt("contentView", "sprint-with-us-proposal-guide"))
+        dest: routeDest(adt("swuVendorGuide", null))
       })
     ]
   });

--- a/src/front-end/typescript/lib/pages/proposal/team-with-us/create.tsx
+++ b/src/front-end/typescript/lib/pages/proposal/team-with-us/create.tsx
@@ -42,6 +42,7 @@ import { User, UserType } from "shared/lib/resources/user";
 import { ADT, adt, Id } from "shared/lib/types";
 import { invalid, valid, Validation } from "shared/lib/validation";
 import { OrganizationSlim } from "shared/lib/resources/organization";
+import { GUIDE_AUDIENCE } from "front-end/lib/pages/guide/view";
 
 type ModalId = "submit" | "cancel";
 
@@ -454,7 +455,12 @@ export const component: component_.page.Component<
       getFooter: () => (
         <span>
           Need help?{" "}
-          <Link dest={routeDest(adt("twuVendorGuide", null))}>
+          <Link
+            dest={routeDest(
+              adt("twuGuide", {
+                guideAudience: GUIDE_AUDIENCE.Vendor
+              })
+            )}>
             Read the guide
           </Link>{" "}
           to learn how to create and manage a <em>Team With Us</em> proposal.

--- a/src/front-end/typescript/lib/pages/proposal/team-with-us/create.tsx
+++ b/src/front-end/typescript/lib/pages/proposal/team-with-us/create.tsx
@@ -454,8 +454,7 @@ export const component: component_.page.Component<
       getFooter: () => (
         <span>
           Need help?{" "}
-          <Link
-            dest={routeDest(adt("contentView", "team-with-us-proposal-guide"))}>
+          <Link dest={routeDest(adt("twuVendorGuide", null))}>
             Read the guide
           </Link>{" "}
           to learn how to create and manage a <em>Team With Us</em> proposal.

--- a/src/front-end/typescript/lib/pages/proposal/team-with-us/edit/tab/index.ts
+++ b/src/front-end/typescript/lib/pages/proposal/team-with-us/edit/tab/index.ts
@@ -127,7 +127,7 @@ export function makeSidebarState(
         text: "Read Guide",
         active: false,
         newTab: false,
-        dest: routeDest(adt("contentView", "team-with-us-proposal-guide"))
+        dest: routeDest(adt("twuVendorGuide", null))
       })
     ]
   });

--- a/src/front-end/typescript/lib/pages/proposal/team-with-us/edit/tab/index.ts
+++ b/src/front-end/typescript/lib/pages/proposal/team-with-us/edit/tab/index.ts
@@ -1,6 +1,7 @@
 import * as MenuSidebar from "front-end/lib/components/sidebar/menu";
 import * as TabbedPage from "front-end/lib/components/sidebar/menu/tabbed-page";
 import { component } from "front-end/lib/framework";
+import { GUIDE_AUDIENCE } from "front-end/lib/pages/guide/view";
 import * as ProposalTab from "front-end/lib/pages/proposal/team-with-us/edit/tab/proposal";
 import * as ScoresheetTab from "front-end/lib/pages/proposal/team-with-us/edit/tab/scoresheet";
 import { routeDest } from "front-end/lib/views/link";
@@ -127,7 +128,11 @@ export function makeSidebarState(
         text: "Read Guide",
         active: false,
         newTab: false,
-        dest: routeDest(adt("twuVendorGuide", null))
+        dest: routeDest(
+          adt("twuGuide", {
+            guideAudience: GUIDE_AUDIENCE.Vendor
+          })
+        )
       })
     ]
   });


### PR DESCRIPTION
This PR closes issue: [DMM-134]

Includes tests? [N]
Updated docs? [N]

Proposed changes:
- Adds ministry and vendor guide routes for SWU, TWU, and CWU

Additional notes:
- These original routes can still be accessed using the contentView route