### PR TITLE
Feat/multi user proposal UI

### DIFF
--- a/src/front-end/typescript/config.ts
+++ b/src/front-end/typescript/config.ts
@@ -35,6 +35,8 @@ export const DROPDOWN_CARET_SIZE = 0.8; //rem
 
 export const TOAST_AUTO_DISMISS_DURATION = 20000; //ms
 
+export const PROPOSAL_POLL_DURATION = 10000; //ms
+
 export const APP_TERMS_CONTENT_ID = "terms-and-conditions";
 
 export const SWU_PROPOSAL_EVALUATION_CONTENT_ID =

--- a/src/front-end/typescript/lib/pages/proposal/code-with-us/edit/tab/proposal.tsx
+++ b/src/front-end/typescript/lib/pages/proposal/code-with-us/edit/tab/proposal.tsx
@@ -985,17 +985,28 @@ export const component: Tab.Component<State, Msg> = {
       case "orgProposalChangeDetected":
         return component_.page.modal.show({
           title: "Proposal Changes Detected",
-          body: () =>
-            "Changes have been made to this proposal, please save your changes offline and refresh the page.",
+          body: () => (
+            <>
+              <p>
+                Someone else in your organization has submitted changes to this
+                proposal since you started editing it.
+              </p>
+              <p>Your options are:</p>
+              <ol>
+                <li>
+                  Save your changes to a document offline, cancel editing, and
+                  re-enter your changes.
+                </li>
+                <li>
+                  Keep working, and when you submit, your version{" "}
+                  <strong>will</strong> overwrite the previously submitted
+                  changes.
+                </li>
+              </ol>
+            </>
+          ),
           onCloseMsg: adt("hideModal") as Msg,
-          actions: [
-            {
-              text: "<Action>",
-              color: "info",
-              msg: adt("hideModal"),
-              button: true
-            }
-          ]
+          actions: []
         });
       case null:
         return component_.page.modal.hide();

--- a/src/front-end/typescript/lib/pages/proposal/code-with-us/edit/tab/proposal.tsx
+++ b/src/front-end/typescript/lib/pages/proposal/code-with-us/edit/tab/proposal.tsx
@@ -321,7 +321,7 @@ const update: component_.page.Update<State, InnerMsg, Route> = ({
           .set("proposal", proposalResult.value),
         [
           ...component_.cmd.mapMany(formCmds, (msg) => adt("form", msg) as Msg),
-          component_.cmd.dispatch(adt("checkStatus"))
+          component_.cmd.dispatch(adt("checkStatus") as Msg)
         ]
       ];
     }
@@ -749,7 +749,7 @@ const update: component_.page.Update<State, InnerMsg, Route> = ({
         [
           component_.cmd.delayedDispatch(
             PROPOSAL_POLL_DURATION,
-            adt("checkStatus")
+            adt("checkStatus") as Msg
           )
         ]
       ];

--- a/src/front-end/typescript/lib/pages/proposal/sprint-with-us/edit/tab/proposal.tsx
+++ b/src/front-end/typescript/lib/pages/proposal/sprint-with-us/edit/tab/proposal.tsx
@@ -1,4 +1,7 @@
-import { SWU_PROPOSAL_EVALUATION_CONTENT_ID } from "front-end/config";
+import {
+  PROPOSAL_POLL_DURATION,
+  SWU_PROPOSAL_EVALUATION_CONTENT_ID
+} from "front-end/config";
 import { makeStartLoading, makeStopLoading } from "front-end/lib";
 import { Route } from "front-end/lib/app/types";
 import * as SubmitProposalTerms from "front-end/lib/components/submit-proposal-terms";
@@ -40,7 +43,8 @@ type ModalId =
   | "saveChangesAndSubmit"
   | "withdrawBeforeDeadline"
   | "withdrawAfterDeadline"
-  | "delete";
+  | "delete"
+  | "orgProposalChangeDetected";
 
 export interface State extends Tab.Params {
   organizations: OrganizationSlim[];
@@ -103,7 +107,9 @@ export type InnerMsg =
   | ADT<
       "onDeleteResponse",
       api.ResponseValidation<SWUProposal, DeleteValidationErrors>
-    >;
+    >
+  | ADT<"checkStatus">
+  | ADT<"onCheckStatusResponse", api.ResponseValidation<SWUProposal, string[]>>;
 
 export type Msg = component_.page.Msg<InnerMsg, Route>;
 
@@ -284,7 +290,10 @@ const update: component_.base.Update<State, Msg> = ({ state, msg }) => {
         result.value,
         result.value.status === SWUProposalStatus.Draft
       );
-      return [newState.set("isEditing", true), cmds];
+      return [
+        newState.set("isEditing", true),
+        [...cmds, component_.cmd.dispatch(adt("checkStatus") as Msg)]
+      ];
     }
     case "cancelEditing": {
       const [newState, cmds] = resetProposal(state, state.proposal);
@@ -670,6 +679,46 @@ const update: component_.base.Update<State, Msg> = ({ state, msg }) => {
         ]
       ];
     }
+    case "checkStatus": {
+      return [
+        state,
+        state.isEditing
+          ? [
+              api.proposals.swu.readOne<Msg>(state.proposal.opportunity.id)(
+                state.proposal.id,
+                (result) => adt("onCheckStatusResponse", result)
+              )
+            ]
+          : []
+      ];
+    }
+    case "onCheckStatusResponse": {
+      const incomingProposal = api.getValidValue(msg.value, null);
+      if (!incomingProposal) {
+        return [state, []];
+      }
+
+      if (incomingProposal.updatedAt > state.proposal.updatedAt) {
+        return [
+          state,
+          [
+            component_.cmd.dispatch(
+              adt("showModal", "orgProposalChangeDetected" as const) as Msg
+            )
+          ]
+        ];
+      }
+
+      return [
+        state,
+        [
+          component_.cmd.delayedDispatch(
+            PROPOSAL_POLL_DURATION,
+            adt("checkStatus") as Msg
+          )
+        ]
+      ];
+    }
     default:
       return [state, []];
   }
@@ -888,6 +937,21 @@ export const component: Tab.Component<State, Msg> = {
               text: "Cancel",
               color: "secondary",
               msg: adt("hideModal")
+            }
+          ]
+        });
+      case "orgProposalChangeDetected":
+        return component_.page.modal.show({
+          title: "Proposal Changes Detected",
+          body: () =>
+            "Changes have been made to this proposal, please save your changes offline and refresh the page.",
+          onCloseMsg: adt("hideModal") as Msg,
+          actions: [
+            {
+              text: "<Action>",
+              color: "info",
+              msg: adt("hideModal"),
+              button: true
             }
           ]
         });

--- a/src/front-end/typescript/lib/pages/proposal/sprint-with-us/edit/tab/proposal.tsx
+++ b/src/front-end/typescript/lib/pages/proposal/sprint-with-us/edit/tab/proposal.tsx
@@ -943,17 +943,28 @@ export const component: Tab.Component<State, Msg> = {
       case "orgProposalChangeDetected":
         return component_.page.modal.show({
           title: "Proposal Changes Detected",
-          body: () =>
-            "Changes have been made to this proposal, please save your changes offline and refresh the page.",
+          body: () => (
+            <>
+              <p>
+                Someone else in your organization has submitted changes to this
+                proposal since you started editing it.
+              </p>
+              <p>Your options are:</p>
+              <ol>
+                <li>
+                  Save your changes to a document offline, cancel editing, and
+                  re-enter your changes.
+                </li>
+                <li>
+                  Keep working, and when you submit, your version{" "}
+                  <strong>will</strong> overwrite the previously submitted
+                  changes.
+                </li>
+              </ol>
+            </>
+          ),
           onCloseMsg: adt("hideModal") as Msg,
-          actions: [
-            {
-              text: "<Action>",
-              color: "info",
-              msg: adt("hideModal"),
-              button: true
-            }
-          ]
+          actions: []
         });
       case null:
         return component_.page.modal.hide();


### PR DESCRIPTION
This PR closes issue: [DMM-299

Includes tests? [N]
Updated docs? [N]

Proposed changes:
- Poll backend for changes to a "shared" proposal"
- If the incoming updatedAt > state updatedAt, stop polling and display a modal warning the viewer user they can either save their changes offline or continue and overwrite their changes

Additional notes:
- Polling is only active while the viewer user is editing
