### PR TITLE
Feat/changelog UI

### DIFF
--- a/src/front-end/typescript/lib/http/api/organization/lib.ts
+++ b/src/front-end/typescript/lib/http/api/organization/lib.ts
@@ -1,8 +1,24 @@
+import { compareDates } from "shared/lib";
 import * as Resource from "shared/lib/resources/organization";
 
+interface RawOrganizationHistoryRecord
+  extends Omit<Resource.OrganizationHistoryRecord, "createdAt"> {
+  createdAt: string;
+}
+
+function rawCWUHistoryRecordToCWUHistoryRecord(
+  raw: RawOrganizationHistoryRecord
+): Resource.OrganizationHistoryRecord {
+  return {
+    ...raw,
+    createdAt: new Date(raw.createdAt)
+  };
+}
+
 export interface RawOrganization
-  extends Omit<Resource.Organization, "acceptedSWUTerms"> {
+  extends Omit<Resource.Organization, "acceptedSWUTerms" | "history"> {
   acceptedSWUTerms?: Date | null;
+  history?: RawOrganizationHistoryRecord[];
 }
 
 export function rawOrganizationToOrganization(
@@ -10,7 +26,12 @@ export function rawOrganizationToOrganization(
 ): Resource.Organization {
   return {
     ...raw,
-    acceptedSWUTerms: raw.acceptedSWUTerms && new Date(raw.acceptedSWUTerms)
+    acceptedSWUTerms: raw.acceptedSWUTerms && new Date(raw.acceptedSWUTerms),
+    history:
+      raw.history &&
+      raw.history
+        .map((s) => rawCWUHistoryRecordToCWUHistoryRecord(s))
+        .sort((a, b) => compareDates(a.createdAt, b.createdAt) * -1)
   };
 }
 

--- a/src/front-end/typescript/lib/pages/organization/edit/tab/changelog.tsx
+++ b/src/front-end/typescript/lib/pages/organization/edit/tab/changelog.tsx
@@ -1,0 +1,183 @@
+import { Route } from "front-end/lib/app/types";
+import {
+  component as component_,
+  immutable,
+  Immutable
+} from "front-end/lib/framework";
+import * as Table from "front-end/lib/components/table";
+import * as Tab from "front-end/lib/pages/organization/edit/tab";
+import React from "react";
+import Link, { routeDest } from "front-end/lib/views/link";
+import { Row, Col } from "reactstrap";
+import { EMPTY_STRING } from "shared/config";
+import { formatDate, formatTime } from "shared/lib";
+import { isAdmin } from "shared/lib/resources/user";
+import { adt } from "shared/lib/types";
+import { OrganizationHistoryTypeToTitleCase } from "front-end/lib/pages/organization/lib";
+import { ReadyMsg } from "front-end/lib/framework/component/page";
+import EditTabHeader from "front-end/lib/pages/organization/lib/views/edit-tab-header";
+
+export type State = Tab.Params & Table.State;
+
+export type InnerMsg = Table.Msg | ReadyMsg;
+
+export type Msg = component_.page.Msg<InnerMsg, Route>;
+
+function getTableState(state: State) {
+  return (({
+    idNamespace,
+    THView,
+    TDView,
+    activeTooltipThIndex,
+    activeTooltipTdIndex,
+    ..._
+  }) => ({
+    idNamespace,
+    THView,
+    TDView,
+    activeTooltipThIndex,
+    activeTooltipTdIndex
+  }))(state);
+}
+
+export const init: component_.base.Init<Tab.Params, State, Msg> = (params) => {
+  const [tableState, tableCmds] = Table.init({
+    idNamespace: "organization-changelog-table"
+  });
+
+  return [{ ...tableState, ...params }, tableCmds];
+};
+
+export const update: component_.page.Update<State, InnerMsg, Route> = ({
+  state,
+  msg
+}) => {
+  switch (msg.tag) {
+    case "toggleTooltipTd":
+    case "toggleTooltipTh": {
+      const [tableState, tableCmds] = Table.update({
+        state: immutable(getTableState(state)),
+        msg
+      });
+      return [state.merge(tableState), tableCmds];
+    }
+    default:
+      return [state, []];
+  }
+};
+
+function tableHeadCells(): Table.HeadCells {
+  const cells = [
+    {
+      children: "Entry Type",
+      className: "text-nowrap"
+    },
+    {
+      children: "Member",
+      className: "text-nowrap text-center"
+    },
+    {
+      children: "Created",
+      className: "text-nowrap text-center"
+    }
+  ];
+
+  return cells.map(({ style, ...cell }: Table.HeadCells[number]) => ({
+    ...cell,
+    style: { ...style, width: `calc(100% / ${cells.length})` }
+  }));
+}
+
+function tableBodyRows(state: Immutable<State>): Table.BodyRows {
+  const history = state.organization.history ?? [];
+  return history.map((record) => {
+    return [
+      {
+        children: OrganizationHistoryTypeToTitleCase(record.type),
+        className: "text-wrap"
+      },
+      {
+        children: record.member ? (
+          isAdmin(state.viewerUser) ? (
+            <Link
+              className="text-uppercase small"
+              dest={routeDest(
+                adt("userProfile", { userId: record.member.id })
+              )}>
+              {record.member.name}
+            </Link>
+          ) : (
+            record.member.name
+          )
+        ) : (
+          EMPTY_STRING
+        ),
+        className: "text-nowrap text-center"
+      },
+      {
+        children: (
+          <div className="d-flex justify-content-center">
+            <div>
+              <div>{formatDate(record.createdAt)}</div>
+              <div>{formatTime(record.createdAt, true)}</div>
+              {(() => {
+                if (isAdmin(state.viewerUser)) {
+                  return (
+                    <Link
+                      className="text-uppercase small"
+                      dest={routeDest(
+                        adt("userProfile", { userId: record.createdBy.id })
+                      )}>
+                      {record.createdBy.name}
+                    </Link>
+                  );
+                }
+                return (
+                  <div className="text-secondary text-uppercase small">
+                    {record.createdBy.name}
+                  </div>
+                );
+              })()}
+            </div>
+          </div>
+        ),
+        className: "text-nowrap"
+      }
+    ];
+  });
+}
+
+const view: component_.page.View<State, InnerMsg, Route> = ({
+  state,
+  dispatch
+}) => {
+  return (
+    <div>
+      <EditTabHeader
+        legalName={state.organization.legalName}
+        swuQualified={state.swuQualified}
+        twuQualified={state.twuQualified}
+      />
+      <Row className="mt-5">
+        <Col xs="12">
+          <h3 className="mb-4">Changelog</h3>
+          <Table.view
+            headCells={tableHeadCells()}
+            bodyRows={tableBodyRows(state)}
+            state={immutable(getTableState(state))}
+            dispatch={dispatch}
+          />
+        </Col>
+      </Row>
+    </div>
+  );
+};
+
+export const component: Tab.Component<State, InnerMsg> = {
+  init,
+  update,
+  view,
+  onInitResponse() {
+    return component_.page.readyMsg();
+  }
+};

--- a/src/front-end/typescript/lib/pages/organization/edit/tab/index.ts
+++ b/src/front-end/typescript/lib/pages/organization/edit/tab/index.ts
@@ -4,6 +4,7 @@ import { component } from "front-end/lib/framework";
 import * as OrganizationTab from "front-end/lib/pages/organization/edit/tab/organization";
 import * as QualificationTab from "front-end/lib/pages/organization/edit/tab/swu-qualification";
 import * as TWUQualificationTab from "front-end/lib/pages/organization/edit/tab/twu-qualification";
+import * as Changelog from "front-end/lib/pages/organization/edit/tab/changelog";
 import * as TeamTab from "front-end/lib/pages/organization/edit/tab/team";
 import { routeDest } from "front-end/lib/views/link";
 import { AffiliationMember } from "shared/lib/resources/affiliation";
@@ -65,6 +66,12 @@ export interface Tabs {
     TWUQualificationTab.InnerMsg,
     InitResponse
   >;
+  changelog: TabbedPage.Tab<
+    Params,
+    Changelog.State,
+    Changelog.InnerMsg,
+    InitResponse
+  >;
 }
 
 export type TabId = TabbedPage.TabId<Tabs>;
@@ -79,6 +86,7 @@ export const parseTabId: TabbedPage.ParseTabId<Tabs> = (raw) => {
     case "team":
     case "swuQualification":
     case "twuQualification":
+    case "changelog":
       return raw;
     default:
       return null;
@@ -106,6 +114,12 @@ export function idToDefinition<K extends TabId>(
         component: TWUQualificationTab.component,
         icon: "shield",
         title: "TWU Qualification"
+      } as TabbedPage.TabDefinition<Tabs, K>;
+    case "changelog":
+      return {
+        component: Changelog.component,
+        icon: "history",
+        title: "Changelog"
       } as TabbedPage.TabDefinition<Tabs, K>;
     case "organization":
     default:
@@ -140,7 +154,8 @@ export function makeSidebarState(
       makeSidebarLink("organization", organization, activeTab),
       makeSidebarLink("team", organization, activeTab),
       makeSidebarLink("swuQualification", organization, activeTab),
-      makeSidebarLink("twuQualification", organization, activeTab)
+      makeSidebarLink("twuQualification", organization, activeTab),
+      makeSidebarLink("changelog", organization, activeTab)
     ]
   });
 }

--- a/src/front-end/typescript/lib/pages/organization/lib/index.tsx
+++ b/src/front-end/typescript/lib/pages/organization/lib/index.tsx
@@ -1,0 +1,16 @@
+import { AffiliationEvent } from "shared/lib/resources/affiliation";
+import { OrganizationHistoryRecord } from "shared/lib/resources/organization";
+
+export function OrganizationHistoryTypeToTitleCase(
+  t: OrganizationHistoryRecord["type"]
+): string {
+  switch (t) {
+    case AffiliationEvent.AdminStatusGranted:
+      return "Admin Rights Given";
+    case AffiliationEvent.AdminStatusRevoked:
+      return "Admin Rights Removed";
+    default:
+      // Remove default case after fully enumerating organization events
+      return "";
+  }
+}

--- a/tests/back-end/setup-server.jest.ts
+++ b/tests/back-end/setup-server.jest.ts
@@ -20,7 +20,7 @@ beforeAll(async () => {
   await startServer({
     port: 3000 + Number(process.env.JEST_WORKER_ID)
   });
-}, 15000);
+}, 40000);
 
 afterAll(async () => {
   await stopServer();


### PR DESCRIPTION
This PR closes issue: [DMM-275]

Includes tests? [N]
Updated docs? [N]

Proposed changes:
- Adds a changelog tab to the organization edit page
- Changelog tab currently displays admin rights changes, but can be expanded to other affiliation and org events

Additional notes:
- Uncomment org admin work in src/front-end/typescript/lib/pages/organization/edit/tab/team.tsx to make changes