### PR TITLE
Feat/next previous buttons

### DIFF
--- a/src/front-end/typescript/lib/pages/proposal/sprint-with-us/lib/views/proposal-tab-carousel.tsx
+++ b/src/front-end/typescript/lib/pages/proposal/sprint-with-us/lib/views/proposal-tab-carousel.tsx
@@ -38,6 +38,16 @@ export function sortProponentsByAnonymousProponentName(
       return compareNumbers(a.order, b.order) * -1;
     });
 }
+
+/**
+ * Browse opportunity's proposals from a tab details view.
+ * `proposals` should be filtered appropriately for the tab.
+ *
+ * @see {@link Props}
+ *
+ * @param props - proposals, proposal, tab
+ * @returns - base view component
+ */
 const ProposalTabCarousel: component.base.View<Props> = ({
   proposals,
   proposal,

--- a/src/front-end/typescript/lib/pages/proposal/sprint-with-us/lib/views/proposal-tab-carousel.tsx
+++ b/src/front-end/typescript/lib/pages/proposal/sprint-with-us/lib/views/proposal-tab-carousel.tsx
@@ -1,0 +1,84 @@
+import { component } from "front-end/lib/framework";
+import Link, {
+  iconLinkSymbol,
+  leftPlacement,
+  rightPlacement,
+  routeDest
+} from "front-end/lib/views/link";
+import React from "react";
+import {
+  SWUProposal,
+  SWUProposalSlim
+} from "shared/lib/resources/proposal/sprint-with-us";
+import { adt } from "shared/lib/types";
+import * as Tab from "front-end/lib/pages/proposal/sprint-with-us/view/tab";
+
+export interface Props {
+  proposal: SWUProposal;
+  proposals: SWUProposalSlim[];
+  tab: Tab.TabId;
+}
+
+const ProposalTabCarousel: component.base.View<Props> = ({
+  proposals,
+  proposal,
+  tab
+}) => {
+  const index = proposals.findIndex(
+    (otherProposal) => otherProposal.id === proposal.id
+  );
+
+  // Safeguard against proposals/proposal prop mismatch
+  if (index < 0) {
+    return null;
+  }
+
+  const prevIndex = index - 1;
+  const nextIndex = index + 1;
+  const prevRouteParams = proposals[nextIndex]
+    ? {
+        proposalId: proposals[nextIndex].id,
+        opportunityId: proposals[nextIndex].opportunity.id,
+        tab
+      }
+    : null;
+
+  const nextRouteParams = proposals[prevIndex]
+    ? {
+        proposalId: proposals[prevIndex].id,
+        opportunityId: proposals[prevIndex].opportunity.id,
+        tab
+      }
+    : null;
+
+  return (
+    <div className="d-flex justify-content-between">
+      {prevRouteParams ? (
+        <Link
+          button
+          color="info"
+          outline
+          symbol_={leftPlacement(iconLinkSymbol("arrow-left"))}
+          dest={routeDest(adt("proposalSWUView", prevRouteParams))}>
+          Previous Proponent
+        </Link>
+      ) : (
+        <div />
+      )}
+      {nextRouteParams ? (
+        <Link
+          button
+          color="primary"
+          outline
+          symbol_={rightPlacement(iconLinkSymbol("arrow-right"))}
+          dest={routeDest(adt("proposalSWUView", nextRouteParams))}>
+          Next Proponent
+        </Link>
+      ) : (
+        <div />
+      )}
+    </div>
+  );
+};
+
+export default ProposalTabCarousel;

--- a/src/front-end/typescript/lib/pages/proposal/sprint-with-us/lib/views/proposal-tab-carousel.tsx
+++ b/src/front-end/typescript/lib/pages/proposal/sprint-with-us/lib/views/proposal-tab-carousel.tsx
@@ -65,18 +65,18 @@ const ProposalTabCarousel: component.base.View<Props> = ({
 
   const prevIndex = index - 1;
   const nextIndex = index + 1;
-  const prevRouteParams = proposals[nextIndex]
+  const prevRouteParams = proposals[prevIndex]
     ? {
-        proposalId: proposals[nextIndex].id,
-        opportunityId: proposals[nextIndex].opportunity.id,
+        proposalId: proposals[prevIndex].id,
+        opportunityId: proposals[prevIndex].opportunity.id,
         tab
       }
     : null;
 
-  const nextRouteParams = proposals[prevIndex]
+  const nextRouteParams = proposals[nextIndex]
     ? {
-        proposalId: proposals[prevIndex].id,
-        opportunityId: proposals[prevIndex].opportunity.id,
+        proposalId: proposals[nextIndex].id,
+        opportunityId: proposals[nextIndex].opportunity.id,
         tab
       }
     : null;

--- a/src/front-end/typescript/lib/pages/proposal/sprint-with-us/lib/views/proposal-tab-carousel.tsx
+++ b/src/front-end/typescript/lib/pages/proposal/sprint-with-us/lib/views/proposal-tab-carousel.tsx
@@ -12,6 +12,7 @@ import {
 } from "shared/lib/resources/proposal/sprint-with-us";
 import { adt } from "shared/lib/types";
 import * as Tab from "front-end/lib/pages/proposal/sprint-with-us/view/tab";
+import { compareNumbers } from "shared/lib";
 
 export interface Props {
   proposal: SWUProposal;
@@ -19,11 +20,30 @@ export interface Props {
   tab: Tab.TabId;
 }
 
+/**
+ * Sorts proponents by anonymous proponent name in ascending order.
+ *
+ * @param proposals - unsorted proponents
+ * @returns - sorted proponents with order property
+ */
+export function sortProponentsByAnonymousProponentName(
+  proposals: SWUProposalSlim[]
+) {
+  return proposals
+    .reduce<(SWUProposalSlim & { order: number })[]>((acc, p) => {
+      const order = Number(p.anonymousProponentName.match(/\d+/)?.at(0));
+      return isNaN(order) ? acc : [...acc, { ...p, order }];
+    }, [])
+    .sort((a, b) => {
+      return compareNumbers(a.order, b.order) * -1;
+    });
+}
 const ProposalTabCarousel: component.base.View<Props> = ({
   proposals,
   proposal,
   tab
 }) => {
+  proposals = sortProponentsByAnonymousProponentName(proposals);
   const index = proposals.findIndex(
     (otherProposal) => otherProposal.id === proposal.id
   );

--- a/src/front-end/typescript/lib/pages/proposal/sprint-with-us/lib/views/proposal-tab-carousel.tsx
+++ b/src/front-end/typescript/lib/pages/proposal/sprint-with-us/lib/views/proposal-tab-carousel.tsx
@@ -35,7 +35,7 @@ export function sortProponentsByAnonymousProponentName(
       return isNaN(order) ? acc : [...acc, { ...p, order }];
     }, [])
     .sort((a, b) => {
-      return compareNumbers(a.order, b.order) * -1;
+      return compareNumbers(a.order, b.order) * 1;
     });
 }
 

--- a/src/front-end/typescript/lib/pages/proposal/sprint-with-us/view/index.tsx
+++ b/src/front-end/typescript/lib/pages/proposal/sprint-with-us/view/index.tsx
@@ -20,7 +20,8 @@ import * as api from "front-end/lib/http/api";
 import * as Tab from "front-end/lib/pages/proposal/sprint-with-us/view/tab";
 import {
   DEFAULT_SWU_PROPOSAL_TITLE,
-  SWUProposal
+  SWUProposal,
+  SWUProposalSlim
 } from "shared/lib/resources/proposal/sprint-with-us";
 import { UserType, User } from "shared/lib/resources/user";
 import { adt, ADT, Id } from "shared/lib/types";
@@ -90,14 +91,17 @@ function makeInit<K extends Tab.TabId>(): component_.page.Init<
           })
         ) as State_<K>,
         [
-          component_.cmd.join(
+          component_.cmd.join3(
             api.proposals.swu.readOne(opportunityId)(proposalId, (response) =>
               api.isValid(response) ? response.value : null
             ),
             api.opportunities.swu.readOne()(opportunityId, (response) =>
               api.isValid(response) ? response.value : null
             ),
-            (proposal, opportunity) => {
+            api.proposals.swu.readMany(opportunityId)((response) =>
+              api.getValidValue(response, [])
+            ),
+            (proposal, opportunity, proposals) => {
               if (!proposal || !opportunity)
                 return component_.global.replaceRouteMsg(
                   adt("notFound" as const, { path: routePath })

--- a/src/front-end/typescript/lib/pages/proposal/sprint-with-us/view/index.tsx
+++ b/src/front-end/typescript/lib/pages/proposal/sprint-with-us/view/index.tsx
@@ -199,7 +199,8 @@ function makeComponent<K extends Tab.TabId>(): component_.page.Component<
                     immutable<Tab.Tabs[K]["state"]>(tabState)
                   ])
                   .set("sidebar", immutable(sidebarState))
-                  .set("proposal", proposal),
+                  .set("proposal", proposal)
+                  .set("proposals", proposals),
                 [
                   ...component_.cmd.mapMany(
                     sidebarCmds,

--- a/src/front-end/typescript/lib/pages/proposal/sprint-with-us/view/tab/index.ts
+++ b/src/front-end/typescript/lib/pages/proposal/sprint-with-us/view/tab/index.ts
@@ -8,7 +8,10 @@ import * as TeamQuestionsTab from "front-end/lib/pages/proposal/sprint-with-us/v
 import * as TeamScenarioTab from "front-end/lib/pages/proposal/sprint-with-us/view/tab/team-scenario";
 import { routeDest } from "front-end/lib/views/link";
 import { SWUOpportunity } from "shared/lib/resources/opportunity/sprint-with-us";
-import { SWUProposal } from "shared/lib/resources/proposal/sprint-with-us";
+import {
+  SWUProposal,
+  SWUProposalSlim
+} from "shared/lib/resources/proposal/sprint-with-us";
 import { SWUTeamQuestionResponseEvaluation } from "shared/lib/resources/evaluations/sprint-with-us/team-questions";
 import { User } from "shared/lib/resources/user";
 import { adt } from "shared/lib/types";
@@ -37,6 +40,7 @@ export interface Params {
   evaluating: boolean;
   questionEvaluation?: SWUTeamQuestionResponseEvaluation;
   panelQuestionEvaluations: SWUTeamQuestionResponseEvaluation[];
+  proposals: SWUProposalSlim[];
 }
 
 export type InitResponse = null;

--- a/src/front-end/typescript/lib/pages/proposal/sprint-with-us/view/tab/team-questions.tsx
+++ b/src/front-end/typescript/lib/pages/proposal/sprint-with-us/view/tab/team-questions.tsx
@@ -961,9 +961,7 @@ const TeamQuestionResponsesView: component_.base.View<{
         </Row>
       </div>
       <ProposalTabCarousel
-        proposals={state.proposals.sort((a, b) =>
-          compareSWUProposalsForPublicSector(a, b, "questionsScore")
-        )}
+        proposals={state.proposals}
         proposal={state.proposal}
         tab="teamQuestions"
       />

--- a/src/front-end/typescript/lib/pages/proposal/sprint-with-us/view/tab/team-questions.tsx
+++ b/src/front-end/typescript/lib/pages/proposal/sprint-with-us/view/tab/team-questions.tsx
@@ -12,6 +12,7 @@ import {
 import * as api from "front-end/lib/http/api";
 import * as toasts from "front-end/lib/pages/proposal/sprint-with-us/lib/toasts";
 import ViewTabHeader from "front-end/lib/pages/proposal/sprint-with-us/lib/views/view-tab-header";
+import ProposalTabCarousel from "front-end/lib/pages/proposal/sprint-with-us/lib/views/proposal-tab-carousel";
 import * as Tab from "front-end/lib/pages/proposal/sprint-with-us/view/tab";
 import Accordion from "front-end/lib/views/accordion";
 // import { iconLinkSymbol, leftPlacement } from "front-end/lib/views/link";
@@ -959,6 +960,13 @@ const TeamQuestionResponsesView: component_.base.View<{
           </Col>
         </Row>
       </div>
+      <ProposalTabCarousel
+        proposals={state.proposals.sort((a, b) =>
+          compareSWUProposalsForPublicSector(a, b, "questionsScore")
+        )}
+        proposal={state.proposal}
+        tab="teamQuestions"
+      />
     </div>
   );
 };


### PR DESCRIPTION
Includes tests? [N]
Updated docs? [N]

Proposed changes:
- New component for rotating between proposals at tab view
- Currently only applied to team-questions tab
- Proponents are sorted by anonymous proponent name

Additional notes:
- Still need to apply the same changes to TWU