### PR TITLE
Feat/organization changelog

### DIFF
--- a/src/front-end/typescript/lib/pages/organization/lib/components/form.tsx
+++ b/src/front-end/typescript/lib/pages/organization/lib/components/form.tsx
@@ -73,6 +73,7 @@ export interface Values
     | "deactivatedBy"
     | "serviceAreas"
     | "viewerIsOrgAdmin"
+    | "history"
   > {
   newLogoImage?: File;
 }

--- a/src/migrations/tasks/20231108161232_affiliation-events.ts
+++ b/src/migrations/tasks/20231108161232_affiliation-events.ts
@@ -1,0 +1,32 @@
+import { makeDomainLogger } from "back-end/lib/logger";
+import { console as consoleAdapter } from "back-end/lib/logger/adapters";
+import Knex from "knex";
+
+const logger = makeDomainLogger(consoleAdapter, "migrations");
+
+export enum AffiliationEvent {
+  AdminStatusGranted = "ADMIN_STATUS_GRANTED",
+  AdminStatusRevoked = "ADMIN_STATUS_REVOKED"
+}
+
+export async function up(connection: Knex): Promise<void> {
+  await connection.schema.createTable("affiliationEvents", (table) => {
+    table.uuid("id").primary().unique().notNullable();
+    table.timestamp("createdAt").notNullable();
+    table.uuid("createdBy").references("id").inTable("users").notNullable();
+    table
+      .uuid("affiliation")
+      .references("id")
+      .inTable("affiliations")
+      .notNullable()
+      .onDelete("CASCADE");
+    table.enu("event", Object.values(AffiliationEvent)).notNullable();
+  });
+
+  logger.info("Created affiliationEvents table.");
+}
+
+export async function down(connection: Knex): Promise<void> {
+  await connection.schema.dropTable("affiliationEvents");
+  logger.info("Completed dropping affiliationEvents table.");
+}

--- a/src/shared/lib/resources/affiliation.ts
+++ b/src/shared/lib/resources/affiliation.ts
@@ -2,7 +2,7 @@ import {
   Organization,
   OrganizationSlim
 } from "shared/lib/resources/organization";
-import { User, usersHaveCapability } from "shared/lib/resources/user";
+import { User, UserSlim, usersHaveCapability } from "shared/lib/resources/user";
 import { ADT, BodyWithErrors, Id } from "shared/lib/types";
 import { ErrorTypeFrom } from "shared/lib/validation";
 
@@ -16,6 +16,18 @@ export enum MembershipStatus {
   Active = "ACTIVE",
   Inactive = "INACTIVE",
   Pending = "PENDING"
+}
+
+export enum AffiliationEvent {
+  AdminStatusGranted = "ADMIN_STATUS_GRANTED",
+  AdminStatusRevoked = "ADMIN_STATUS_REVOKED"
+}
+
+export interface AffiliationHistoryRecord {
+  createdAt: Date;
+  createdBy: UserSlim;
+  type: AffiliationEvent;
+  member: UserSlim;
 }
 
 export interface Affiliation {

--- a/src/shared/lib/resources/organization.ts
+++ b/src/shared/lib/resources/organization.ts
@@ -9,6 +9,7 @@ import {
 } from "shared/lib/types";
 import { ErrorTypeFrom } from "shared/lib/validation/index";
 import { TWUServiceArea } from "shared/lib/resources/opportunity/team-with-us";
+import { AffiliationEvent } from "shared/lib/resources/affiliation";
 
 export { ReadManyResponseValidationErrors } from "shared/lib/types";
 
@@ -23,6 +24,16 @@ export interface OrganizationAdmin {
   numTeamMembers?: number;
   serviceAreas: TWUServiceAreaRecord[];
   viewerIsOrgAdmin?: boolean;
+}
+
+// Populate this as needed
+export enum OrganizationEvent {}
+
+export interface OrganizationHistoryRecord {
+  createdAt: Date;
+  createdBy: UserSlim;
+  type: OrganizationEvent | AffiliationEvent;
+  member?: UserSlim;
 }
 
 export interface Organization extends OrganizationAdmin {
@@ -45,6 +56,7 @@ export interface Organization extends OrganizationAdmin {
   active: boolean;
   deactivatedOn?: Date;
   deactivatedBy?: Id;
+  history?: OrganizationHistoryRecord[];
 }
 
 export interface OrganizationSlim extends OrganizationAdmin {

--- a/tests/back-end/integration/resources/proposals/code-with-us.test.ts
+++ b/tests/back-end/integration/resources/proposals/code-with-us.test.ts
@@ -165,7 +165,8 @@ test("code-with-us proposal crud", async () => {
         "numTeamMembers",
         "owner",
         "possessAllCapabilities",
-        "possessOneServiceArea"
+        "possessOneServiceArea",
+        "history"
       ]),
       createdAt: expect.any(String),
       updatedAt: expect.any(String)

--- a/tests/back-end/integration/resources/proposals/sprint-with-us.test.ts
+++ b/tests/back-end/integration/resources/proposals/sprint-with-us.test.ts
@@ -123,7 +123,8 @@ test("sprint-with-us proposal crud", async () => {
       "id",
       "legalName",
       "logoImageFile",
-      "active"
+      "active",
+      "viewerIsOrgAdmin"
     ])
   );
 

--- a/tests/back-end/integration/resources/proposals/team-with-us.test.ts
+++ b/tests/back-end/integration/resources/proposals/team-with-us.test.ts
@@ -143,7 +143,8 @@ test("team-with-us proposal crud", async () => {
       "id",
       "legalName",
       "logoImageFile",
-      "active"
+      "active",
+      "viewerIsOrgAdmin"
     ])
   );
 


### PR DESCRIPTION
This PR closes issue: [DMM-343, DMM-344]

Includes tests? [N]
Updated docs? [N]

Proposed changes:
- Add history events for organizations and their affiliations
- Record AdminStatusGranted and AdminStatusRevoked events on their respective status changes
- Include history in organization response

Additional notes:
- Trying to keep this PR smaller, so leaving the changelog UI for later
- Provided some scaffolding for OrganizationEvents though none exist at the moment. I've added commentary where I felt it would be helpful
