### PR TITLE
Feat/duplicate proposal alert

### DIFF
--- a/src/back-end/lib/db/affiliation.ts
+++ b/src/back-end/lib/db/affiliation.ts
@@ -132,8 +132,8 @@ export const readOneAffiliation = tryDb<[Id, Id], Affiliation | null>(
   }
 );
 
-export const readOneAffiliationById = tryDb<[Id], Affiliation | null>(
-  async (connection, id) => {
+export const readOneAffiliationById = tryDb<[Id, boolean?], Affiliation | null>(
+  async (connection, id, activeOnly = true) => {
     const result = await connection<RawAffiliation>("affiliations")
       .join(
         "organizations",
@@ -144,7 +144,9 @@ export const readOneAffiliationById = tryDb<[Id], Affiliation | null>(
       .select<RawAffiliation>("affiliations.*")
       .where({ "affiliations.id": id })
       .andWhereNot({
-        "affiliations.membershipStatus": MembershipStatus.Inactive,
+        ...(activeOnly
+          ? { "affiliations.membershipStatus": MembershipStatus.Inactive }
+          : {}),
         "organizations.active": false
       })
       .first();

--- a/src/back-end/lib/db/organization.ts
+++ b/src/back-end/lib/db/organization.ts
@@ -171,7 +171,7 @@ async function rawHistoryRecordToHistoryRecord(
     const { affiliation: affilationId, event: type, ...restOfRaw } = value;
 
     const affiliation = getValidValue(
-      await readOneAffiliationById(connection, affilationId),
+      await readOneAffiliationById(connection, affilationId, false),
       null
     );
 

--- a/src/back-end/lib/db/organization.ts
+++ b/src/back-end/lib/db/organization.ts
@@ -553,7 +553,8 @@ export const readOwnedOrganizations = tryDb<[Session], OrganizationSlim[]>(
         })
         .andWhere({
           "organizations.active": true,
-          "affiliations.user": session.user.id
+          "affiliations.user": session.user.id,
+          "affiliations.membershipStatus": MembershipStatus.Active
         })) as RawOrganization[]) || [];
     return valid(
       await Promise.all(

--- a/src/back-end/lib/db/proposal/code-with-us.ts
+++ b/src/back-end/lib/db/proposal/code-with-us.ts
@@ -570,7 +570,7 @@ export const readOwnCWUProposals = tryDb<
   );
 });
 
-export const readOneProposalWithIdsQuery = (
+const readOneProposalWithIdsQuery = (
   query: (
     connection: Connection,
     ...ids: Id[]

--- a/src/back-end/lib/db/proposal/sprint-with-us.ts
+++ b/src/back-end/lib/db/proposal/sprint-with-us.ts
@@ -624,7 +624,7 @@ export const readOwnSWUProposals = tryDb<
   );
 });
 
-export const readOneSWUProposalWithIdsQuery = (
+const readOneSWUProposalWithIdsQuery = (
   query: (
     connection: Connection,
     ...ids: Id[]
@@ -652,7 +652,7 @@ export const readOneSWUProposalByOpportunityAndAuthor =
 export const readOneSWUProposalByOpportunityAndOrgAuthor =
   readOneSWUProposalWithIdsQuery(
     async (connection, userId, opportunityId, organizationId) =>
-      await connection<RawSWUProposal>("swuProposals")
+      await connection<RawSWUProposal, { id: Id }>("swuProposals")
         .where({ opportunity: opportunityId, organization: organizationId })
         .andWhereNot({ createdBy: userId })
         .select("id")

--- a/src/back-end/lib/db/proposal/team-with-us.ts
+++ b/src/back-end/lib/db/proposal/team-with-us.ts
@@ -499,26 +499,48 @@ export const readOwnTWUProposals = tryDb<
   );
 });
 
+const readOneTWUProposalWithIdsQuery = (
+  query: (
+    connection: Connection,
+    ...ids: Id[]
+  ) => Promise<Pick<RawTWUProposal, "id"> | undefined>
+) =>
+  tryDb<[Session, ...Id[]], Id | null>(async (connection, session, ...ids) => {
+    if (!session) {
+      return valid(null);
+    }
+
+    const result = (await query(connection, session.user.id, ...ids))?.id;
+
+    return valid(result ? result : null);
+  });
+
 /**
  * Used as confirmation that the person creating a proposal is not the same
  * person as who created the opportunity. Returns `valid(null)` on success.
  */
-export const readOneTWUProposalByOpportunityAndAuthor = tryDb<
-  [Id, Session],
-  Id | null
->(async (connection, opportunityId, session) => {
-  if (!session) {
-    return valid(null);
-  }
-  const result = (
-    await connection<{ id: Id }>("twuProposals")
-      .where({ opportunity: opportunityId, createdBy: session.user.id })
-      .select("id")
-      .first()
-  )?.id;
+export const readOneTWUProposalByOpportunityAndAuthor =
+  readOneTWUProposalWithIdsQuery(
+    async (connection, userId, opportunityId) =>
+      await connection<RawTWUProposal, { id: Id }>("twuProposals")
+        .where({ opportunity: opportunityId, createdBy: userId })
+        .select("id")
+        .first()
+  );
 
-  return valid(result ? result : null);
-});
+/**
+ * Used as confirmation that the organization does not have more than one
+ * proposal associated with the opportunity. Returns `valid(null)` on success.
+ */
+export const readOneTWUProposalByOpportunityAndOrgAuthor =
+  readOneTWUProposalWithIdsQuery(
+    async (connection, userId, opportunityId, organizationId) =>
+      await connection<RawTWUProposal, { id: Id }>("twuProposals")
+        .where({ opportunity: opportunityId, organization: organizationId })
+        .andWhereNot({ createdBy: userId })
+        .select("id")
+        .first()
+  );
 
 async function isTWUProposalAuthor(
   connection: Connection,

--- a/src/back-end/lib/resources/proposal/code-with-us.ts
+++ b/src/back-end/lib/resources/proposal/code-with-us.ts
@@ -292,7 +292,18 @@ const create: crud.Create<
           database: [db.ERROR_MESSAGE]
         });
       }
-      if (dbResult.value) {
+      // Check for existing proposal on this opportunity, authored by this user
+      const dbResultProposal = await db.readOneProposalByOpportunityAndAuthor(
+        connection,
+        request.session,
+        opportunity
+      );
+      if (isInvalid(dbResultProposal)) {
+        return invalid({
+          database: [db.ERROR_MESSAGE]
+        });
+      }
+      if (dbResultProposal.value) {
         return invalid({
           conflict: ["You already have a proposal for this opportunity."]
         });

--- a/src/back-end/lib/resources/proposal/code-with-us.ts
+++ b/src/back-end/lib/resources/proposal/code-with-us.ts
@@ -41,7 +41,6 @@ import {
   getValidValue,
   invalid,
   isInvalid,
-  isValid,
   valid,
   Validation
 } from "shared/lib/validation";
@@ -885,8 +884,12 @@ const delete_: crud.Delete<
         request.params.id,
         request.session
       );
+      if (isInvalid(validatedCWUProposal)) {
+        return invalid({
+          status: ["You can not delete a proposal that is not a draft."]
+        });
+      }
       if (
-        isValid(validatedCWUProposal) &&
         !(await permissions.deleteCWUProposal(
           connection,
           request.session,
@@ -895,11 +898,6 @@ const delete_: crud.Delete<
       ) {
         return invalid({
           permissions: [permissions.ERROR_MESSAGE]
-        });
-      }
-      if (isInvalid(validatedCWUProposal)) {
-        return invalid({
-          status: ["You can not delete a proposal that is not a draft."]
         });
       }
       if (validatedCWUProposal.value.status !== CWUProposalStatus.Draft) {

--- a/src/back-end/lib/resources/proposal/sprint-with-us.ts
+++ b/src/back-end/lib/resources/proposal/sprint-with-us.ts
@@ -1600,8 +1600,12 @@ const delete_: crud.Delete<
         request.params.id,
         request.session
       );
+      if (isInvalid(validatedSWUProposal)) {
+        return invalid({
+          notFound: ["The specified proposal was not found."]
+        });
+      }
       if (
-        isValid(validatedSWUProposal) &&
         !(await permissions.deleteSWUProposal(
           connection,
           request.session,
@@ -1610,11 +1614,6 @@ const delete_: crud.Delete<
       ) {
         return invalid({
           permissions: [permissions.ERROR_MESSAGE]
-        });
-      }
-      if (isInvalid(validatedSWUProposal)) {
-        return invalid({
-          notFound: ["The specified proposal was not found."]
         });
       }
       if (validatedSWUProposal.value.status !== SWUProposalStatus.Draft) {

--- a/src/back-end/lib/resources/proposal/team-with-us.ts
+++ b/src/back-end/lib/resources/proposal/team-with-us.ts
@@ -297,21 +297,46 @@ const create: crud.Create<
         });
       }
 
+      // Check for existing proposal on this opportunity, authored by this user
+      if (organization) {
+        const dbResultOrgProposal =
+          await db.readOneTWUProposalByOpportunityAndOrgAuthor(
+            connection,
+            request.session,
+            opportunity,
+            organization
+          );
+        if (isInvalid(dbResultOrgProposal)) {
+          return invalid({
+            database: [db.ERROR_MESSAGE]
+          });
+        }
+        if (dbResultOrgProposal.value) {
+          return invalid({
+            existingOrganizationProposal: {
+              proposalId: dbResultOrgProposal.value,
+              errors: ["Please select a different organization."]
+            }
+          });
+        }
+      }
+
       /**
        * Check for existing proposal on this opportunity, authored by this user
        * If the person is not the author, dbResult will be valid(null)
        */
-      const dbResult = await db.readOneTWUProposalByOpportunityAndAuthor(
-        connection,
-        opportunity,
-        request.session
-      );
-      if (isInvalid(dbResult)) {
+      const dbResultProposal =
+        await db.readOneTWUProposalByOpportunityAndAuthor(
+          connection,
+          request.session,
+          opportunity
+        );
+      if (isInvalid(dbResultProposal)) {
         return invalid({
           database: [db.ERROR_MESSAGE]
         });
       }
-      if (dbResult.value) {
+      if (dbResultProposal.value) {
         return invalid({
           conflict: ["You already have a proposal for this opportunity."]
         });
@@ -598,6 +623,32 @@ const update: crud.Update<
                 ]
               })
             });
+          }
+
+          // Check for existing proposal on this opportunity, authored by this user
+          if (validatedOrganization.value) {
+            const dbResult =
+              await db.readOneTWUProposalByOpportunityAndOrgAuthor(
+                connection,
+                request.session,
+                twuOpportunity.id,
+                validatedOrganization.value.id
+              );
+            if (isInvalid(dbResult)) {
+              return invalid({
+                database: [db.ERROR_MESSAGE]
+              });
+            }
+            if (dbResult.value && dbResult.value !== request.params.id) {
+              return invalid({
+                proposal: adt("edit" as const, {
+                  existingOrganizationProposal: {
+                    proposalId: dbResult.value,
+                    errors: ["Please select a different organization."]
+                  }
+                })
+              });
+            }
           }
 
           // Attachments must be validated for both drafts and published opportunities

--- a/src/back-end/lib/resources/proposal/team-with-us.ts
+++ b/src/back-end/lib/resources/proposal/team-with-us.ts
@@ -1233,8 +1233,12 @@ const delete_: crud.Delete<
         request.params.id,
         request.session
       );
+      if (isInvalid(validatedTWUProposal)) {
+        return invalid({
+          notFound: ["The specified proposal was not found."]
+        });
+      }
       if (
-        isValid(validatedTWUProposal) &&
         !(await permissions.deleteTWUProposal(
           connection,
           request.session,
@@ -1243,11 +1247,6 @@ const delete_: crud.Delete<
       ) {
         return invalid({
           permissions: [permissions.ERROR_MESSAGE]
-        });
-      }
-      if (isInvalid(validatedTWUProposal)) {
-        return invalid({
-          notFound: ["The specified proposal was not found."]
         });
       }
       if (validatedTWUProposal.value.status !== TWUProposalStatus.Draft) {

--- a/src/front-end/typescript/lib/pages/proposal/code-with-us/create.tsx
+++ b/src/front-end/typescript/lib/pages/proposal/code-with-us/create.tsx
@@ -1,5 +1,6 @@
 import {
   getActionsValid,
+  getAlertsValid,
   getMetadataValid,
   getModalValid,
   makePageMetadata,
@@ -547,6 +548,12 @@ export const component: component_.page.Component<
         : "Create Code With Us Proposal"
     );
   }, makePageMetadata("Create Code With Us Proposal")),
+
+  getAlerts: getAlertsValid<ValidState, Msg>((state) => {
+    return state.form
+      ? Form.getAlerts(state.form)
+      : component_.page.alerts.empty();
+  }),
 
   getActions: getActionsValid(({ state, dispatch }) => {
     const form = state.form;

--- a/src/front-end/typescript/lib/pages/proposal/code-with-us/edit/tab/proposal.tsx
+++ b/src/front-end/typescript/lib/pages/proposal/code-with-us/edit/tab/proposal.tsx
@@ -783,6 +783,12 @@ export const component: Tab.Component<State, Msg> = {
     return adt("onInitResponse", response) as InnerMsg;
   },
 
+  getAlerts: (state) => {
+    return state.form
+      ? Form.getAlerts(state.form)
+      : component_.page.alerts.empty();
+  },
+
   getModal: (state) => {
     const hasAcceptedTerms =
       SubmitProposalTerms.getProposalCheckbox(state.submitTerms) &&

--- a/src/front-end/typescript/lib/pages/proposal/code-with-us/lib/components/form.tsx
+++ b/src/front-end/typescript/lib/pages/proposal/code-with-us/lib/components/form.tsx
@@ -1152,3 +1152,35 @@ export const view: component_.base.View<Props> = (props) => {
     </TabbedFormComponent.view>
   );
 };
+
+export function getAlerts<Msg>(
+  state: Immutable<State>
+): component_.page.Alerts<Msg> {
+  return {
+    errors: (() => {
+      if (state.existingProposalForOrganizationError) {
+        return [
+          {
+            text: (
+              <span>
+                The selected organization already has a proposal with this
+                opportunity. You may access it{" "}
+                <Link
+                  dest={routeDest(
+                    adt("proposalCWUEdit", {
+                      proposalId: state.existingProposalForOrganizationError,
+                      opportunityId: state.opportunity.id
+                    })
+                  )}>
+                  here
+                </Link>
+                .
+              </span>
+            )
+          }
+        ];
+      }
+      return [];
+    })()
+  };
+}

--- a/src/front-end/typescript/lib/pages/proposal/code-with-us/lib/components/form.tsx
+++ b/src/front-end/typescript/lib/pages/proposal/code-with-us/lib/components/form.tsx
@@ -19,7 +19,8 @@ import { Alert, Col, Row } from "reactstrap";
 import { compareStrings, getString } from "shared/lib";
 import {
   AffiliationSlim,
-  MembershipType
+  memberIsOrgAdmin,
+  memberIsOwner
 } from "shared/lib/resources/affiliation";
 import { FileUploadMetadata } from "shared/lib/resources/file";
 import { CWUOpportunity } from "shared/lib/resources/opportunity/code-with-us";
@@ -258,7 +259,7 @@ export const init: component_.base.Init<Params, State, Msg> = ({
       options: adt(
         "options",
         affiliations
-          .filter((a) => a.membershipType === MembershipType.Owner)
+          .filter((a) => memberIsOwner(a) || memberIsOrgAdmin(a))
           .sort((a, b) =>
             compareStrings(a.organization.legalName, b.organization.legalName)
           )

--- a/src/front-end/typescript/lib/pages/proposal/code-with-us/lib/components/form.tsx
+++ b/src/front-end/typescript/lib/pages/proposal/code-with-us/lib/components/form.tsx
@@ -76,6 +76,7 @@ export interface State {
   showEvaluationCriteria: boolean;
   proposalText: Immutable<RichMarkdownEditor.State>;
   additionalComments: Immutable<RichMarkdownEditor.State>;
+  existingProposalForOrganizationError: Id | null;
   // Attachments tab
   attachments: Immutable<Attachments.State>;
 }
@@ -312,7 +313,8 @@ export const init: component_.base.Init<Params, State, Msg> = ({
       organization: immutable(organizationState),
       proposalText: immutable(proposalTextState),
       additionalComments: immutable(additionalCommentsState),
-      attachments: immutable(attachmentsState)
+      attachments: immutable(attachmentsState),
+      existingProposalForOrganizationError: null
     },
     [
       ...component_.cmd.mapMany(tabbedFormCmds, (msg) =>
@@ -584,8 +586,10 @@ function setErrors(state: Immutable<State>, errors?: Errors): Immutable<State> {
       ? errors.proponent.value
       : {};
   const organizationErrors =
-    errors && errors.proponent && errors.proponent.tag === "organization"
+    errors?.proponent?.tag === "organization"
       ? errors.proponent.value
+      : errors?.existingOrganizationProposal
+      ? errors.existingOrganizationProposal.errors
       : [];
   return state
     .update("proposalText", (s) =>
@@ -624,7 +628,13 @@ function setErrors(state: Immutable<State>, errors?: Errors): Immutable<State> {
     .update("country", (s) =>
       FormField.setErrors(s, individualProponentErrors.country || [])
     )
-    .update("organization", (s) => FormField.setErrors(s, organizationErrors));
+    .update("organization", (s) => FormField.setErrors(s, organizationErrors))
+    .set(
+      "existingProposalForOrganizationError",
+      errors?.existingOrganizationProposal
+        ? errors.existingOrganizationProposal.proposalId
+        : null
+    );
 }
 
 export function validate(state: Immutable<State>): Immutable<State> {

--- a/src/front-end/typescript/lib/pages/proposal/sprint-with-us/lib/components/form.tsx
+++ b/src/front-end/typescript/lib/pages/proposal/sprint-with-us/lib/components/form.tsx
@@ -388,9 +388,7 @@ export function setErrors(
     ? errors.existingOrganizationProposal.errors
     : [];
   return state
-    .update("organization", (s) =>
-      FormField.setErrors(s, organizationErrors || [])
-    )
+    .update("organization", (s) => FormField.setErrors(s, organizationErrors))
     .update("team", (s) =>
       Team.setErrors(s, {
         inceptionPhase: errors?.inceptionPhase,

--- a/src/front-end/typescript/lib/pages/proposal/sprint-with-us/lib/components/form.tsx
+++ b/src/front-end/typescript/lib/pages/proposal/sprint-with-us/lib/components/form.tsx
@@ -1549,6 +1549,31 @@ export function getAlerts<Msg>(
       } else {
         return [];
       }
+    })(),
+    errors: (() => {
+      if (state.existingProposalForOrganizationError) {
+        return [
+          {
+            text: (
+              <span>
+                The selected organization already has a proposal with this
+                opportunity. You may access it{" "}
+                <Link
+                  dest={routeDest(
+                    adt("proposalSWUEdit", {
+                      proposalId: state.existingProposalForOrganizationError,
+                      opportunityId: state.opportunity.id
+                    })
+                  )}>
+                  here
+                </Link>
+                .
+              </span>
+            )
+          }
+        ];
+      }
+      return [];
     })()
   };
 }

--- a/src/front-end/typescript/lib/pages/proposal/sprint-with-us/lib/components/form.tsx
+++ b/src/front-end/typescript/lib/pages/proposal/sprint-with-us/lib/components/form.tsx
@@ -118,6 +118,7 @@ export interface State
   isReviewPrototypePhaseAccordionOpen: boolean;
   isReviewImplementationPhaseAccordionOpen: boolean;
   openReviewTeamQuestionResponseAccordions: Set<number>;
+  existingProposalForOrganizationError: Id | null;
 }
 
 export type Msg =
@@ -340,7 +341,8 @@ export const init: component_.base.Init<Params, State, Msg> = ({
       implementationCost: immutable(implementationCostState),
       totalCost: immutable(totalCostState),
       teamQuestions: immutable(teamQuestionsState),
-      references: immutable(referencesState)
+      references: immutable(referencesState),
+      existingProposalForOrganizationError: null
     },
     [
       ...component_.cmd.mapMany(tabbedFormCmds, (msg) =>
@@ -380,9 +382,14 @@ export function setErrors(
   state: Immutable<State>,
   errors?: Errors
 ): Immutable<State> {
+  const organizationErrors = errors?.organization
+    ? errors.organization
+    : errors?.existingOrganizationProposal
+    ? errors.existingOrganizationProposal.errors
+    : [];
   return state
     .update("organization", (s) =>
-      FormField.setErrors(s, errors?.organization || [])
+      FormField.setErrors(s, organizationErrors || [])
     )
     .update("team", (s) =>
       Team.setErrors(s, {
@@ -415,6 +422,12 @@ export function setErrors(
     )
     .update("references", (s) =>
       References.setErrors(s, errors?.references || [])
+    )
+    .set(
+      "existingProposalForOrganizationError",
+      errors?.existingOrganizationProposal
+        ? errors.existingOrganizationProposal.proposalId
+        : null
     );
 }
 

--- a/src/front-end/typescript/lib/pages/proposal/team-with-us/lib/components/form.tsx
+++ b/src/front-end/typescript/lib/pages/proposal/team-with-us/lib/components/form.tsx
@@ -1172,6 +1172,31 @@ export function getAlerts<Msg>(
       } else {
         return [];
       }
+    })(),
+    errors: (() => {
+      if (state.existingProposalForOrganizationError) {
+        return [
+          {
+            text: (
+              <span>
+                The selected organization already has a proposal with this
+                opportunity. You may access it{" "}
+                <Link
+                  dest={routeDest(
+                    adt("proposalTWUEdit", {
+                      proposalId: state.existingProposalForOrganizationError,
+                      opportunityId: state.opportunity.id
+                    })
+                  )}>
+                  here
+                </Link>
+                .
+              </span>
+            )
+          }
+        ];
+      }
+      return [];
     })()
   };
 }

--- a/src/front-end/typescript/lib/pages/proposal/team-with-us/lib/components/form.tsx
+++ b/src/front-end/typescript/lib/pages/proposal/team-with-us/lib/components/form.tsx
@@ -94,6 +94,7 @@ export interface State
   resourceQuestions: Immutable<ResourceQuestions.State>;
   // Review Proposal Tab
   openReviewResourceQuestionResponseAccordions: Set<number>;
+  existingProposalForOrganizationError: Id | null;
 }
 
 export type Msg =
@@ -228,7 +229,8 @@ export const init: component_.base.Init<Params, State, Msg> = ({
       organization: immutable(organizationState),
       team: immutable(teamState),
       hourlyRate: immutable(hourlyRateState),
-      resourceQuestions: immutable(resourceQuestionsState)
+      resourceQuestions: immutable(resourceQuestionsState),
+      existingProposalForOrganizationError: null
     },
     [
       ...component_.cmd.mapMany(tabbedFormCmds, (msg) =>
@@ -258,11 +260,15 @@ export function setErrors(
   state: Immutable<State>,
   errors?: Errors
 ): Immutable<State> {
+  const organizationErrors = errors?.organization
+    ? errors.organization
+    : errors?.existingOrganizationProposal
+    ? errors.existingOrganizationProposal.errors
+    : [];
   return (
     state
-      .update("organization", (s) =>
-        FormField.setErrors(s, errors?.organization || [])
-      )
+      .update("organization", (s) => FormField.setErrors(s, organizationErrors))
+      // TODO: Populate the rest of the form errors correctly.
       // .update( "team", (s) =>
       //   Team.setErrors(s, {
       //     team.errors?team
@@ -281,6 +287,12 @@ export function setErrors(
             (errors as CreateValidationErrors).resourceQuestionResponses) ||
             []
         )
+      )
+      .set(
+        "existingProposalForOrganizationError",
+        errors?.existingOrganizationProposal
+          ? errors.existingOrganizationProposal.proposalId
+          : null
       )
   );
 }

--- a/src/shared/lib/resources/proposal/code-with-us.ts
+++ b/src/shared/lib/resources/proposal/code-with-us.ts
@@ -250,6 +250,7 @@ export interface CreateValidationErrors
     ErrorTypeFrom<CreateRequestBody> & BodyWithErrors,
     "proponent" | "attachments"
   > {
+  existingOrganizationProposal?: { proposalId: Id; errors: string[] };
   proponent?: CreateProponentValidationErrors;
   attachments?: string[][];
 }
@@ -280,6 +281,7 @@ export interface UpdateEditValidationErrors
   extends ErrorTypeFrom<
     Omit<UpdateEditRequestBody, "proponent" | "attachments">
   > {
+  existingOrganizationProposal?: { proposalId: Id; errors: string[] };
   proponent?: CreateProponentValidationErrors;
   attachments?: string[][];
 }

--- a/src/shared/lib/resources/proposal/sprint-with-us.ts
+++ b/src/shared/lib/resources/proposal/sprint-with-us.ts
@@ -305,6 +305,7 @@ export interface CreateValidationErrors extends BodyWithErrors {
   references?: CreateSWUProposalReferenceValidationErrors[];
   teamQuestionResponses?: CreateSWUProposalTeamQuestionResponseValidationErrors[];
   organization?: string[];
+  existingOrganizationProposal?: { proposalId: Id; errors: string[] };
   opportunity?: string[];
   status?: string[];
   totalProposedCost?: string[];
@@ -365,6 +366,7 @@ export interface UpdateEditValidationErrors {
   implementationPhase?: CreateSWUProposalPhaseValidationErrors;
   references?: CreateSWUProposalReferenceValidationErrors[];
   organization?: string[];
+  existingOrganizationProposal?: { proposalId: Id; errors: string[] };
 }
 
 export interface UpdateValidationErrors extends BodyWithErrors {

--- a/src/shared/lib/resources/proposal/team-with-us.ts
+++ b/src/shared/lib/resources/proposal/team-with-us.ts
@@ -208,6 +208,7 @@ export interface CreateValidationErrors extends BodyWithErrors {
   attachments?: string[][];
   resourceQuestionResponses?: CreateTWUProposalResourceQuestionResponseValidationErrors[];
   organization?: string[];
+  existingOrganizationProposal?: { proposalId: Id; errors: string[] };
   opportunity?: string[];
   status?: string[];
   team?: CreateTWUProposalTeamMemberValidationErrors[];
@@ -257,6 +258,7 @@ export interface UpdateResourceQuestionScoreValidationErrors {
 export interface UpdateEditValidationErrors {
   attachments?: string[][];
   organization?: string[];
+  existingOrganizationProposal?: { proposalId: Id; errors: string[] };
 }
 
 export interface UpdateValidationErrors extends BodyWithErrors {


### PR DESCRIPTION
This PR closes issue: [DMM-367]

Includes tests? [N]
Updated docs? [N]

Proposed changes:
- Read Org Proposals for CWU, SWU, and TWU on create and edit
- Generate existingOrganizationProposal error if there's an existing proposal on create
- Generate existingOrganizationProposal error if there's an existing proposal with a different id on edit
- Provide readOneAffiliationById an `activeOnly` parameter to specify types of affiliations read
- Include inactive affiliations when generating organization history

Additional notes:
- Missing "Submitted <Date> By <User> | Updated <Date> By <User>" format in edit headers
