### PR TITLE
DMM-407 Fix incorrect enumeration/display of proposal rankings

### DIFF
--- a/src/back-end/lib/db/proposal/sprint-with-us.ts
+++ b/src/back-end/lib/db/proposal/sprint-with-us.ts
@@ -1892,12 +1892,6 @@ async function calculateScores<T extends RawSWUProposal | RawSWUProposalSlim>(
 
   const proposalScorings = await generateSWUProposalQuery(connection)
     .where({ "proposals.opportunity": opportunityId })
-    .join(
-      "swuTeamQuestionResponses as responses",
-      "responses.proposal",
-      "=",
-      "proposals.id"
-    )
     .select<ProposalScoring[]>(
       "proposals.id",
       "statuses.status",

--- a/src/back-end/lib/db/proposal/team-with-us.ts
+++ b/src/back-end/lib/db/proposal/team-with-us.ts
@@ -1547,12 +1547,6 @@ async function calculateScores<T extends RawTWUProposal | RawTWUProposalSlim>(
 
   const proposalScorings = await generateTWUProposalQuery(connection)
     .where({ "proposals.opportunity": opportunityId })
-    .join(
-      "twuResourceQuestionResponses as responses",
-      "responses.proposal",
-      "=",
-      "proposals.id"
-    )
     .select<ProposalScoring[]>(
       "proposals.id",
       "statuses.status",

--- a/src/shared/lib/index.ts
+++ b/src/shared/lib/index.ts
@@ -92,6 +92,8 @@ export function flipCurried<A, B, C>(
 }
 
 export function getOrdinalSuffix(position: number): string {
+  if (position > 10 && position < 20) return "th"; // teens are all "th"
+
   switch (position % 10) {
     case 1:
       return "st";


### PR DESCRIPTION
This PR closes issue: https://bcdevex.atlassian.net/browse/DMM-407

This PR fixes 2 issues related to the display of proposal rankings when viewing an evaluated SWU or TWU opportunity:

1. Proposal rankings were being calculated against an incorrect query that returned duplicates of the same proposal. There was an unnecessary join being performed that returned a record of the same proposal for each question/response present. The fix was to remove that join.

2. Proposal rankings that were in the 'teens' -- between 10 and 20 -- were showing with incorrect suffixes (i.e. `11st`). An exception for amounts in that range was added to the utility function, so that these rankings will show correctly (see screen grab for example).

<img width="519" alt="Screenshot 2024-02-11 at 4 08 36 PM" src="https://github.com/bcgov/digital_marketplace/assets/6961467/234f1ec2-8296-42b3-8347-3cdaad503ec5">
