### PR TITLE
Feat/admin edit proposal

### DIFF
--- a/src/back-end/lib/db/affiliation.ts
+++ b/src/back-end/lib/db/affiliation.ts
@@ -347,7 +347,7 @@ export const deleteAffiliation = tryDb<[Id], Affiliation>(
 
 function makeIsUserTypeChecker(
   membershipType: MembershipType
-): (connection: Connection, user: User, ordId: Id) => Promise<boolean> {
+): (connection: Connection, user: User, orgId: Id) => Promise<boolean> {
   return async (connection: Connection, user: User, orgId: Id) => {
     if (!user) {
       return false;

--- a/src/back-end/lib/db/proposal/code-with-us.ts
+++ b/src/back-end/lib/db/proposal/code-with-us.ts
@@ -1,5 +1,10 @@
 import { generateUuid } from "back-end/lib";
-import { Connection, Transaction, tryDb } from "back-end/lib/db";
+import {
+  Connection,
+  Transaction,
+  isUserOwnerOrAdminOfOrg,
+  tryDb
+} from "back-end/lib/db";
 import { readOneFileById } from "back-end/lib/db/file";
 import {
   generateCWUOpportunityQuery,
@@ -373,7 +378,8 @@ export const readOneCWUProposal = tryDb<[Id, Session], CWUProposal | null>(
           session,
           result.opportunity,
           result.id,
-          result.status
+          result.status,
+          result.proponentOrganization
         )
       ) {
         // Add score to proposal
@@ -582,7 +588,7 @@ export const readOneProposalByOpportunityAndAuthor = tryDb<
   );
 });
 
-export async function isCWUProposalAuthor(
+async function isCWUProposalAuthor(
   connection: Connection,
   user: User,
   id: Id
@@ -1077,7 +1083,8 @@ export const readOneCWUAwardedProposal = tryDb<
       session,
       opportunity,
       result.id,
-      result.status
+      result.status,
+      result.proponentOrganization
     )
   ) {
     // Add score to proposal

--- a/src/back-end/lib/db/proposal/code-with-us.ts
+++ b/src/back-end/lib/db/proposal/code-with-us.ts
@@ -597,6 +597,18 @@ export async function isCWUProposalAuthor(
   }
 }
 
+export async function isCWUProposalAuthorOrIsUserOwnerOrAdminOfOrg(
+  connection: Connection,
+  user: User,
+  proposalId: Id,
+  orgId: Id | null
+) {
+  return (
+    (await isCWUProposalAuthor(connection, user, proposalId)) ||
+    (!!orgId && (await isUserOwnerOrAdminOfOrg(connection, user, orgId)))
+  );
+}
+
 export const createCWUProposal = tryDb<
   [CreateCWUProposalParams, AuthenticatedSession],
   CWUProposal

--- a/src/back-end/lib/db/proposal/sprint-with-us.ts
+++ b/src/back-end/lib/db/proposal/sprint-with-us.ts
@@ -1,5 +1,10 @@
 import { generateUuid } from "back-end/lib";
-import { Connection, Transaction, tryDb } from "back-end/lib/db";
+import {
+  Connection,
+  Transaction,
+  isUserOwnerOrAdminOfOrg,
+  tryDb
+} from "back-end/lib/db";
 import { readOneFileById } from "back-end/lib/db/file";
 import {
   generateSWUOpportunityQuery,
@@ -636,7 +641,7 @@ export const readOneSWUProposalByOpportunityAndAuthor = tryDb<
   return valid(result ? result : null);
 });
 
-export async function isSWUProposalAuthor(
+async function isSWUProposalAuthor(
   connection: Connection,
   user: User,
   id: Id
@@ -722,7 +727,8 @@ export const readOneSWUProposal = tryDb<
         connection,
         session,
         result.opportunity,
-        result.id
+        result.id,
+        result.organization
       )
     ) {
       const rawProposalStatuses = await connection<RawHistoryRecord>(
@@ -747,7 +753,8 @@ export const readOneSWUProposal = tryDb<
       session,
       result.opportunity,
       result.id,
-      result.status
+      result.status,
+      result.organization
     );
     result.teamQuestionResponses =
       getValidValue(
@@ -1732,7 +1739,8 @@ export const readOneSWUAwardedProposal = tryDb<
       session,
       opportunity,
       result.id,
-      result.status
+      result.status,
+      result.organization
     ))
   ) {
     await calculateScores(connection, session, opportunity, [result]);

--- a/src/back-end/lib/db/proposal/sprint-with-us.ts
+++ b/src/back-end/lib/db/proposal/sprint-with-us.ts
@@ -651,6 +651,18 @@ export async function isSWUProposalAuthor(
   }
 }
 
+export async function isSWUProposalAuthorOrIsUserOwnerOrAdminOfOrg(
+  connection: Connection,
+  user: User,
+  proposalId: Id,
+  orgId: Id | null
+) {
+  return (
+    (await isSWUProposalAuthor(connection, user, proposalId)) ||
+    (!!orgId && (await isUserOwnerOrAdminOfOrg(connection, user, orgId)))
+  );
+}
+
 export const readManyProposalReferences = tryDb<[Id], SWUProposalReference[]>(
   async (connection, proposalId) => {
     const results = await connection<SWUProposalReference>(

--- a/src/back-end/lib/db/proposal/team-with-us.ts
+++ b/src/back-end/lib/db/proposal/team-with-us.ts
@@ -1,5 +1,10 @@
 import { generateUuid } from "back-end/lib";
-import { Connection, Transaction, tryDb } from "back-end/lib/db";
+import {
+  Connection,
+  Transaction,
+  isUserOwnerOrAdminOfOrg,
+  tryDb
+} from "back-end/lib/db";
 import { readOneFileById } from "back-end/lib/db/file";
 import {
   generateTWUOpportunityQuery,
@@ -515,7 +520,7 @@ export const readOneTWUProposalByOpportunityAndAuthor = tryDb<
   return valid(result ? result : null);
 });
 
-export async function isTWUProposalAuthor(
+async function isTWUProposalAuthor(
   connection: Connection,
   user: User,
   id: Id
@@ -615,7 +620,8 @@ export const readOneTWUProposal = tryDb<
         connection,
         session,
         result.opportunity,
-        result.id
+        result.id,
+        result.organization
       )
     ) {
       const rawProposalStatuses = await connection<RawHistoryRecord>(
@@ -640,7 +646,8 @@ export const readOneTWUProposal = tryDb<
       session,
       result.opportunity,
       result.id,
-      result.status
+      result.status,
+      result.organization
     );
     result.resourceQuestionResponses =
       getValidValue(
@@ -1380,7 +1387,8 @@ export const readOneTWUAwardedProposal = tryDb<
       session,
       opportunity,
       result.id,
-      result.status
+      result.status,
+      result.organization
     ))
   ) {
     await calculateScores(connection, session, opportunity, [result]);

--- a/src/back-end/lib/db/proposal/team-with-us.ts
+++ b/src/back-end/lib/db/proposal/team-with-us.ts
@@ -530,6 +530,18 @@ export async function isTWUProposalAuthor(
   }
 }
 
+export async function isTWUProposalAuthorOrIsUserOwnerOrAdminOfOrg(
+  connection: Connection,
+  user: User,
+  proposalId: Id,
+  orgId: Id | null
+) {
+  return (
+    (await isTWUProposalAuthor(connection, user, proposalId)) ||
+    (!!orgId && (await isUserOwnerOrAdminOfOrg(connection, user, orgId)))
+  );
+}
+
 export const readManyProposalResourceQuestionResponses = tryDb<
   [Id, boolean?],
   RawTWUProposalResourceQuestionResponse[]

--- a/src/back-end/lib/permissions.ts
+++ b/src/back-end/lib/permissions.ts
@@ -3,10 +3,10 @@ import {
   hasCWUAttachmentPermission,
   hasFilePermission,
   isCWUOpportunityAuthor,
-  isCWUProposalAuthor,
+  isCWUProposalAuthorOrIsUserOwnerOrAdminOfOrg,
   isSWUOpportunityAuthor,
   isTWUOpportunityAuthor,
-  isTWUProposalAuthor,
+  isTWUProposalAuthorOrIsUserOwnerOrAdminOfOrg,
   isUserOwnerOfOrg,
   isUserOwnerOrAdminOfOrg,
   userHasAcceptedCurrentTerms,
@@ -14,7 +14,7 @@ import {
 } from "back-end/lib/db";
 import {
   hasSWUAttachmentPermission,
-  isSWUProposalAuthor
+  isSWUProposalAuthorOrIsUserOwnerOrAdminOfOrg
 } from "back-end/lib/db/proposal/sprint-with-us";
 import { Affiliation } from "shared/lib/resources/affiliation";
 import {
@@ -41,6 +41,7 @@ import {
 import {
   CWUProposal,
   CWUProposalStatus,
+  getCWUProponentOrganizationId,
   isCWUProposalStatusVisibleToGovernment
 } from "shared/lib/resources/proposal/code-with-us";
 import {
@@ -59,6 +60,7 @@ import {
   TWUProposal,
   TWUProposalStatus
 } from "shared/lib/resources/proposal/team-with-us";
+import { Id } from "shared/lib/types";
 
 export const ERROR_MESSAGE =
   "You do not have permission to perform this action.";
@@ -410,10 +412,15 @@ export async function readOneCWUProposal(
       )
     );
   } else if (isVendor(session)) {
-    // If a vendor, only proposals they have authored will be returned (filtered at db layer)
+    // If a vendor, only proposals they or their org have authored will be returned (filtered at db layer)
     return (
       (session &&
-        (await isCWUProposalAuthor(connection, session.user, proposal.id))) ||
+        (await isCWUProposalAuthorOrIsUserOwnerOrAdminOfOrg(
+          connection,
+          session.user,
+          proposal.id,
+          getCWUProponentOrganizationId(proposal)
+        ))) ||
       false
     );
   }
@@ -425,7 +432,8 @@ export async function readCWUProposalScore(
   session: Session,
   opportunityId: string,
   proposalId: string,
-  proposalStatus: CWUProposalStatus
+  proposalStatus: CWUProposalStatus,
+  orgId: Id | null | undefined
 ): Promise<boolean> {
   return (
     isAdmin(session) ||
@@ -436,7 +444,12 @@ export async function readCWUProposalScore(
         opportunityId
       ))) ||
     (session &&
-      (await isCWUProposalAuthor(connection, session.user, proposalId)) &&
+      (await isCWUProposalAuthorOrIsUserOwnerOrAdminOfOrg(
+        connection,
+        session.user,
+        proposalId,
+        orgId ?? null
+      )) &&
       (proposalStatus === CWUProposalStatus.Awarded ||
         proposalStatus === CWUProposalStatus.NotAwarded)) ||
     false
@@ -472,13 +485,18 @@ export async function createCWUProposal(
 export async function editCWUProposal(
   connection: Connection,
   session: Session,
-  proposalId: string,
+  proposal: CWUProposal,
   opportunity: CWUOpportunity
 ): Promise<boolean> {
   return (
     isAdmin(session) ||
     (session &&
-      (await isCWUProposalAuthor(connection, session.user, proposalId)) &&
+      (await isCWUProposalAuthorOrIsUserOwnerOrAdminOfOrg(
+        connection,
+        session.user,
+        proposal.id,
+        getCWUProponentOrganizationId(proposal)
+      )) &&
       (await hasAcceptedPreviousTerms(connection, session))) ||
     (session &&
       (await isCWUOpportunityAuthor(
@@ -494,11 +512,16 @@ export async function editCWUProposal(
 export async function submitCWUProposal(
   connection: Connection,
   session: Session,
-  proposalId: string
+  proposal: CWUProposal
 ): Promise<boolean> {
   return (
     (session &&
-      (await isCWUProposalAuthor(connection, session.user, proposalId)) &&
+      (await isCWUProposalAuthorOrIsUserOwnerOrAdminOfOrg(
+        connection,
+        session.user,
+        proposal.id,
+        getCWUProponentOrganizationId(proposal)
+      )) &&
       (await hasAcceptedCurrentTerms(connection, session))) ||
     false
   );
@@ -507,11 +530,16 @@ export async function submitCWUProposal(
 export async function deleteCWUProposal(
   connection: Connection,
   session: Session,
-  proposalId: string
+  proposal: CWUProposal
 ): Promise<boolean> {
   return (
     (session &&
-      (await isCWUProposalAuthor(connection, session.user, proposalId))) ||
+      (await isCWUProposalAuthorOrIsUserOwnerOrAdminOfOrg(
+        connection,
+        session.user,
+        proposal.id,
+        getCWUProponentOrganizationId(proposal)
+      ))) ||
     false
   );
 }
@@ -609,10 +637,15 @@ export async function readOneSWUProposal(
       )
     );
   } else if (isVendor(session)) {
-    // If a vendor, only proposals they have authored will be returned (filtered at db layer)
+    // If a vendor, only proposals they or their org have authored will be returned (filtered at db layer)
     return (
       (session &&
-        (await isSWUProposalAuthor(connection, session.user, proposal.id))) ||
+        (await isSWUProposalAuthorOrIsUserOwnerOrAdminOfOrg(
+          connection,
+          session.user,
+          proposal.id,
+          proposal.organization?.id ?? null
+        ))) ||
       false
     );
   }
@@ -646,7 +679,8 @@ export async function readSWUProposalHistory(
   connection: Connection,
   session: Session,
   opportunityId: string,
-  proposalId: string
+  proposalId: string,
+  orgId: Id | null
 ): Promise<boolean> {
   return (
     isAdmin(session) ||
@@ -657,7 +691,12 @@ export async function readSWUProposalHistory(
         opportunityId
       ))) ||
     (session &&
-      (await isSWUProposalAuthor(connection, session.user, proposalId))) ||
+      (await isSWUProposalAuthorOrIsUserOwnerOrAdminOfOrg(
+        connection,
+        session.user,
+        proposalId,
+        orgId ?? null
+      ))) ||
     false
   );
 }
@@ -667,7 +706,8 @@ export async function readSWUProposalScore(
   session: Session,
   opportunityId: string,
   proposalId: string,
-  proposalStatus: SWUProposalStatus
+  proposalStatus: SWUProposalStatus,
+  orgId: Id | null
 ): Promise<boolean> {
   return (
     isAdmin(session) ||
@@ -678,7 +718,12 @@ export async function readSWUProposalScore(
         opportunityId
       ))) ||
     (session &&
-      (await isSWUProposalAuthor(connection, session.user, proposalId)) &&
+      (await isSWUProposalAuthorOrIsUserOwnerOrAdminOfOrg(
+        connection,
+        session.user,
+        proposalId,
+        orgId
+      )) &&
       (proposalStatus === SWUProposalStatus.Awarded ||
         proposalStatus === SWUProposalStatus.NotAwarded)) ||
     false
@@ -703,7 +748,11 @@ export async function submitSWUProposal(
     !!session &&
     isVendor(session) &&
     (await hasAcceptedCurrentTerms(connection, session)) &&
-    (await isUserOwnerOfOrg(connection, session.user, organization.id)) &&
+    (await isUserOwnerOrAdminOfOrg(
+      connection,
+      session.user,
+      organization.id
+    )) &&
     doesOrganizationMeetSWUQualification(organization)
   );
 }
@@ -711,13 +760,18 @@ export async function submitSWUProposal(
 export async function editSWUProposal(
   connection: Connection,
   session: Session,
-  proposalId: string,
+  proposal: SWUProposal,
   opportunity: SWUOpportunity
 ): Promise<boolean> {
   return (
     isAdmin(session) ||
     (session &&
-      (await isSWUProposalAuthor(connection, session.user, proposalId)) &&
+      (await isSWUProposalAuthorOrIsUserOwnerOrAdminOfOrg(
+        connection,
+        session.user,
+        proposal.id,
+        proposal.organization?.id ?? null
+      )) &&
       (await hasAcceptedPreviousTerms(connection, session))) ||
     (session &&
       (await isSWUOpportunityAuthor(
@@ -733,11 +787,16 @@ export async function editSWUProposal(
 export async function deleteSWUProposal(
   connection: Connection,
   session: Session,
-  proposalId: string
+  proposal: SWUProposal
 ): Promise<boolean> {
   return (
     (session &&
-      (await isSWUProposalAuthor(connection, session.user, proposalId))) ||
+      (await isSWUProposalAuthorOrIsUserOwnerOrAdminOfOrg(
+        connection,
+        session.user,
+        proposal.id,
+        proposal.organization?.id ?? null
+      ))) ||
     false
   );
 }
@@ -828,13 +887,18 @@ export function suspendTWUOpportunity(session: Session): boolean {
 export async function editTWUProposal(
   connection: Connection,
   session: Session,
-  proposalId: string,
+  proposal: TWUProposal,
   opportunity: TWUOpportunity
 ): Promise<boolean> {
   return (
     isAdmin(session) ||
     (session &&
-      (await isTWUProposalAuthor(connection, session.user, proposalId)) &&
+      (await isTWUProposalAuthorOrIsUserOwnerOrAdminOfOrg(
+        connection,
+        session.user,
+        proposal.id,
+        proposal.organization?.id ?? null
+      )) &&
       (await hasAcceptedPreviousTerms(connection, session))) ||
     (session &&
       (await isTWUOpportunityAuthor(
@@ -874,10 +938,15 @@ export async function readOneTWUProposal(
       )
     );
   } else if (isVendor(session)) {
-    // If a vendor, only proposals they have authored will be returned (filtered at db layer)
+    // If a vendor, only proposals they or their org have authored will be returned (filtered at db layer)
     return (
       (session &&
-        (await isTWUProposalAuthor(connection, session.user, proposal.id))) ||
+        (await isTWUProposalAuthorOrIsUserOwnerOrAdminOfOrg(
+          connection,
+          session.user,
+          proposal.id,
+          proposal.organization?.id ?? null
+        ))) ||
       false
     );
   }
@@ -907,7 +976,8 @@ export async function readTWUProposalHistory(
   connection: Connection,
   session: Session,
   opportunityId: string,
-  proposalId: string
+  proposalId: string,
+  orgId: Id | null
 ): Promise<boolean> {
   return (
     isAdmin(session) ||
@@ -918,7 +988,12 @@ export async function readTWUProposalHistory(
         opportunityId
       ))) ||
     (session &&
-      (await isTWUProposalAuthor(connection, session.user, proposalId))) ||
+      (await isTWUProposalAuthorOrIsUserOwnerOrAdminOfOrg(
+        connection,
+        session.user,
+        proposalId,
+        orgId
+      ))) ||
     false
   );
 }
@@ -928,7 +1003,8 @@ export async function readTWUProposalScore(
   session: Session,
   opportunityId: string,
   proposalId: string,
-  proposalStatus: TWUProposalStatus
+  proposalStatus: TWUProposalStatus,
+  orgId: Id | null
 ): Promise<boolean> {
   return (
     isAdmin(session) ||
@@ -939,7 +1015,12 @@ export async function readTWUProposalScore(
         opportunityId
       ))) ||
     (session &&
-      (await isTWUProposalAuthor(connection, session.user, proposalId)) &&
+      (await isTWUProposalAuthorOrIsUserOwnerOrAdminOfOrg(
+        connection,
+        session.user,
+        proposalId,
+        orgId
+      )) &&
       (proposalStatus === TWUProposalStatus.Awarded ||
         proposalStatus === TWUProposalStatus.NotAwarded)) ||
     false
@@ -967,7 +1048,11 @@ export async function submitTWUProposal(
     !!session &&
     isVendor(session) &&
     (await hasAcceptedCurrentTerms(connection, session)) &&
-    (await isUserOwnerOfOrg(connection, session.user, organization.id)) &&
+    (await isUserOwnerOrAdminOfOrg(
+      connection,
+      session.user,
+      organization.id
+    )) &&
     doesOrganizationMeetTWUQualification(organization)
   );
 }
@@ -982,11 +1067,16 @@ export async function submitTWUProposal(
 export async function deleteTWUProposal(
   connection: Connection,
   session: Session,
-  proposalId: string
+  proposal: TWUProposal
 ): Promise<boolean> {
   return (
     (session &&
-      (await isTWUProposalAuthor(connection, session.user, proposalId))) ||
+      (await isTWUProposalAuthorOrIsUserOwnerOrAdminOfOrg(
+        connection,
+        session.user,
+        proposal.id,
+        proposal.organization?.id ?? null
+      ))) ||
     false
   );
 }

--- a/src/back-end/lib/resources/proposal/code-with-us.ts
+++ b/src/back-end/lib/resources/proposal/code-with-us.ts
@@ -41,6 +41,7 @@ import {
   getValidValue,
   invalid,
   isInvalid,
+  isValid,
   valid,
   Validation
 } from "shared/lib/validation";
@@ -476,7 +477,7 @@ const update: crud.Update<
         !(await permissions.editCWUProposal(
           connection,
           request.session,
-          request.params.id,
+          validatedCWUProposal.value,
           cwuOpportunity
         ))
       ) {
@@ -491,7 +492,7 @@ const update: crud.Update<
         !(await permissions.submitCWUProposal(
           connection,
           request.session,
-          request.params.id
+          validatedCWUProposal.value
         ))
       ) {
         return invalid({
@@ -830,22 +831,23 @@ const delete_: crud.Delete<
 > = (connection: db.Connection) => {
   return {
     async validateRequestBody(request) {
+      const validatedCWUProposal = await validateCWUProposalId(
+        connection,
+        request.params.id,
+        request.session
+      );
       if (
+        isValid(validatedCWUProposal) &&
         !(await permissions.deleteCWUProposal(
           connection,
           request.session,
-          request.params.id
+          validatedCWUProposal.value
         ))
       ) {
         return invalid({
           permissions: [permissions.ERROR_MESSAGE]
         });
       }
-      const validatedCWUProposal = await validateCWUProposalId(
-        connection,
-        request.params.id,
-        request.session
-      );
       if (isInvalid(validatedCWUProposal)) {
         return invalid({
           status: ["You can not delete a proposal that is not a draft."]

--- a/src/back-end/lib/resources/proposal/sprint-with-us.ts
+++ b/src/back-end/lib/resources/proposal/sprint-with-us.ts
@@ -585,7 +585,7 @@ const update: crud.Update<
         !(await permissions.editSWUProposal(
           connection,
           request.session,
-          request.params.id,
+          validatedSWUProposal.value,
           swuOpportunity
         ))
       ) {
@@ -1590,14 +1590,7 @@ const delete_: crud.Delete<
 > = (connection: db.Connection) => {
   return {
     async validateRequestBody(request) {
-      if (
-        !permissions.isSignedIn(request.session) ||
-        !(await permissions.deleteSWUProposal(
-          connection,
-          request.session,
-          request.params.id
-        ))
-      ) {
+      if (!permissions.isSignedIn(request.session)) {
         return invalid({
           permissions: [permissions.ERROR_MESSAGE]
         });
@@ -1607,6 +1600,18 @@ const delete_: crud.Delete<
         request.params.id,
         request.session
       );
+      if (
+        isValid(validatedSWUProposal) &&
+        !(await permissions.deleteSWUProposal(
+          connection,
+          request.session,
+          validatedSWUProposal.value
+        ))
+      ) {
+        return invalid({
+          permissions: [permissions.ERROR_MESSAGE]
+        });
+      }
       if (isInvalid(validatedSWUProposal)) {
         return invalid({
           notFound: ["The specified proposal was not found."]

--- a/src/back-end/lib/resources/proposal/team-with-us.ts
+++ b/src/back-end/lib/resources/proposal/team-with-us.ts
@@ -557,7 +557,7 @@ const update: crud.Update<
         !(await permissions.editTWUProposal(
           connection,
           request.session,
-          request.params.id,
+          validatedTWUProposal.value,
           twuOpportunity
         ))
       ) {
@@ -1223,14 +1223,7 @@ const delete_: crud.Delete<
 > = (connection: db.Connection) => {
   return {
     async validateRequestBody(request) {
-      if (
-        !permissions.isSignedIn(request.session) ||
-        !(await permissions.deleteTWUProposal(
-          connection,
-          request.session,
-          request.params.id
-        ))
-      ) {
+      if (!permissions.isSignedIn(request.session)) {
         return invalid({
           permissions: [permissions.ERROR_MESSAGE]
         });
@@ -1240,6 +1233,18 @@ const delete_: crud.Delete<
         request.params.id,
         request.session
       );
+      if (
+        isValid(validatedTWUProposal) &&
+        !(await permissions.deleteTWUProposal(
+          connection,
+          request.session,
+          validatedTWUProposal.value
+        ))
+      ) {
+        return invalid({
+          permissions: [permissions.ERROR_MESSAGE]
+        });
+      }
       if (isInvalid(validatedTWUProposal)) {
         return invalid({
           notFound: ["The specified proposal was not found."]

--- a/src/front-end/typescript/lib/pages/organization/lib/components/form.tsx
+++ b/src/front-end/typescript/lib/pages/organization/lib/components/form.tsx
@@ -72,7 +72,6 @@ export interface Values
     | "deactivatedOn"
     | "deactivatedBy"
     | "serviceAreas"
-    | "viewerIsOrgAdmin"
     | "history"
   > {
   newLogoImage?: File;

--- a/src/front-end/typescript/lib/pages/organization/list.tsx
+++ b/src/front-end/typescript/lib/pages/organization/list.tsx
@@ -202,14 +202,13 @@ function tableBodyRows(state: Immutable<State>): Table.BodyRows {
     };
     return [
       {
-        children:
-          org.owner || org.viewerIsOrgAdmin ? (
-            <Link dest={routeDest(adt("orgEdit", { orgId: org.id }))}>
-              {org.legalName}
-            </Link>
-          ) : (
-            org.legalName
-          )
+        children: org.owner ? (
+          <Link dest={routeDest(adt("orgEdit", { orgId: org.id }))}>
+            {org.legalName}
+          </Link>
+        ) : (
+          org.legalName
+        )
       },
       ...(showOwnerColumn(state) ? [owner] : [])
     ];

--- a/src/shared/lib/resources/organization.ts
+++ b/src/shared/lib/resources/organization.ts
@@ -23,7 +23,6 @@ export interface OrganizationAdmin {
   possessOneServiceArea?: boolean;
   numTeamMembers?: number;
   serviceAreas: TWUServiceAreaRecord[];
-  viewerIsOrgAdmin?: boolean;
 }
 
 // Populate this as needed

--- a/src/shared/lib/resources/proposal/code-with-us.ts
+++ b/src/shared/lib/resources/proposal/code-with-us.ts
@@ -169,6 +169,13 @@ export function getCWUProponentTypeTitleCase(
   }
 }
 
+export function getCWUProponentOrganizationId(
+  proposal: CWUProposal | CWUProposalSlim
+): Id | null {
+  const proponentId = getCWUProponentId(proposal);
+  return proponentId.tag === "organization" ? proponentId.value : null;
+}
+
 export type CWUProposalSlim = Omit<
   CWUProposal,
   "proposalText" | "additionalComments" | "history" | "attachments"

--- a/tests/back-end/integration/resources/proposals/sprint-with-us.test.ts
+++ b/tests/back-end/integration/resources/proposals/sprint-with-us.test.ts
@@ -123,8 +123,7 @@ test("sprint-with-us proposal crud", async () => {
       "id",
       "legalName",
       "logoImageFile",
-      "active",
-      "viewerIsOrgAdmin"
+      "active"
     ])
   );
 

--- a/tests/back-end/integration/resources/proposals/team-with-us.test.ts
+++ b/tests/back-end/integration/resources/proposals/team-with-us.test.ts
@@ -143,8 +143,7 @@ test("team-with-us proposal crud", async () => {
       "id",
       "legalName",
       "logoImageFile",
-      "active",
-      "viewerIsOrgAdmin"
+      "active"
     ])
   );
 


### PR DESCRIPTION
This PR closes issue: [DMM-273]

Includes tests? [N]
Updated docs? [N]

Proposed changes:
- Allow org admins to perform CRUD actions on their org's proposals
- Provide viewerIsAdmin info to some DB queries 
- `viewerIsAdmin` property ended up being unnecessary in the front-end so I removed it

Additional notes:
- IMPORTANT: We still need to prevent users from submitting if there is an existing proposal associated with the organization
