### PR TITLE
Feat/toggle admin status

### DIFF
--- a/src/back-end/lib/db/affiliation.ts
+++ b/src/back-end/lib/db/affiliation.ts
@@ -300,10 +300,11 @@ export const deleteAffiliation = tryDb<[Id], Affiliation>(
   }
 );
 
-export async function isUserOwnerOfOrg(
+async function isUserMembershipTypeOfOrg(
   connection: Connection,
   user: User,
-  orgId: Id
+  orgId: Id,
+  membershipType: MembershipType
 ): Promise<boolean> {
   if (!user) {
     return false;
@@ -312,11 +313,37 @@ export async function isUserOwnerOfOrg(
     .where({
       user: user.id,
       organization: orgId,
-      membershipType: MembershipType.Owner
+      membershipType
     })
     .first();
 
   return !!result;
+}
+
+export async function isUserOwnerOfOrg(
+  connection: Connection,
+  user: User,
+  orgId: Id
+): Promise<boolean> {
+  return await isUserMembershipTypeOfOrg(
+    connection,
+    user,
+    orgId,
+    MembershipType.Owner
+  );
+}
+
+export async function isUserAdminOfOrg(
+  connection: Connection,
+  user: User,
+  orgId: Id
+): Promise<boolean> {
+  return await isUserMembershipTypeOfOrg(
+    connection,
+    user,
+    orgId,
+    MembershipType.Admin
+  );
 }
 
 export async function readActiveOwnerCount(

--- a/src/back-end/lib/db/affiliation.ts
+++ b/src/back-end/lib/db/affiliation.ts
@@ -311,7 +311,8 @@ function makeIsUserTypeChecker(
       .where({
         user: user.id,
         organization: orgId,
-        membershipType
+        membershipType,
+        membershipStatus: MembershipStatus.Active
       })
       .first();
 

--- a/src/back-end/lib/db/affiliation.ts
+++ b/src/back-end/lib/db/affiliation.ts
@@ -248,6 +248,32 @@ export const approveAffiliation = tryDb<[Id], Affiliation>(
   }
 );
 
+export const updateAdminStatus = tryDb<[Id, MembershipType], Affiliation>(
+  async (connection, id, membershipType: MembershipType) => {
+    const now = new Date();
+    const [result] = await connection<RawAffiliation>("affiliations")
+      .update(
+        {
+          membershipType,
+          updatedAt: now
+        } as RawAffiliation,
+        "*"
+      )
+      .where({
+        id
+      })
+      .whereIn("organization", function () {
+        this.select("id").from("organizations").where({
+          active: true
+        });
+      });
+    if (!result) {
+      throw new Error("unable to update admin status");
+    }
+    return valid(await rawAffiliationToAffiliation(connection, result));
+  }
+);
+
 export const deleteAffiliation = tryDb<[Id], Affiliation>(
   async (connection, id) => {
     const now = new Date();

--- a/src/back-end/lib/db/organization.ts
+++ b/src/back-end/lib/db/organization.ts
@@ -105,7 +105,8 @@ async function rawOrganizationSlimToOrganizationSlim(
     possessOneServiceArea,
     numTeamMembers,
     active,
-    serviceAreas
+    serviceAreas,
+    viewerIsOrgAdmin
   } = raw;
   let fetchedLogoImageFile: FileRecord | undefined;
   if (logoImageFile) {
@@ -130,7 +131,8 @@ async function rawOrganizationSlimToOrganizationSlim(
     active,
     numTeamMembers:
       numTeamMembers === undefined ? undefined : parseInt(numTeamMembers, 10),
-    serviceAreas
+    serviceAreas,
+    ...(viewerIsOrgAdmin ? { viewerIsOrgAdmin } : {})
   };
 }
 
@@ -180,18 +182,7 @@ function generateOrganizationQuery(connection: Connection) {
         })
         .as("numTeamMembers"),
       connection.raw(
-        `(
-        SELECT
-          coalesce(
-            json_agg(sa),
-            '[]' :: json
-          ) AS "serviceAreas"
-        FROM
-          "twuOrganizationServiceAreas" tosa
-          JOIN "serviceAreas" sa ON tosa."serviceArea" = sa.id
-        WHERE
-          tosa.organization = ?
-      )`,
+        '(select coalesce(json_agg(sa), \'[]\' :: json) as "serviceAreas" from "twuOrganizationServiceAreas" tosa join "serviceAreas" sa ON tosa."serviceArea" = sa.id where tosa.organization = ?)',
         connection.ref("organizations.id")
       )
     );
@@ -327,7 +318,20 @@ export const readManyOrganizations = tryDb<
   [Session, boolean?, number?, number?],
   ReadManyResponseBody
 >(async (connection, session, allowInactive = false, page, pageSize) => {
-  let query = generateOrganizationQuery(connection);
+  let query = generateOrganizationQuery(connection).select(
+    connection.raw('exists(?) as "viewerIsOrgAdmin"', [
+      connection
+        .select("user")
+        .from("affiliations")
+        .where({
+          organization: connection.ref("organizations.id"),
+          membershipStatus: MembershipStatus.Active,
+          membershipType: MembershipType.Admin,
+          user: session?.user.id
+        })
+        .first()
+    ])
+  );
 
   if (!allowInactive) {
     query = query.andWhere({ "organizations.active": true });
@@ -369,9 +373,13 @@ export const readManyOrganizations = tryDb<
         acceptedTWUTerms,
         acceptedSWUTerms,
         active,
-        serviceAreas
+        serviceAreas,
+        viewerIsOrgAdmin
       } = raw;
-      if (!isAdmin(session) && raw.owner !== session?.user.id) {
+      if (
+        !isAdmin(session) &&
+        !(raw.owner === session?.user.id || viewerIsOrgAdmin)
+      ) {
         return await rawOrganizationSlimToOrganizationSlim(connection, {
           id,
           legalName,
@@ -394,7 +402,8 @@ export const readManyOrganizations = tryDb<
           possessOneServiceArea: serviceAreas.length > 0,
           acceptedTWUTerms,
           acceptedSWUTerms,
-          serviceAreas
+          serviceAreas,
+          viewerIsOrgAdmin
         });
       }
     })

--- a/src/back-end/lib/permissions.ts
+++ b/src/back-end/lib/permissions.ts
@@ -7,6 +7,7 @@ import {
   isSWUOpportunityAuthor,
   isTWUOpportunityAuthor,
   isTWUProposalAuthor,
+  isUserAdminOfOrg,
   isUserOwnerOfOrg,
   userHasAcceptedCurrentTerms,
   userHasAcceptedPreviousTerms
@@ -171,7 +172,8 @@ export async function readOneOrganization(
   }
   return (
     isAdmin(session) ||
-    (await isUserOwnerOfOrg(connection, session.user, orgId))
+    (await isUserOwnerOfOrg(connection, session.user, orgId)) ||
+    (await isUserAdminOfOrg(connection, session.user, orgId))
   );
 }
 

--- a/src/back-end/lib/permissions.ts
+++ b/src/back-end/lib/permissions.ts
@@ -259,7 +259,8 @@ export async function updateAffiliationAdminStatus(
 ): Promise<boolean> {
   return (
     isAdmin(session) ||
-    (!!session && (await isUserOwnerOfOrg(connection, session.user, orgId)))
+    (!!session &&
+      (await isUserOwnerOrAdminOfOrg(connection, session.user, orgId)))
   );
 }
 

--- a/src/back-end/lib/permissions.ts
+++ b/src/back-end/lib/permissions.ts
@@ -239,7 +239,7 @@ export async function createAffiliation(
   );
 }
 
-export function updateAffiliation(
+export function approveAffiliation(
   session: Session,
   affiliation: Affiliation
 ): boolean {
@@ -247,6 +247,18 @@ export function updateAffiliation(
   return (
     isAdmin(session) || (!!session && session.user.id === affiliation.user.id)
   );
+}
+
+export async function updateAffiliationAdminStatus(
+  connection: Connection,
+  session: Session,
+  orgId: string
+): Promise<boolean> {
+  return session
+    ? isAdmin(session) ||
+        (await isUserOwnerOfOrg(connection, session.user, orgId)) ||
+        (await isUserAdminOfOrg(connection, session.user, orgId))
+    : false;
 }
 
 export async function deleteAffiliation(

--- a/src/back-end/lib/resources/affiliation.ts
+++ b/src/back-end/lib/resources/affiliation.ts
@@ -14,6 +14,7 @@ import {
   validateAffiliationId,
   validateOrganizationId
 } from "back-end/lib/validation";
+import { get, isBoolean } from "lodash";
 import { getString } from "shared/lib";
 import {
   Affiliation,
@@ -24,19 +25,23 @@ import {
   DeleteValidationErrors,
   MembershipStatus,
   MembershipType,
-  UpdateValidationErrors
+  UpdateValidationErrors,
+  UpdateRequestBody as SharedUpdateRequestBody,
+  adminStatusToAffiliationMembershipType
 } from "shared/lib/resources/affiliation";
 import { Organization } from "shared/lib/resources/organization";
 import { Session } from "shared/lib/resources/session";
 import { UserStatus, UserType } from "shared/lib/resources/user";
-import { Id } from "shared/lib/types";
+import { ADT, adt, Id } from "shared/lib/types";
 import {
   allValid,
   getInvalidValue,
   getValidValue,
   invalid,
   isInvalid,
-  valid
+  isValid,
+  valid,
+  Validation
 } from "shared/lib/validation";
 import * as affiliationValidation from "shared/lib/validation/affiliation";
 
@@ -47,7 +52,11 @@ export interface ValidatedCreateRequestBody {
   membershipStatus: MembershipStatus;
 }
 
-type ValidatedUpdateRequestBody = Id;
+export type UpdateRequestBody = SharedUpdateRequestBody | null;
+
+type ValidatedUpdateRequestBody =
+  | ADT<"approve">
+  | ADT<"updateAdminStatus", MembershipType>;
 
 type ValidatedDeleteRequestBody = Id;
 
@@ -282,15 +291,33 @@ const create: crud.Create<
 const update: crud.Update<
   Session,
   db.Connection,
-  null,
+  UpdateRequestBody,
   ValidatedUpdateRequestBody,
   UpdateValidationErrors
 > = (connection: db.Connection) => {
   return {
     async parseRequestBody(_request) {
-      return null;
+      const body = _request.body.tag === "json" ? _request.body.value : {};
+      const tag = getString(body, "tag");
+      const value: unknown = get(body, "value");
+      switch (tag) {
+        case "approve":
+          return adt("approve");
+        case "updateAdminStatus": {
+          if (isBoolean(value)) {
+            return adt("updateAdminStatus", value);
+          } else {
+            return null;
+          }
+        }
+        default:
+          return null;
+      }
     },
     async validateRequestBody(request) {
+      if (!request.body) {
+        return invalid({ affiliation: adt("parseFailure" as const) });
+      }
       const validatedAffiliation = await validateAffiliationId(
         connection,
         request.params.id
@@ -301,41 +328,91 @@ const update: crud.Update<
         });
       }
       const existingAffiliation = validatedAffiliation.value;
-      if (existingAffiliation.membershipStatus === MembershipStatus.Pending) {
-        if (
-          !permissions.updateAffiliation(request.session, existingAffiliation)
-        ) {
+      switch (request.body.tag) {
+        case "approve": {
+          if (
+            existingAffiliation.membershipStatus === MembershipStatus.Pending
+          ) {
+            if (
+              !permissions.approveAffiliation(
+                request.session,
+                existingAffiliation
+              )
+            ) {
+              return invalid({
+                permissions: [permissions.ERROR_MESSAGE]
+              });
+            }
+            return valid(adt("approve" as const));
+          }
           return invalid({
-            permissions: [permissions.ERROR_MESSAGE]
+            affiliation: ["Membership is not pending."]
           });
         }
-        return valid(existingAffiliation.id);
+        case "updateAdminStatus": {
+          if (existingAffiliation.membershipType === MembershipType.Owner) {
+            return invalid({
+              affiliation: ["Owner membership type cannot be updated."]
+            });
+          }
+
+          if (
+            !permissions.updateAffiliationAdminStatus(
+              connection,
+              request.session,
+              existingAffiliation.organization.id
+            )
+          ) {
+            return invalid({
+              permissions: [permissions.ERROR_MESSAGE]
+            });
+          }
+
+          const membershipType = adminStatusToAffiliationMembershipType(
+            request.body.value
+          );
+          return valid(adt("updateAdminStatus" as const, membershipType));
+        }
+        default:
+          return invalid({ affiliation: adt("parseFailure" as const) });
       }
-      return invalid({
-        affiliation: ["Membership is not pending."]
-      });
     },
     respond: wrapRespond({
       valid: async (request) => {
-        const id = request.body;
-        const dbResult = await db.approveAffiliation(connection, id);
-        if (isInvalid(dbResult)) {
-          return basicResponse(
-            503,
-            request.session,
-            makeJsonResponseBody({ database: [db.ERROR_MESSAGE] })
-          );
+        const id = request.params.id;
+        let dbResult: Validation<Affiliation, null>;
+        switch (request.body.tag) {
+          case "approve":
+            dbResult = await db.approveAffiliation(connection, id);
+            if (isValid(dbResult)) {
+              affiliationNotifications.handleUserAcceptedInvitation(
+                connection,
+                dbResult.value
+              );
+            }
+            break;
+          case "updateAdminStatus":
+            dbResult = await db.updateAdminStatus(
+              connection,
+              id,
+              request.body.value
+            );
+            break;
         }
-        // Notify organization admin that new member has joined
-        affiliationNotifications.handleUserAcceptedInvitation(
-          connection,
-          dbResult.value
-        );
-        return basicResponse(
-          200,
-          request.session,
-          makeJsonResponseBody(dbResult.value)
-        );
+        switch (dbResult.tag) {
+          case "valid":
+            return basicResponse(
+              200,
+              request.session,
+              makeJsonResponseBody(dbResult.value)
+            );
+          case "invalid":
+            return basicResponse(
+              503,
+              request.session,
+              makeJsonResponseBody({ database: [db.ERROR_MESSAGE] })
+            );
+        }
       },
       invalid: async (request) => {
         return basicResponse(

--- a/src/back-end/lib/resources/affiliation.ts
+++ b/src/back-end/lib/resources/affiliation.ts
@@ -357,11 +357,11 @@ const update: crud.Update<
           }
 
           if (
-            !permissions.updateAffiliationAdminStatus(
+            !(await permissions.updateAffiliationAdminStatus(
               connection,
               request.session,
               existingAffiliation.organization.id
-            )
+            ))
           ) {
             return invalid({
               permissions: [permissions.ERROR_MESSAGE]

--- a/src/back-end/lib/resources/affiliation.ts
+++ b/src/back-end/lib/resources/affiliation.ts
@@ -27,7 +27,8 @@ import {
   MembershipType,
   UpdateValidationErrors,
   UpdateRequestBody as SharedUpdateRequestBody,
-  adminStatusToAffiliationMembershipType
+  adminStatusToAffiliationMembershipType,
+  memberIsOwner
 } from "shared/lib/resources/affiliation";
 import { Organization } from "shared/lib/resources/organization";
 import { Session } from "shared/lib/resources/session";
@@ -350,9 +351,20 @@ const update: crud.Update<
           });
         }
         case "updateAdminStatus": {
-          if (existingAffiliation.membershipType === MembershipType.Owner) {
+          if (memberIsOwner(existingAffiliation)) {
             return invalid({
               affiliation: ["Owner membership type cannot be updated."]
+            });
+          }
+
+          if (
+            permissions.isOwnAccount(
+              request.session,
+              existingAffiliation.user.id
+            )
+          ) {
+            return invalid({
+              affiliation: ["Members cannot update their own admin status."]
             });
           }
 

--- a/src/front-end/sass/index.scss
+++ b/src/front-end/sass/index.scss
@@ -605,6 +605,19 @@ nav.navbar .nav-link:hover {
   }
 }
 
+[class*="affiliations-admin-status"] {
+  .custom-control {
+    padding-left: 0;
+  }
+
+  .custom-control-label::before,
+  .custom-control-label::after {
+    position: absolute;
+    left: 50%;
+    transform: translateX(-50%);
+  }
+}
+
 .spinner-border-sm {
   border-width: 0.15em;
 }

--- a/src/front-end/typescript/lib/components/accept-org-admin-terms.tsx
+++ b/src/front-end/typescript/lib/components/accept-org-admin-terms.tsx
@@ -1,53 +1,24 @@
 import * as FormField from "front-end/lib/components/form-field";
 import * as Checkbox from "front-end/lib/components/form-field/checkbox";
-import {
-  immutable,
-  Immutable,
-  component as component_
-} from "front-end/lib/framework";
+import { Immutable, component as component_ } from "front-end/lib/framework";
 import React from "react";
-import { ADT, adt } from "shared/lib/types";
 
-export interface State {
-  orgAdmin: Immutable<Checkbox.State>;
-}
-
-export type Msg = ADT<"orgAdmin", Checkbox.Msg>;
-
+export type State = Checkbox.State;
+export type Msg = Checkbox.Msg;
 export type Params = Checkbox.Params;
 
-export const init: component_.base.Init<Params, State, Msg> = (orgAdmin) => {
-  const [orgAdminState, orgAdminCmds] = Checkbox.init(orgAdmin);
-  return [
-    {
-      orgAdmin: immutable(orgAdminState)
-    },
-    component_.cmd.mapMany(orgAdminCmds, (msg) => adt("orgAdmin", msg) as Msg)
-  ];
-};
-
-export const update: component_.base.Update<State, Msg> = ({ state, msg }) => {
-  switch (msg.tag) {
-    case "orgAdmin":
-      return component_.base.updateChild({
-        state,
-        childStatePath: ["orgAdmin"],
-        childUpdate: Checkbox.update,
-        childMsg: msg.value,
-        mapChildMsg: (v) => adt("orgAdmin", v) as Msg
-      });
-  }
-};
+export const init = Checkbox.init;
+export const update = Checkbox.update;
 
 export function setOrgAdminCheckbox(
   state: Immutable<State>,
   v: Checkbox.Value
 ): Immutable<State> {
-  return state.update("orgAdmin", (s) => FormField.setValue(s, v));
+  return FormField.setValue(state, v);
 }
 
 export function getOrgAdminCheckbox(state: Immutable<State>): Checkbox.Value {
-  return FormField.getValue(state.orgAdmin);
+  return FormField.getValue(state);
 }
 
 export type Props = component_.base.ComponentViewProps<State, Msg>;
@@ -66,11 +37,8 @@ export const view: component_.base.View<Props> = ({ state, dispatch }) => {
             "By checking the box, you confirm that you are making this user an agent of your organization for the purposes of responding to Competition Notices."
         }}
         className="font-weight-bold"
-        state={state.orgAdmin}
-        dispatch={component_.base.mapDispatch(
-          dispatch,
-          (v) => adt("orgAdmin", v) as Msg
-        )}
+        state={state}
+        dispatch={dispatch}
       />
     </div>
   );

--- a/src/front-end/typescript/lib/components/accept-org-admin-terms.tsx
+++ b/src/front-end/typescript/lib/components/accept-org-admin-terms.tsx
@@ -1,0 +1,85 @@
+import * as FormField from "front-end/lib/components/form-field";
+import * as Checkbox from "front-end/lib/components/form-field/checkbox";
+import {
+  immutable,
+  Immutable,
+  component as component_
+} from "front-end/lib/framework";
+import React from "react";
+import { ADT, adt } from "shared/lib/types";
+
+export interface State {
+  orgAdmin: Immutable<Checkbox.State>;
+}
+
+export type Msg = ADT<"orgAdmin", Checkbox.Msg>;
+
+export type Params = Checkbox.Params;
+
+export const init: component_.base.Init<Params, State, Msg> = (orgAdmin) => {
+  const [orgAdminState, orgAdminCmds] = Checkbox.init(orgAdmin);
+  return [
+    {
+      orgAdmin: immutable(orgAdminState)
+    },
+    component_.cmd.mapMany(orgAdminCmds, (msg) => adt("orgAdmin", msg) as Msg)
+  ];
+};
+
+export const update: component_.base.Update<State, Msg> = ({ state, msg }) => {
+  switch (msg.tag) {
+    case "orgAdmin":
+      return component_.base.updateChild({
+        state,
+        childStatePath: ["orgAdmin"],
+        childUpdate: Checkbox.update,
+        childMsg: msg.value,
+        mapChildMsg: (v) => adt("orgAdmin", v) as Msg
+      });
+  }
+};
+
+export function setOrgAdminCheckbox(
+  state: Immutable<State>,
+  v: Checkbox.Value
+): Immutable<State> {
+  return state.update("orgAdmin", (s) => FormField.setValue(s, v));
+}
+
+export function getOrgAdminCheckbox(state: Immutable<State>): Checkbox.Value {
+  return FormField.getValue(state.orgAdmin);
+}
+
+export type Props = component_.base.ComponentViewProps<State, Msg>;
+
+export const view: component_.base.View<Props> = ({ state, dispatch }) => {
+  return (
+    <div>
+      <p>
+        By giving admin powers to this user, they will be able to create, edit,
+        and submit legally binding Proposals in response to Competition Notices
+        on behalf of your organization.
+      </p>
+      <Checkbox.view
+        extraChildProps={{
+          inlineLabel:
+            "By checking the box, you confirm that you are making this user an agent of your organization for the purposes of responding to Competition Notices."
+        }}
+        className="font-weight-bold"
+        state={state.orgAdmin}
+        dispatch={component_.base.mapDispatch(
+          dispatch,
+          (v) => adt("orgAdmin", v) as Msg
+        )}
+      />
+    </div>
+  );
+};
+
+export const component: component_.base.Component<Params, State, Msg, Props> = {
+  init,
+  update,
+  view
+};
+
+export default component;

--- a/src/front-end/typescript/lib/http/api/affiliation.ts
+++ b/src/front-end/typescript/lib/http/api/affiliation.ts
@@ -32,7 +32,7 @@ export function readManyForOrganization<Msg>(
 }
 
 export function update<Msg>(): crud.UpdateAction<
-  null,
+  Resource.UpdateRequestBody,
   Resource.Affiliation,
   Resource.UpdateValidationErrors,
   Msg

--- a/src/front-end/typescript/lib/pages/organization/edit/tab/team.tsx
+++ b/src/front-end/typescript/lib/pages/organization/edit/tab/team.tsx
@@ -545,7 +545,7 @@ function membersTableBodyRows(
             <CustomInput
               type="checkbox"
               id={`affiliations-admin-checkbox-${i}`}
-              onClick={(e) => {
+              onChange={(e) => {
                 if (e) {
                   e.stopPropagation();
                 }

--- a/src/front-end/typescript/lib/pages/organization/edit/tab/team.tsx
+++ b/src/front-end/typescript/lib/pages/organization/edit/tab/team.tsx
@@ -258,7 +258,7 @@ const update: component_.base.Update<State, Msg> = ({ state, msg }) => {
         [
           api.affiliations.update<Msg>()(
             msg.value.id,
-            null,
+            adt("approve"),
             (response) =>
               adt("onApproveAffiliationResponse", [
                 api.isValid(response),

--- a/src/front-end/typescript/lib/pages/organization/edit/tab/team.tsx
+++ b/src/front-end/typescript/lib/pages/organization/edit/tab/team.tsx
@@ -40,7 +40,11 @@ import {
   memberIsAdmin,
   UpdateValidationErrors
 } from "shared/lib/resources/affiliation";
-import { isAdmin, isVendor } from "shared/lib/resources/user";
+import {
+  isAdmin,
+  isVendor,
+  usersAreEquivalent
+} from "shared/lib/resources/user";
 import { adt, ADT, Id } from "shared/lib/types";
 import { validateUserEmail } from "shared/lib/validation/affiliation";
 
@@ -558,7 +562,11 @@ function membersTableBodyRows(
                       ) as Msg
                     );
               }}
-              disabled={isLoading || memberIsOwner(m)}
+              disabled={
+                isLoading ||
+                memberIsOwner(m) ||
+                usersAreEquivalent(state.viewerUser, m.user)
+              }
               checked={isAffiliationAdminStatusChecked(m)}
             />
           </div>

--- a/src/front-end/typescript/lib/pages/organization/edit/tab/team.tsx
+++ b/src/front-end/typescript/lib/pages/organization/edit/tab/team.tsx
@@ -37,7 +37,7 @@ import {
   MembershipType,
   Affiliation,
   CreateValidationErrors,
-  memberIsAdmin,
+  memberIsOrgAdmin,
   UpdateValidationErrors
 } from "shared/lib/resources/affiliation";
 import {
@@ -131,7 +131,9 @@ function resetAddTeamMemberEmails(
 function isAffiliationAdminStatusChecked(
   affiliationMember: AffiliationMember
 ): boolean {
-  return memberIsOwner(affiliationMember) || memberIsAdmin(affiliationMember);
+  return (
+    memberIsOwner(affiliationMember) || memberIsOrgAdmin(affiliationMember)
+  );
 }
 
 const init: component_.base.Init<Tab.Params, State, Msg> = (params) => {

--- a/src/front-end/typescript/lib/pages/organization/lib/components/form.tsx
+++ b/src/front-end/typescript/lib/pages/organization/lib/components/form.tsx
@@ -68,7 +68,11 @@ export type Msg =
 export interface Values
   extends Omit<
     Required<CreateRequestBody>,
-    "logoImageFile" | "deactivatedOn" | "deactivatedBy" | "serviceAreas"
+    | "logoImageFile"
+    | "deactivatedOn"
+    | "deactivatedBy"
+    | "serviceAreas"
+    | "viewerIsOrgAdmin"
   > {
   newLogoImage?: File;
 }

--- a/src/front-end/typescript/lib/pages/organization/list.tsx
+++ b/src/front-end/typescript/lib/pages/organization/list.tsx
@@ -26,7 +26,13 @@ import {
   OrganizationSlim,
   ReadManyResponseBody
 } from "shared/lib/resources/organization";
-import { isVendor, User, UserType } from "shared/lib/resources/user";
+import {
+  isAdmin,
+  isVendor,
+  User,
+  usersAreEquivalent,
+  UserType
+} from "shared/lib/resources/user";
 import { ADT, adt } from "shared/lib/types";
 
 type TableOrganization = OrganizationSlim;
@@ -181,22 +187,29 @@ function tableBodyRows(state: Immutable<State>): Table.BodyRows {
     const owner = {
       className: "text-nowrap",
       children: org.owner ? (
-        <Link dest={routeDest(adt("userProfile", { userId: org.owner.id }))}>
-          {org.owner.name}
-        </Link>
+        state.sessionUser &&
+        (usersAreEquivalent(org.owner, state.sessionUser) ||
+          isAdmin(state.sessionUser)) ? (
+          <Link dest={routeDest(adt("userProfile", { userId: org.owner.id }))}>
+            {org.owner.name}
+          </Link>
+        ) : (
+          org.owner.name
+        )
       ) : (
         EMPTY_STRING
       )
     };
     return [
       {
-        children: org.owner ? (
-          <Link dest={routeDest(adt("orgEdit", { orgId: org.id }))}>
-            {org.legalName}
-          </Link>
-        ) : (
-          org.legalName
-        )
+        children:
+          org.owner || org.viewerIsOrgAdmin ? (
+            <Link dest={routeDest(adt("orgEdit", { orgId: org.id }))}>
+              {org.legalName}
+            </Link>
+          ) : (
+            org.legalName
+          )
       },
       ...(showOwnerColumn(state) ? [owner] : [])
     ];

--- a/src/front-end/typescript/lib/pages/user/profile/tab/organizations.tsx
+++ b/src/front-end/typescript/lib/pages/user/profile/tab/organizations.tsx
@@ -220,7 +220,7 @@ const update: component_.base.Update<State, Msg> = ({ state, msg }) => {
         [
           api.affiliations.update<Msg>()(
             msg.value.id,
-            null,
+            adt("approve"),
             (response) =>
               adt("onApproveAffiliationResponse", [
                 msg.value,

--- a/src/front-end/typescript/lib/pages/user/profile/tab/organizations.tsx
+++ b/src/front-end/typescript/lib/pages/user/profile/tab/organizations.tsx
@@ -21,7 +21,7 @@ import { Col, Row } from "reactstrap";
 import { compareStrings, find } from "shared/lib";
 import {
   AffiliationSlim,
-  memberIsAdmin,
+  memberIsOrgAdmin,
   memberIsPending,
   MembershipType
 } from "shared/lib/resources/affiliation";
@@ -421,7 +421,7 @@ function affiliatedTableBodyRows(
       {
         children: (
           <div>
-            {memberIsAdmin(affiliation) ? (
+            {memberIsOrgAdmin(affiliation) ? (
               <Link
                 dest={routeDest(
                   adt("orgEdit", { orgId: affiliation.organization.id })

--- a/src/front-end/typescript/lib/pages/user/profile/tab/organizations.tsx
+++ b/src/front-end/typescript/lib/pages/user/profile/tab/organizations.tsx
@@ -21,6 +21,7 @@ import { Col, Row } from "reactstrap";
 import { compareStrings, find } from "shared/lib";
 import {
   AffiliationSlim,
+  memberIsAdmin,
   memberIsPending,
   MembershipType
 } from "shared/lib/resources/affiliation";
@@ -420,7 +421,16 @@ function affiliatedTableBodyRows(
       {
         children: (
           <div>
-            <span>{affiliation.organization.legalName}</span>
+            {memberIsAdmin(affiliation) ? (
+              <Link
+                dest={routeDest(
+                  adt("orgEdit", { orgId: affiliation.organization.id })
+                )}>
+                {affiliation.organization.legalName}
+              </Link>
+            ) : (
+              <span>{affiliation.organization.legalName}</span>
+            )}
             {isPending ? <PendingBadge className="ml-3" /> : null}
           </div>
         ),

--- a/src/shared/lib/resources/affiliation.ts
+++ b/src/shared/lib/resources/affiliation.ts
@@ -94,3 +94,9 @@ export function memberIsOwner(
 ): boolean {
   return member.membershipType === MembershipType.Owner;
 }
+
+export function adminStatusToAffiliationMembershipType(
+  admin: boolean
+): MembershipType {
+  return admin ? MembershipType.Admin : MembershipType.Member;
+}

--- a/src/shared/lib/resources/affiliation.ts
+++ b/src/shared/lib/resources/affiliation.ts
@@ -100,7 +100,7 @@ export function memberIsOwner(
   return member.membershipType === MembershipType.Owner;
 }
 
-export function memberIsAdmin(
+export function memberIsOrgAdmin(
   member: Pick<Affiliation, "membershipType">
 ): boolean {
   return member.membershipType === MembershipType.Admin;

--- a/src/shared/lib/resources/affiliation.ts
+++ b/src/shared/lib/resources/affiliation.ts
@@ -3,7 +3,7 @@ import {
   OrganizationSlim
 } from "shared/lib/resources/organization";
 import { User, usersHaveCapability } from "shared/lib/resources/user";
-import { BodyWithErrors, Id } from "shared/lib/types";
+import { ADT, BodyWithErrors, Id } from "shared/lib/types";
 import { ErrorTypeFrom } from "shared/lib/validation";
 
 export enum MembershipType {
@@ -47,6 +47,10 @@ export interface CreateRequestBody {
   membershipType: MembershipType;
 }
 
+export type UpdateRequestBody =
+  | ADT<"approve">
+  | ADT<"updateAdminStatus", boolean>;
+
 export interface CreateValidationErrors
   extends ErrorTypeFrom<CreateRequestBody>,
     BodyWithErrors {
@@ -55,7 +59,7 @@ export interface CreateValidationErrors
 }
 
 export interface UpdateValidationErrors extends BodyWithErrors {
-  affiliation?: string[];
+  affiliation?: string[] | ADT<"parseFailure">;
 }
 
 export interface DeleteValidationErrors extends BodyWithErrors {

--- a/src/shared/lib/resources/affiliation.ts
+++ b/src/shared/lib/resources/affiliation.ts
@@ -8,7 +8,8 @@ import { ErrorTypeFrom } from "shared/lib/validation";
 
 export enum MembershipType {
   Owner = "OWNER",
-  Member = "MEMBER"
+  Member = "MEMBER",
+  Admin = "ADMIN"
 }
 
 export enum MembershipStatus {
@@ -97,6 +98,12 @@ export function memberIsOwner(
   member: Pick<Affiliation, "membershipType">
 ): boolean {
   return member.membershipType === MembershipType.Owner;
+}
+
+export function memberIsAdmin(
+  member: Pick<Affiliation, "membershipType">
+): boolean {
+  return member.membershipType === MembershipType.Admin;
 }
 
 export function adminStatusToAffiliationMembershipType(

--- a/src/shared/lib/resources/organization.ts
+++ b/src/shared/lib/resources/organization.ts
@@ -22,6 +22,7 @@ export interface OrganizationAdmin {
   possessOneServiceArea?: boolean;
   numTeamMembers?: number;
   serviceAreas: TWUServiceAreaRecord[];
+  viewerIsOrgAdmin?: boolean;
 }
 
 export interface Organization extends OrganizationAdmin {

--- a/src/shared/lib/resources/user.ts
+++ b/src/shared/lib/resources/user.ts
@@ -63,7 +63,10 @@ export function userToUserSlim(u: User): UserSlim {
   };
 }
 
-export function usersAreEquivalent(a: User, b: User): boolean {
+export function usersAreEquivalent<T extends User | UserSlim>(
+  a: T,
+  b: T
+): boolean {
   return a.id === b.id;
 }
 


### PR DESCRIPTION
This PR closes issue: [DMM-240, DMM-265, DMM-266, DMM-267, DMM-268, DMM-269, DMM-270, DMM-271]

Includes tests? [N]
Updated docs? [N]

Proposed changes:
- Modifies Affiliations update endpoint to accept multiple types of update requests
- Adds a new "updateAdminStatus" update request type
- Adds a checkbox to each member on the team team page that can only be used according to the user stories referenced in the issues above
- Display confirmation modal when granting admin rights