### PR TITLE
Feat/admin create submit proposal

### DIFF
--- a/src/front-end/typescript/lib/pages/user/profile/tab/organizations.tsx
+++ b/src/front-end/typescript/lib/pages/user/profile/tab/organizations.tsx
@@ -139,7 +139,7 @@ const update: component_.base.Update<State, Msg> = ({ state, msg }) => {
             (a) => a.membershipType === MembershipType.Owner
           ),
           affiliatedRecords: affiliations.filter(
-            (a) => a.membershipType === MembershipType.Member
+            (a) => a.membershipType !== MembershipType.Owner
           )
         }),
         [component_.cmd.dispatch(component_.page.readyMsg())]

--- a/src/migrations/tasks/20231017100758_update-membership-types.ts
+++ b/src/migrations/tasks/20231017100758_update-membership-types.ts
@@ -1,0 +1,56 @@
+import { makeDomainLogger } from "back-end/lib/logger";
+import { console as consoleAdapter } from "back-end/lib/logger/adapters";
+import Knex from "knex";
+
+const logger = makeDomainLogger(consoleAdapter, "migrations");
+
+enum MembershipType {
+  Owner = "OWNER",
+  Member = "MEMBER",
+  Admin = "ADMIN"
+}
+
+enum PreviousMembershipType {
+  Owner = "OWNER",
+  Member = "MEMBER"
+}
+
+export async function up(connection: Knex): Promise<void> {
+  await connection.schema.raw(
+    ' \
+    ALTER TABLE "affiliations" \
+    DROP CONSTRAINT "affiliations_membershipType_check" \
+  '
+  );
+
+  await connection.schema.raw(` \
+    ALTER TABLE "affiliations" \
+    ADD CONSTRAINT "affiliations_membershipType_check" \
+    CHECK ("membershipType" IN ('${Object.values(MembershipType).join(
+      "','"
+    )}')) \
+  `);
+  logger.info("Completed modifying affiliations table.");
+}
+
+export async function down(connection: Knex): Promise<void> {
+  await connection.schema.raw(
+    ' \
+    ALTER TABLE "affiliations" \
+    DROP CONSTRAINT "affiliations_membershipType_check" \
+  '
+  );
+
+  await connection("affiliations")
+    .where({ membershipType: MembershipType.Admin })
+    .update({ membershipType: PreviousMembershipType.Member });
+
+  await connection.schema.raw(` \
+    ALTER TABLE "affiliations" \
+    ADD CONSTRAINT "affiliations_membershipType_check" \
+    CHECK ("membershipType" IN ('${Object.values(PreviousMembershipType).join(
+      "','"
+    )}')) \
+  `);
+  logger.info("Completed reverting affiliations table.");
+}

--- a/src/shared/lib/resources/affiliation.ts
+++ b/src/shared/lib/resources/affiliation.ts
@@ -8,7 +8,8 @@ import { ErrorTypeFrom } from "shared/lib/validation";
 
 export enum MembershipType {
   Owner = "OWNER",
-  Member = "MEMBER"
+  Member = "MEMBER",
+  Admin = "ADMIN"
 }
 
 export enum MembershipStatus {


### PR DESCRIPTION
This PR closes issue: [DMM-272]

Includes tests? [N]
Updated docs? [N]

Proposed changes:
- Create new Admin membershipType
- Allow Admin members the ability to create/edit/submit proposals

Additional notes:
- Part of a larger epic, [DMM-181](https://bcdevex.atlassian.net/browse/DMM-181).
- Could have made a separate request for "administered organizations" or something like that, but owners and admins have the same privileges when it comes to proposal CRUD.

