### PR TITLE
DMM-412 Remove 'Max budget' hint from TWU proposal input

### DIFF
--- a/src/front-end/typescript/lib/pages/proposal/team-with-us/lib/components/form.tsx
+++ b/src/front-end/typescript/lib/pages/proposal/team-with-us/lib/components/form.tsx
@@ -24,7 +24,7 @@ import Markdown, { ProposalMarkdown } from "front-end/lib/views/markdown";
 import { find } from "lodash";
 import React from "react";
 import { Alert, Col, Row } from "reactstrap";
-import { formatAmount, formatDate } from "shared/lib";
+import { formatDate } from "shared/lib";
 import {
   isTWUOpportunityAcceptingProposals,
   TWUOpportunity
@@ -683,7 +683,6 @@ const PricingView: component_.base.View<Props> = ({
   dispatch,
   disabled
 }) => {
-  const { maxBudget } = state.opportunity;
   return (
     <div>
       <Row>
@@ -751,10 +750,6 @@ const PricingView: component_.base.View<Props> = ({
             extraChildProps={{ prefix: "$" }}
             label="Hourly Rate"
             placeholder="Hourly Rate"
-            hint={`Maximum opportunity budget is ${formatAmount(
-              maxBudget,
-              "$"
-            )}`}
             state={state.hourlyRate}
             dispatch={component_.base.mapDispatch(dispatch, (value) =>
               adt("hourlyRate" as const, value)


### PR DESCRIPTION
This PR closes issue: https://bcdevex.atlassian.net/browse/DMM-412

This is a small PR to remove the `Max opportunity budget` text hint on the Hourly Rate input on the TWU Proposal - Pricing Tab. After this change has been merged, the input will appear without the hint (see below):


<img width="578" alt="Screenshot 2024-02-11 at 12 44 09 PM" src="https://github.com/bcgov/digital_marketplace/assets/6961467/23632ee7-3e7c-40ea-8334-b1faff9d1661">
