### PR TITLE
DMM-403/DMM-405 Restrict proposal withdrawals + adjust notifications

### DIFF
--- a/src/back-end/lib/mailer/notifications/proposal/code-with-us.tsx
+++ b/src/back-end/lib/mailer/notifications/proposal/code-with-us.tsx
@@ -8,16 +8,13 @@ import * as templates from "back-end/lib/mailer/templates";
 import { makeSend } from "back-end/lib/mailer/transport";
 import React from "react";
 import { CONTACT_EMAIL, EMPTY_STRING } from "shared/config";
-import {
-  CWUOpportunity,
-  isCWUOpportunityClosed
-} from "shared/lib/resources/opportunity/code-with-us";
+import { CWUOpportunity } from "shared/lib/resources/opportunity/code-with-us";
 import {
   CWUProposal,
   CWUProposalSlim
 } from "shared/lib/resources/proposal/code-with-us";
 import { AuthenticatedSession } from "shared/lib/resources/session";
-import { User } from "shared/lib/resources/user";
+import { User, UserType } from "shared/lib/resources/user";
 import { Id } from "shared/lib/types";
 import { getValidValue } from "shared/lib/validation";
 
@@ -155,13 +152,6 @@ export async function handleCWUProposalWithdrawn(
       ),
       null
     );
-  // Need to read opportunityAuthor separate here, as this session will not be allowed to read from opportunity itself
-  const opportunityAuthor =
-    proposal &&
-    getValidValue(
-      await db.readOneCWUOpportunityAuthor(connection, proposal.opportunity.id),
-      null
-    );
 
   if (proposal && opportunity) {
     const withdrawnProponent =
@@ -170,23 +160,28 @@ export async function handleCWUProposalWithdrawn(
         await db.readOneUser(connection, proposal.createdBy.id),
         null
       );
-    // Notify opportunity author if opportunity is closed
-    if (
-      opportunityAuthor &&
-      withdrawnProponent &&
-      isCWUOpportunityClosed(opportunity)
-    ) {
-      await withdrawnCWUProposalSubmission(
-        opportunityAuthor,
-        withdrawnProponent,
-        opportunity
-      );
-    }
     // Notify proposal author
     if (withdrawnProponent) {
       await withdrawnCWUProposalSubmissionProposalAuthor(
         withdrawnProponent,
         opportunity
+      );
+
+      // Notify admins that the proposal has been withdrawn
+      const adminUsers =
+        getValidValue(
+          await db.readManyUsersByRole(connection, UserType.Admin),
+          null
+        ) || [];
+      await Promise.all(
+        adminUsers.map(
+          async (admin) =>
+            await withdrawnCWUProposalSubmission(
+              admin,
+              withdrawnProponent,
+              opportunity
+            )
+        )
       );
     }
   }

--- a/src/back-end/lib/mailer/notifications/proposal/code-with-us.tsx
+++ b/src/back-end/lib/mailer/notifications/proposal/code-with-us.tsx
@@ -137,7 +137,6 @@ export async function handleCWUProposalWithdrawn(
   proposalId: Id,
   session: AuthenticatedSession
 ): Promise<void> {
-  //Notify the opportunity author if the opportunity is in an awardable state
   const proposal = getValidValue(
     await db.readOneCWUProposal(connection, proposalId, session),
     null

--- a/src/back-end/lib/mailer/notifications/proposal/sprint-with-us.tsx
+++ b/src/back-end/lib/mailer/notifications/proposal/sprint-with-us.tsx
@@ -143,7 +143,6 @@ export async function handleSWUProposalWithdrawn(
   proposalId: Id,
   session: AuthenticatedSession
 ): Promise<void> {
-  //Notify the opportunity author that the proposal has been withdrawn
   const proposal = getValidValue(
     await db.readOneSWUProposal(connection, proposalId, session),
     null

--- a/src/back-end/lib/mailer/notifications/proposal/team-with-us.tsx
+++ b/src/back-end/lib/mailer/notifications/proposal/team-with-us.tsx
@@ -8,16 +8,13 @@ import * as templates from "back-end/lib/mailer/templates";
 import { makeSend } from "back-end/lib/mailer/transport";
 import React from "react";
 import { CONTACT_EMAIL, EMPTY_STRING } from "shared/config";
-import {
-  isTWUOpportunityClosed,
-  TWUOpportunity
-} from "shared/lib/resources/opportunity/team-with-us";
+import { TWUOpportunity } from "shared/lib/resources/opportunity/team-with-us";
 import {
   TWUProposal,
   TWUProposalSlim
 } from "shared/lib/resources/proposal/team-with-us";
 import { AuthenticatedSession } from "shared/lib/resources/session";
-import { User } from "shared/lib/resources/user";
+import { User, UserType } from "shared/lib/resources/user";
 import { Id } from "shared/lib/types";
 import { getValidValue } from "shared/lib/validation";
 
@@ -161,13 +158,6 @@ export async function handleTWUProposalWithdrawn(
       ),
       null
     );
-  // Need to read opportunityAuthor separate here, as this session will not be allowed to read from opportunity itself
-  const opportunityAuthor =
-    proposal &&
-    getValidValue(
-      await db.readOneTWUOpportunityAuthor(connection, proposal.opportunity.id),
-      null
-    );
 
   if (proposal && opportunity) {
     const withdrawnProponent =
@@ -176,23 +166,28 @@ export async function handleTWUProposalWithdrawn(
         await db.readOneUser(connection, proposal.createdBy.id),
         null
       );
-    // Notify opportunity author if opportunity is closed
-    if (
-      opportunityAuthor &&
-      withdrawnProponent &&
-      isTWUOpportunityClosed(opportunity)
-    ) {
-      await withdrawnTWUProposalSubmission(
-        opportunityAuthor,
-        withdrawnProponent,
-        opportunity
-      );
-    }
     // Notify proposal author
     if (withdrawnProponent) {
       await withdrawnTWUProposalSubmissionProposalAuthor(
         withdrawnProponent,
         opportunity
+      );
+
+      // Notify admins that the proposal has been withdrawn
+      const adminUsers =
+        getValidValue(
+          await db.readManyUsersByRole(connection, UserType.Admin),
+          null
+        ) || [];
+      await Promise.all(
+        adminUsers.map(
+          async (admin) =>
+            await withdrawnTWUProposalSubmission(
+              admin,
+              withdrawnProponent,
+              opportunity
+            )
+        )
       );
     }
   }

--- a/src/back-end/lib/mailer/notifications/proposal/team-with-us.tsx
+++ b/src/back-end/lib/mailer/notifications/proposal/team-with-us.tsx
@@ -143,7 +143,6 @@ export async function handleTWUProposalWithdrawn(
   proposalId: Id,
   session: AuthenticatedSession
 ): Promise<void> {
-  //Notify the opportunity author if the opportunity is in an award-able state
   const proposal = getValidValue(
     await db.readOneTWUProposal(connection, proposalId, session),
     null

--- a/src/front-end/typescript/lib/pages/proposal/code-with-us/edit/tab/proposal.tsx
+++ b/src/front-end/typescript/lib/pages/proposal/code-with-us/edit/tab/proposal.tsx
@@ -1169,19 +1169,7 @@ export const component: Tab.Component<State, Msg> = {
       case CWUProposalStatus.UnderReview:
       case CWUProposalStatus.Evaluated:
       case CWUProposalStatus.Awarded:
-        return component_.page.actions.links([
-          {
-            children: "Withdraw",
-            symbol_: leftPlacement(iconLinkSymbol("ban")),
-            button: true,
-            outline: true,
-            color: "c-nav-fg-alt",
-            disabled,
-            loading: isWithdrawLoading,
-            onClick: () =>
-              dispatch(adt("showModal", "withdrawAfterDeadline" as const))
-          }
-        ]);
+        return component_.page.actions.none();
       case CWUProposalStatus.Withdrawn:
         if (isAcceptingProposals) {
           return component_.page.actions.links([

--- a/src/front-end/typescript/lib/pages/proposal/sprint-with-us/edit/tab/proposal.tsx
+++ b/src/front-end/typescript/lib/pages/proposal/sprint-with-us/edit/tab/proposal.tsx
@@ -1128,19 +1128,7 @@ export const component: Tab.Component<State, Msg> = {
       case SWUProposalStatus.EvaluatedCodeChallenge:
       case SWUProposalStatus.EvaluatedTeamScenario:
       case SWUProposalStatus.Awarded:
-        return component_.page.actions.links([
-          {
-            children: "Withdraw",
-            symbol_: leftPlacement(iconLinkSymbol("ban")),
-            button: true,
-            outline: true,
-            color: "c-nav-fg-alt",
-            disabled,
-            loading: isWithdrawLoading,
-            onClick: () =>
-              dispatch(adt("showModal", "withdrawAfterDeadline" as const))
-          }
-        ]);
+        return component_.page.actions.none();
       case SWUProposalStatus.Withdrawn:
         if (isAcceptingProposals) {
           return component_.page.actions.links([

--- a/src/front-end/typescript/lib/pages/proposal/team-with-us/edit/tab/proposal.tsx
+++ b/src/front-end/typescript/lib/pages/proposal/team-with-us/edit/tab/proposal.tsx
@@ -1146,19 +1146,7 @@ export const component: Tab.Component<State, Msg> = {
       case TWUProposalStatus.EvaluatedResourceQuestions:
       case TWUProposalStatus.EvaluatedChallenge:
       case TWUProposalStatus.Awarded:
-        return component_.page.actions.links([
-          {
-            children: "Withdraw",
-            symbol_: leftPlacement(iconLinkSymbol("ban")),
-            button: true,
-            outline: true,
-            color: "c-nav-fg-alt",
-            disabled,
-            loading: isWithdrawLoading,
-            onClick: () =>
-              dispatch(adt("showModal", "withdrawAfterDeadline" as const))
-          }
-        ]);
+        return component_.page.actions.none();
       case TWUProposalStatus.Withdrawn:
         if (isAcceptingProposals) {
           return component_.page.actions.links([

--- a/src/shared/lib/resources/proposal/code-with-us.ts
+++ b/src/shared/lib/resources/proposal/code-with-us.ts
@@ -319,36 +319,29 @@ export function isValidStatusChange(
 
     case CWUProposalStatus.UnderReview:
       return (
-        (([
-          CWUProposalStatus.Evaluated,
-          CWUProposalStatus.Disqualified
-        ].includes(to) &&
-          userType !== UserType.Vendor) ||
-          (to === CWUProposalStatus.Withdrawn &&
-            userType === UserType.Vendor)) &&
+        [CWUProposalStatus.Evaluated, CWUProposalStatus.Disqualified].includes(
+          to
+        ) &&
+        userType !== UserType.Vendor &&
         hasProposalDeadlinePassed
       );
 
     case CWUProposalStatus.Evaluated:
       return (
-        (([
+        [
           CWUProposalStatus.Evaluated,
           CWUProposalStatus.Awarded,
           CWUProposalStatus.NotAwarded,
           CWUProposalStatus.Disqualified
         ].includes(to) &&
-          userType !== UserType.Vendor) ||
-          (to === CWUProposalStatus.Withdrawn &&
-            userType === UserType.Vendor)) &&
+        userType !== UserType.Vendor &&
         hasProposalDeadlinePassed
       );
 
     case CWUProposalStatus.Awarded:
       return (
-        ((to === CWUProposalStatus.Disqualified &&
-          userType !== UserType.Vendor) ||
-          (to === CWUProposalStatus.Withdrawn &&
-            userType === UserType.Vendor)) &&
+        to === CWUProposalStatus.Disqualified &&
+        userType !== UserType.Vendor &&
         hasProposalDeadlinePassed
       );
 

--- a/src/shared/lib/resources/proposal/sprint-with-us.ts
+++ b/src/shared/lib/resources/proposal/sprint-with-us.ts
@@ -425,77 +425,63 @@ export function isValidStatusChange(
 
     case SWUProposalStatus.UnderReviewTeamQuestions:
       return (
-        (([
+        [
           SWUProposalStatus.EvaluatedTeamQuestions,
           SWUProposalStatus.Disqualified
         ].includes(to) &&
-          userType !== UserType.Vendor) ||
-          (to === SWUProposalStatus.Withdrawn &&
-            userType === UserType.Vendor)) &&
+        userType !== UserType.Vendor &&
         hasProposalDeadlinePassed
       );
 
     case SWUProposalStatus.EvaluatedTeamQuestions:
       return (
-        ([
+        [
           SWUProposalStatus.UnderReviewCodeChallenge,
           SWUProposalStatus.Disqualified
-        ].includes(to) &&
-          userType !== UserType.Vendor) ||
-        (to === SWUProposalStatus.Withdrawn && userType === UserType.Vendor)
+        ].includes(to) && userType !== UserType.Vendor
       );
 
     case SWUProposalStatus.UnderReviewCodeChallenge:
       return (
-        ([
+        [
           SWUProposalStatus.EvaluatedCodeChallenge,
           SWUProposalStatus.Disqualified,
           SWUProposalStatus.EvaluatedTeamQuestions
-        ].includes(to) &&
-          userType !== UserType.Vendor) ||
-        (to === SWUProposalStatus.Withdrawn && userType === UserType.Vendor)
+        ].includes(to) && userType !== UserType.Vendor
       );
 
     case SWUProposalStatus.EvaluatedCodeChallenge:
       return (
-        ([
+        [
           SWUProposalStatus.UnderReviewTeamScenario,
           SWUProposalStatus.Disqualified
-        ].includes(to) &&
-          userType !== UserType.Vendor) ||
-        (to === SWUProposalStatus.Withdrawn && userType === UserType.Vendor)
+        ].includes(to) && userType !== UserType.Vendor
       );
 
     case SWUProposalStatus.UnderReviewTeamScenario:
       return (
-        ([
+        [
           SWUProposalStatus.EvaluatedTeamScenario,
           SWUProposalStatus.Disqualified,
           SWUProposalStatus.EvaluatedCodeChallenge
-        ].includes(to) &&
-          userType !== UserType.Vendor) ||
-        (to === SWUProposalStatus.Withdrawn && userType === UserType.Vendor)
+        ].includes(to) && userType !== UserType.Vendor
       );
 
     case SWUProposalStatus.EvaluatedTeamScenario:
       return (
-        (([
+        [
           SWUProposalStatus.Awarded,
           SWUProposalStatus.NotAwarded,
           SWUProposalStatus.Disqualified
         ].includes(to) &&
-          userType !== UserType.Vendor) ||
-          (to === SWUProposalStatus.Withdrawn &&
-            userType === UserType.Vendor)) &&
+        userType !== UserType.Vendor &&
         hasProposalDeadlinePassed
       );
 
     case SWUProposalStatus.Awarded:
       return (
-        ((to === SWUProposalStatus.Disqualified &&
-          userType !== UserType.Vendor) ||
-          (to === SWUProposalStatus.Withdrawn &&
-            userType === UserType.Vendor)) &&
+        to === SWUProposalStatus.Disqualified &&
+        userType !== UserType.Vendor &&
         hasProposalDeadlinePassed
       );
 

--- a/src/shared/lib/resources/proposal/team-with-us.ts
+++ b/src/shared/lib/resources/proposal/team-with-us.ts
@@ -317,56 +317,46 @@ export function isValidStatusChange(
 
     case TWUProposalStatus.UnderReviewResourceQuestions:
       return (
-        (([
+        [
           TWUProposalStatus.EvaluatedResourceQuestions,
           TWUProposalStatus.Disqualified
         ].includes(to) &&
-          userType !== UserType.Vendor) ||
-          (to === TWUProposalStatus.Withdrawn &&
-            userType === UserType.Vendor)) &&
+        userType !== UserType.Vendor &&
         hasProposalDeadlinePassed
       );
 
     case TWUProposalStatus.EvaluatedResourceQuestions:
       return (
-        ([
+        [
           TWUProposalStatus.UnderReviewChallenge,
           TWUProposalStatus.Disqualified
-        ].includes(to) &&
-          userType !== UserType.Vendor) ||
-        (to === TWUProposalStatus.Withdrawn && userType === UserType.Vendor)
+        ].includes(to) && userType !== UserType.Vendor
       );
 
     case TWUProposalStatus.UnderReviewChallenge:
       return (
-        ([
+        [
           TWUProposalStatus.EvaluatedChallenge,
           TWUProposalStatus.Disqualified,
           TWUProposalStatus.EvaluatedResourceQuestions
-        ].includes(to) &&
-          userType !== UserType.Vendor) ||
-        (to === TWUProposalStatus.Withdrawn && userType === UserType.Vendor)
+        ].includes(to) && userType !== UserType.Vendor
       );
 
     case TWUProposalStatus.EvaluatedChallenge:
       return (
-        (([
+        [
           TWUProposalStatus.Awarded,
           TWUProposalStatus.NotAwarded,
           TWUProposalStatus.Disqualified
         ].includes(to) &&
-          userType !== UserType.Vendor) ||
-          (to === TWUProposalStatus.Withdrawn &&
-            userType === UserType.Vendor)) &&
+        userType !== UserType.Vendor &&
         hasProposalDeadlinePassed
       );
 
     case TWUProposalStatus.Awarded:
       return (
-        ((to === TWUProposalStatus.Disqualified &&
-          userType !== UserType.Vendor) ||
-          (to === TWUProposalStatus.Withdrawn &&
-            userType === UserType.Vendor)) &&
+        to === TWUProposalStatus.Disqualified &&
+        userType !== UserType.Vendor &&
         hasProposalDeadlinePassed
       );
 


### PR DESCRIPTION
This PR closes issues:

https://bcdevex.atlassian.net/browse/DMM-403
https://bcdevex.atlassian.net/browse/DMM-405

The changes are related to when proposal withdrawals can be performed, and the audience for notifications when a proposal is withdrawn.

1. Proposals can no longer be withdrawn after the opportunity has closed. The API has been restricted to disallow withdrawal updates for closed opportunities, and the `Withdraw` button/action is longer available in the front-end for closed opportunities. (DMM-403)

2. Notifications for proposal withdrawals have been updated to send only to the proposal author (already in place), and to all Admin users. The notification sent to opportunity authors has been removed. (DMM-405)

Example of notification sent to DM admin:

<img width="673" alt="Screenshot 2024-02-11 at 5 32 07 PM" src="https://github.com/bcgov/digital_marketplace/assets/6961467/2f4cd3cc-cb5b-4b79-b473-0a1e54033725">
