### PR TITLE
Fix: Under Review Status Filter

### DIFF
--- a/src/front-end/typescript/lib/pages/opportunity/list.tsx
+++ b/src/front-end/typescript/lib/pages/opportunity/list.tsx
@@ -57,6 +57,26 @@ interface CategorizedOpportunities {
 
 type OpportunityCategory = keyof CategorizedOpportunities;
 
+const opportunityStatusOptions = [
+  { label: "Draft", value: "draft" } as const,
+  { label: "Under Review", value: "under_review" } as const,
+  { label: "Published", value: "published" } as const,
+  { label: "Suspended", value: "suspended" } as const,
+  { label: "Evaluation", value: "evaluation" } as const,
+  { label: "Awarded", value: "awarded" } as const
+];
+
+type OpportunityStatusOptionValue =
+  typeof opportunityStatusOptions[number]["value"];
+
+function isOpportunityStatusOptionValue(
+  oppStatusValue: string | undefined
+): oppStatusValue is OpportunityStatusOptionValue {
+  return opportunityStatusOptions.some(
+    (oppOption) => oppOption.value === oppStatusValue
+  );
+}
+
 export interface State {
   viewerUser?: User;
   toggleWatchLoading: [OpportunityCategory, Id] | null;
@@ -214,14 +234,7 @@ const init: component_.page.Init<
     child: {
       value: null,
       id: "opportunity-filter-status",
-      options: adt("options", [
-        { label: "Draft", value: "draft" },
-        { label: "Under Review", value: "under_Review" },
-        { label: "Published", value: "published" },
-        { label: "Suspended", value: "suspended" },
-        { label: "Evaluation", value: "evaluation" },
-        { label: "Awarded", value: "awarded" }
-      ])
+      options: adt("options", opportunityStatusOptions)
     }
   });
   const [remoteOkFilterState, remoteOkFilterCmds] = Checkbox.init({
@@ -314,7 +327,11 @@ function filter(
     if (remoteOk && !o.value.remoteOk) {
       return false;
     }
-    if (oppStatus && !doesOppHaveStatus(o, oppStatus)) {
+    if (
+      oppStatus &&
+      isOpportunityStatusOptionValue(oppStatus) &&
+      !doesOppHaveStatus(o, oppStatus)
+    ) {
       return false;
     }
     if (
@@ -328,7 +345,10 @@ function filter(
   });
 }
 
-function doesOppHaveStatus(opp: Opportunity, oppStatus: string): boolean {
+function doesOppHaveStatus(
+  opp: Opportunity,
+  oppStatus: OpportunityStatusOptionValue
+): boolean {
   return (
     (oppStatus === "draft" &&
       [

--- a/src/front-end/typescript/lib/pages/opportunity/list.tsx
+++ b/src/front-end/typescript/lib/pages/opportunity/list.tsx
@@ -328,7 +328,6 @@ function filter(
       return false;
     }
     if (
-      oppStatus &&
       isOpportunityStatusOptionValue(oppStatus) &&
       !doesOppHaveStatus(o, oppStatus)
     ) {

--- a/src/front-end/typescript/lib/pages/opportunity/list.tsx
+++ b/src/front-end/typescript/lib/pages/opportunity/list.tsx
@@ -357,7 +357,11 @@ function doesOppHaveStatus(
         TWUO.TWUOpportunityStatus.Draft
       ].includes(opp.value.status)) ||
     (oppStatus === "under_review" &&
-      SWUO.SWUOpportunityStatus.UnderReview === opp.value.status) ||
+      [
+        CWUO.CWUOpportunityStatus.UnderReview,
+        SWUO.SWUOpportunityStatus.UnderReview,
+        TWUO.TWUOpportunityStatus.UnderReview
+      ].includes(opp.value.status)) ||
     (oppStatus === "published" &&
       [
         CWUO.CWUOpportunityStatus.Published,


### PR DESCRIPTION
This PR closes issue: [DMM-281, DMM-372]

Includes tests? [N]
Updated docs? [N]

Proposed changes:
- Populate select options from a list
- Add type safety to the `doesOppHaveStatus` function via the guard function `isOpportunityStatusOptionValue`
- Added specific conditions to check for CWU and TWU "Under Review" statuses (moot because all "Under Review" program statuses have the same value, but I suppose this could change in the future)

Additional notes:
- The was a mismatch in one of the conditions in the doesOppHaveStatus function and a value used by the select component