### PR TITLE
Bug/scoresheet

### DIFF
--- a/src/back-end/lib/db/proposal/sprint-with-us.ts
+++ b/src/back-end/lib/db/proposal/sprint-with-us.ts
@@ -1946,10 +1946,10 @@ async function calculateScores<T extends RawSWUProposal | RawSWUProposalSlim>(
     const proposalScoring = proposalScorings.find((s) => s.id === proposal.id);
     if (proposalScoring) {
       const includeTotalScore =
-        proposalScoring.questionsScore !== null &&
-        proposalScoring.challengeScore !== null &&
-        proposalScoring.scenarioScore !== null &&
-        proposalScoring.priceScore !== null;
+        proposalScoring.questionsScore === null &&
+        proposalScoring.challengeScore === null &&
+        proposalScoring.scenarioScore === null &&
+        proposalScoring.priceScore === null;
       if (
         session.user.type !== UserType.Vendor ||
         proposal.status === SWUProposalStatus.Awarded ||
@@ -1961,8 +1961,8 @@ async function calculateScores<T extends RawSWUProposal | RawSWUProposalSlim>(
         proposal.priceScore = proposalScoring.priceScore || undefined;
         proposal.rank = proposalScoring.rank || undefined;
         proposal.totalScore = includeTotalScore
-          ? proposalScoring.totalScore || undefined
-          : undefined;
+          ? undefined
+          : proposalScoring.totalScore || undefined;
       }
     }
   });

--- a/src/back-end/lib/db/proposal/team-with-us.ts
+++ b/src/back-end/lib/db/proposal/team-with-us.ts
@@ -1599,9 +1599,9 @@ async function calculateScores<T extends RawTWUProposal | RawTWUProposalSlim>(
     const proposalScoring = proposalScorings.find((s) => s.id === proposal.id);
     if (proposalScoring) {
       const includeTotalScore =
-        proposalScoring.questionsScore !== null &&
-        proposalScoring.challengeScore !== null &&
-        proposalScoring.priceScore !== null;
+        proposalScoring.questionsScore === null &&
+        proposalScoring.challengeScore === null &&
+        proposalScoring.priceScore === null;
       if (
         session.user.type !== UserType.Vendor ||
         proposal.status === TWUProposalStatus.Awarded ||
@@ -1612,8 +1612,8 @@ async function calculateScores<T extends RawTWUProposal | RawTWUProposalSlim>(
         proposal.priceScore = proposalScoring.priceScore || undefined;
         proposal.rank = proposalScoring.rank || undefined;
         proposal.totalScore = includeTotalScore
-          ? proposalScoring.totalScore || undefined
-          : undefined;
+          ? undefined
+          : proposalScoring.totalScore || undefined;
       }
     }
   });

--- a/src/front-end/typescript/lib/pages/proposal/sprint-with-us/edit/tab/scoresheet.tsx
+++ b/src/front-end/typescript/lib/pages/proposal/sprint-with-us/edit/tab/scoresheet.tsx
@@ -169,6 +169,9 @@ const NotAvailable: component_.base.View<Pick<State, "proposal">> = ({
         </div>
       );
     }
+    case SWUProposalStatus.NotAwarded: {
+      return <div>The proposal has been awarded</div>;
+    }
     default:
       return (
         <div>

--- a/src/front-end/typescript/lib/pages/proposal/team-with-us/edit/tab/scoresheet.tsx
+++ b/src/front-end/typescript/lib/pages/proposal/team-with-us/edit/tab/scoresheet.tsx
@@ -158,6 +158,9 @@ const NotAvailable: component_.base.View<Pick<State, "proposal">> = ({
         </div>
       );
     }
+    case TWUProposalStatus.NotAwarded: {
+      return <div>The proposal has been awarded</div>;
+    }
     default:
       return (
         <div>

--- a/src/shared/lib/resources/proposal/sprint-with-us.ts
+++ b/src/shared/lib/resources/proposal/sprint-with-us.ts
@@ -596,13 +596,13 @@ export function swuProposalTotalProposedCost(proposal: SWUProposal): number {
 }
 
 /**
- * Returns true if the proposal has a rank, and is either awarded or not awarded.
- * Used to determine if the scoreSheet should be presented to the user.
+ * Returns true if the proposal has a score and a rank, and is either awarded or
+ * not awarded. Used to determine if a scoreSheet should be presented to the user.
  *
  * @remarks
- * Covers an edge case where proposal.totalScore can be undefined while
- * proposal.rank is defined, when a vendor is screened in but all scores
- * (TQ, CC, TS, P) have not been entered.
+ * proposal.totalScore is only undefined when all available scores are empty;
+ * when all of (TQ, CC, TS, P) have not been entered. proposal.totalScore can be
+ * still be defined if some, but not all scores are entered.
  *
  * @see const includeTotalScore in {@link calculateScores} 'src/back-end/lib/db/proposal/sprint-with-us.ts'
  *
@@ -611,6 +611,7 @@ export function swuProposalTotalProposedCost(proposal: SWUProposal): number {
  */
 export function showScoreAndRankToProponent(proposal: SWUProposal): boolean {
   return (
+    proposal.totalScore !== undefined &&
     proposal.rank !== undefined &&
     (proposal.status === SWUProposalStatus.Awarded ||
       proposal.status === SWUProposalStatus.NotAwarded)

--- a/src/shared/lib/resources/proposal/sprint-with-us.ts
+++ b/src/shared/lib/resources/proposal/sprint-with-us.ts
@@ -607,6 +607,7 @@ export function swuProposalTotalProposedCost(proposal: SWUProposal): number {
  * @see const includeTotalScore in {@link calculateScores} 'src/back-end/lib/db/proposal/sprint-with-us.ts'
  *
  * @param proposal SWUProposal
+ * @returns boolean
  */
 export function showScoreAndRankToProponent(proposal: SWUProposal): boolean {
   return (

--- a/src/shared/lib/resources/proposal/sprint-with-us.ts
+++ b/src/shared/lib/resources/proposal/sprint-with-us.ts
@@ -595,9 +595,21 @@ export function swuProposalTotalProposedCost(proposal: SWUProposal): number {
   ]);
 }
 
+/**
+ * Returns true if the proposal has a rank, and is either awarded or not awarded.
+ * Used to determine if the scoreSheet should be presented to the user.
+ *
+ * @remarks
+ * Covers an edge case where proposal.totalScore can be undefined while
+ * proposal.rank is defined, when a vendor is screened in but all scores
+ * (TQ, CC, TS, P) have not been entered.
+ *
+ * @see const includeTotalScore in {@link calculateScores} 'src/back-end/lib/db/proposal/sprint-with-us.ts'
+ *
+ * @param proposal SWUProposal
+ */
 export function showScoreAndRankToProponent(proposal: SWUProposal): boolean {
   return (
-    proposal.totalScore !== undefined &&
     proposal.rank !== undefined &&
     (proposal.status === SWUProposalStatus.Awarded ||
       proposal.status === SWUProposalStatus.NotAwarded)

--- a/src/shared/lib/resources/proposal/team-with-us.ts
+++ b/src/shared/lib/resources/proposal/team-with-us.ts
@@ -413,11 +413,12 @@ export function calculateProposalResourceQuestionScore(
  * @remarks
  * Covers an edge case where proposal.totalScore can be undefined while
  * proposal.rank is defined, when a vendor is screened in but all scores
- * (TQ, CC, TS, P) have not been entered.
+ * (Qu, Ch, Pr) have not been entered.
  *
  * @see const includeTotalScore in {@link calculateScores} 'src/back-end/lib/db/proposal/team-with-us.ts'
  *
- * @param proposal SWUProposal
+ * @param proposal TWUProposal
+ * @returns boolean
  */
 export function showScoreAndRankToProponent(proposal: TWUProposal): boolean {
   return (

--- a/src/shared/lib/resources/proposal/team-with-us.ts
+++ b/src/shared/lib/resources/proposal/team-with-us.ts
@@ -406,9 +406,21 @@ export function calculateProposalResourceQuestionScore(
   return (actualScore / maxPossibleScore) * 100;
 }
 
+/**
+ * Returns true if the proposal has a rank, and is either awarded or not awarded.
+ * Used to determine if the scoreSheet should be presented to the user.
+ *
+ * @remarks
+ * Covers an edge case where proposal.totalScore can be undefined while
+ * proposal.rank is defined, when a vendor is screened in but all scores
+ * (TQ, CC, TS, P) have not been entered.
+ *
+ * @see const includeTotalScore in {@link calculateScores} 'src/back-end/lib/db/proposal/team-with-us.ts'
+ *
+ * @param proposal SWUProposal
+ */
 export function showScoreAndRankToProponent(proposal: TWUProposal): boolean {
   return (
-    proposal.totalScore !== undefined &&
     proposal.rank !== undefined &&
     (proposal.status === TWUProposalStatus.Awarded ||
       proposal.status === TWUProposalStatus.NotAwarded)

--- a/src/shared/lib/resources/proposal/team-with-us.ts
+++ b/src/shared/lib/resources/proposal/team-with-us.ts
@@ -407,13 +407,14 @@ export function calculateProposalResourceQuestionScore(
 }
 
 /**
- * Returns true if the proposal has a rank, and is either awarded or not awarded.
- * Used to determine if the scoreSheet should be presented to the user.
+ * Returns true if the proposal has a score and a rank, and is either awarded or
+ * not awarded. Used to determine if the scoreSheet should be presented to the
+ * user.
  *
  * @remarks
- * Covers an edge case where proposal.totalScore can be undefined while
- * proposal.rank is defined, when a vendor is screened in but all scores
- * (Qu, Ch, Pr) have not been entered.
+ * proposal.totalScore is only undefined when all available scores are empty;
+ * when all of (Qu, Ch, Pr) have not been entered. proposal.totalScore can be
+ * still be defined if some, but not all scores are entered.
  *
  * @see const includeTotalScore in {@link calculateScores} 'src/back-end/lib/db/proposal/team-with-us.ts'
  *
@@ -422,6 +423,7 @@ export function calculateProposalResourceQuestionScore(
  */
 export function showScoreAndRankToProponent(proposal: TWUProposal): boolean {
   return (
+    proposal.totalScore !== undefined &&
     proposal.rank !== undefined &&
     (proposal.status === TWUProposalStatus.Awarded ||
       proposal.status === TWUProposalStatus.NotAwarded)


### PR DESCRIPTION
This PR closes issue: [issue DMM-311]

Includes tests? [N]
Updated docs? [Y]

Proposed changes:
- removing the condition that all scores need to be available to present a scoresheet after Awarded/Not Awarded

Additional notes:
- Not applicable in CWU
- for SWU/TWU: 
  - if there are no scores and Not Awarded, then 'The proposal has been awarded'
  - if there are some scores and Not Awarded or Awarded, then scoresheet + rank
  - if there are all scores and Not Awarded or Awarded, then scoresheet + rank
