### PR TITLE
Feat/add self identification consequences

### DIFF
--- a/src/front-end/typescript/lib/pages/proposal/sprint-with-us/lib/components/form.tsx
+++ b/src/front-end/typescript/lib/pages/proposal/sprint-with-us/lib/components/form.tsx
@@ -1033,9 +1033,17 @@ const TeamQuestionsView: component_.base.View<Props> = ({
           zero.
         </p>
         <Alert color="danger" fade={false} className="mb-5">
-          <strong>Important!</strong> Do not reference your organization{"'"}s
-          name, a team member{"'"}s name or specific company software in any of
-          your responses.
+          <div>
+            <strong>Important!</strong> Do not reference your organization{"'"}s
+            name, a team member{"'"}s name or specific company software in any
+            of your responses.
+          </div>
+          <br />
+          <div>
+            No points will be awarded for any Proponent answer to any question
+            in this step that references the Proponent{"'"}s organization name,
+            Resource name, or specific company software
+          </div>
         </Alert>
       </Col>
       <Col xs="12">

--- a/src/front-end/typescript/lib/pages/proposal/sprint-with-us/lib/components/form.tsx
+++ b/src/front-end/typescript/lib/pages/proposal/sprint-with-us/lib/components/form.tsx
@@ -1042,7 +1042,7 @@ const TeamQuestionsView: component_.base.View<Props> = ({
           <div>
             No points will be awarded for any Proponent answer to any question
             in this step that references the Proponent{"'"}s organization name,
-            Resource name, or specific company software
+            Resource name, or specific company software.
           </div>
         </Alert>
       </Col>

--- a/src/front-end/typescript/lib/pages/proposal/team-with-us/lib/components/form.tsx
+++ b/src/front-end/typescript/lib/pages/proposal/team-with-us/lib/components/form.tsx
@@ -790,9 +790,17 @@ const ResourceQuestionsView: component_.base.View<Props> = ({
           zero.
         </p>
         <Alert color="danger" fade={false} className="mb-5">
-          <strong>Important!</strong> Do not reference your organization{"'"}s
-          name, a team member{"'"}s name or specific company software in any of
-          your responses.
+          <div>
+            <strong>Important!</strong> Do not reference your organization{"'"}s
+            name, a team member{"'"}s name or specific company software in any
+            of your responses.
+          </div>
+          <br />
+          <div>
+            No points will be awarded for any Proponent answer to any question
+            in this step that references the Proponent{"'"}s organization name,
+            Resource name, or specific company software
+          </div>
         </Alert>
       </Col>
       <Col xs="12">

--- a/src/front-end/typescript/lib/pages/proposal/team-with-us/lib/components/form.tsx
+++ b/src/front-end/typescript/lib/pages/proposal/team-with-us/lib/components/form.tsx
@@ -799,7 +799,7 @@ const ResourceQuestionsView: component_.base.View<Props> = ({
           <div>
             No points will be awarded for any Proponent answer to any question
             in this step that references the Proponent{"'"}s organization name,
-            Resource name, or specific company software
+            Resource name, or specific company software.
           </div>
         </Alert>
       </Col>


### PR DESCRIPTION
This PR closes issue: [DMM-252]

Includes tests? [N]
Updated docs? [N]

Proposed changes:
- Expand warning text in SWU and TWU

Example:
<img width="715" alt="Screenshot 2023-09-21 at 4 44 05 PM" src="https://github.com/bcgov/digital_marketplace/assets/11410926/97fe1e44-41c1-4f9d-b28f-2fd9deee626d">
