### PR TITLE
Feat/swu eval flow backend

### DIFF
--- a/src/back-end/lib/db/question-evaluation/sprint-with-us.ts
+++ b/src/back-end/lib/db/question-evaluation/sprint-with-us.ts
@@ -220,6 +220,35 @@ export const readManySWUTeamQuestionResponseEvaluations = tryDb<
   );
 });
 
+export const readOwnSWUTeamQuestionResponseEvaluations = tryDb<
+  [AuthenticatedSession],
+  SWUTeamQuestionResponseEvaluationSlim[]
+>(async (connection, session) => {
+  const evaluations = await generateSWUTeamQuestionResponseEvaluationQuery(
+    connection
+  )
+    .join(
+      "evaluationPanelMembers epm",
+      "epm.id",
+      "=",
+      "evaluations.evaluationPanelMember"
+    )
+    .andWhere({ "epm.user": session.user.id });
+
+  return valid(
+    await Promise.all(
+      evaluations.map(
+        async (result) =>
+          await rawTeamQuestionResponseEvaluationToTeamQuestionResponseEvaluationSlim(
+            connection,
+            session,
+            result
+          )
+      )
+    )
+  );
+});
+
 export const readOneSWUTeamQuestionResponseEvaluationByProposalAndEvaluationPanelMember =
   tryDb<[Id, Id, SWUTeamQuestionResponseEvaluationType, Session], Id | null>(
     async (connection, proposalId, evaluationPanelMemberId, type, session) => {

--- a/src/back-end/lib/db/question-evaluation/sprint-with-us.ts
+++ b/src/back-end/lib/db/question-evaluation/sprint-with-us.ts
@@ -22,6 +22,7 @@ import {
   SWUTeamQuestionResponseEvaluation,
   SWUTeamQuestionResponseEvaluationScores,
   SWUTeamQuestionResponseEvaluationStatus,
+  SWUTeamQuestionResponseEvaluationType,
   UpdateEditRequestBody
 } from "shared/lib/resources/question-evaluation/sprint-with-us";
 import { generateUuid } from "back-end/lib";
@@ -130,6 +131,29 @@ export const isSWUOpportunityEvaluationPanelEvaluator =
 
 export const isSWUOpportunityEvaluationPanelChair =
   makeIsSWUOpportunityEvaluationPanelMember((epm) => epm.chair);
+
+export const readOneSWUTeamQuestionResponseEvaluationByProposalAndEvaluationPanelMember =
+  tryDb<[Id, Id, SWUTeamQuestionResponseEvaluationType, Session], Id | null>(
+    async (connection, proposalId, evaluationPanelMemberId, type, session) => {
+      if (!session) {
+        return valid(null);
+      }
+      const result = (
+        await connection<RawSWUTeamQuestionResponseEvaluation>(
+          "swuTeamQuestionResponseEvaluations"
+        )
+          .where({
+            proposal: proposalId,
+            evaluationPanelMember: evaluationPanelMemberId,
+            type
+          })
+          .select("id")
+          .first()
+      )?.id;
+
+      return valid(result ? result : null);
+    }
+  );
 
 export const readManyTeamQuestionResponseEvaluationScores = tryDb<
   [Id],

--- a/src/back-end/lib/db/question-evaluation/sprint-with-us.ts
+++ b/src/back-end/lib/db/question-evaluation/sprint-with-us.ts
@@ -248,7 +248,7 @@ export const createSWUTeamQuestionResponseEvaluation = tryDb<
     session
   );
   if (isInvalid(dbResult) || !dbResult.value) {
-    throw new Error("unable to create proposal");
+    throw new Error("unable to create team question evaluation");
   }
   return valid(dbResult.value);
 });

--- a/src/back-end/lib/db/question-evaluation/sprint-with-us.ts
+++ b/src/back-end/lib/db/question-evaluation/sprint-with-us.ts
@@ -21,6 +21,7 @@ import {
   CreateSWUTeamQuestionResponseEvaluationScoreBody,
   SWUTeamQuestionResponseEvaluation,
   SWUTeamQuestionResponseEvaluationScores,
+  SWUTeamQuestionResponseEvaluationSlim,
   SWUTeamQuestionResponseEvaluationStatus,
   SWUTeamQuestionResponseEvaluationType,
   UpdateEditRequestBody
@@ -101,6 +102,20 @@ async function RawTeamQuestionResponseEvaluationToTeamQuestionResponseEvaluation
     ),
     proposal,
     evaluationPanelMember
+  };
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+function rawTeamQuestionResponseEvaluationToTeamQuestionResponseEvaluationSlim(
+  raw: RawSWUTeamQuestionResponseEvaluation
+): SWUTeamQuestionResponseEvaluationSlim {
+  const { proposal, evaluationPanelMember, scores, ...restOfRaw } = raw;
+
+  return {
+    ...restOfRaw,
+    scores: scores.map(
+      ({ notes, teamQuestionResponseEvaluation, ...score }) => score
+    )
   };
 }
 

--- a/src/back-end/lib/db/question-evaluation/sprint-with-us.ts
+++ b/src/back-end/lib/db/question-evaluation/sprint-with-us.ts
@@ -6,7 +6,7 @@ import { getValidValue, isInvalid, valid } from "shared/lib/validation";
 import {
   Connection,
   Transaction,
-  readOneSWUProposal,
+  readOneSWUProposalSlim,
   tryDb
 } from "back-end/lib/db";
 import {
@@ -78,7 +78,7 @@ async function rawTeamQuestionResponseEvaluationToTeamQuestionResponseEvaluation
   const proposal =
     session &&
     getValidValue(
-      await readOneSWUProposal(connection, proposalId, session),
+      await readOneSWUProposalSlim(connection, proposalId, session),
       null
     );
   if (!proposal) {

--- a/src/back-end/lib/permissions.ts
+++ b/src/back-end/lib/permissions.ts
@@ -974,7 +974,7 @@ export function editSWUTeamQuestionResponseEvaluation(
       SWUProposalStatus.TeamQuestionsPanelIndividual &&
       evaluation.type === SWUTeamQuestionResponseEvaluationType.Individual) ||
       (evaluation.proposal.status ===
-        SWUProposalStatus.TeamQuestionsPanelIndividual &&
+        SWUProposalStatus.TeamQuestionsPanelConsensus &&
         evaluation.type === SWUTeamQuestionResponseEvaluationType.Conensus))
   );
 }

--- a/src/back-end/lib/permissions.ts
+++ b/src/back-end/lib/permissions.ts
@@ -67,6 +67,10 @@ import {
   isSWUOpportunityEvaluationPanelChair,
   isSWUOpportunityEvaluationPanelEvaluator
 } from "./db/question-evaluation/sprint-with-us";
+import {
+  SWUTeamQuestionResponseEvaluation,
+  SWUTeamQuestionResponseEvaluationType
+} from "shared/lib/resources/question-evaluation/sprint-with-us";
 
 export const ERROR_MESSAGE =
   "You do not have permission to perform this action.";
@@ -891,6 +895,23 @@ export async function createSWUTeamQuestionResponseEvaluation(
           session,
           proposal.opportunity.id
         ))))
+  );
+}
+
+export function editSWUTeamQuestionResponseEvaluation(
+  session: Session,
+  evaluation: SWUTeamQuestionResponseEvaluation
+): boolean {
+  return (
+    !!session &&
+    (isAdmin(session) || isGovernment(session)) &&
+    evaluation.evaluationPanelMember.user.id === session.user.id &&
+    ((evaluation.proposal.opportunity.status ===
+      SWUOpportunityStatus.TeamQuestionsPanelEvaluation &&
+      evaluation.type === SWUTeamQuestionResponseEvaluationType.Individual) ||
+      (evaluation.proposal.opportunity.status ===
+        SWUOpportunityStatus.TeamQuestionsPanelConsensus &&
+        evaluation.type === SWUTeamQuestionResponseEvaluationType.Conensus))
   );
 }
 

--- a/src/back-end/lib/permissions.ts
+++ b/src/back-end/lib/permissions.ts
@@ -1004,7 +1004,7 @@ export function editSWUTeamQuestionResponseEvaluation(
       evaluation.type === SWUTeamQuestionResponseEvaluationType.Individual) ||
       (evaluation.proposal.status ===
         SWUProposalStatus.TeamQuestionsPanelConsensus &&
-        evaluation.type === SWUTeamQuestionResponseEvaluationType.Conensus))
+        evaluation.type === SWUTeamQuestionResponseEvaluationType.Consensus))
   );
 }
 
@@ -1021,7 +1021,7 @@ export function submitSWUTeamQuestionResponseEvaluation(
       evaluation.type === SWUTeamQuestionResponseEvaluationType.Individual) ||
       (evaluation.proposal.status ===
         SWUProposalStatus.TeamQuestionsPanelConsensus &&
-        evaluation.type === SWUTeamQuestionResponseEvaluationType.Conensus))
+        evaluation.type === SWUTeamQuestionResponseEvaluationType.Consensus))
   );
 }
 

--- a/src/back-end/lib/permissions.ts
+++ b/src/back-end/lib/permissions.ts
@@ -25,7 +25,7 @@ import {
 } from "shared/lib/resources/opportunity/code-with-us";
 import {
   CreateSWUOpportunityStatus,
-  doesSWUOpportunityStatusAllowGovToViewEvaluations,
+  doesSWUOpportunityStatusAllowGovToViewTeamQuestionResponseEvaluations,
   doesSWUOpportunityStatusAllowGovToViewProposals,
   SWUOpportunity,
   SWUOpportunityStatus
@@ -882,7 +882,7 @@ export async function readOneSWUTeamQuestionResponseEvaluation(
   return (
     !!session &&
     (isAdmin(session) || isGovernment(session)) &&
-    (doesSWUOpportunityStatusAllowGovToViewEvaluations(
+    (doesSWUOpportunityStatusAllowGovToViewTeamQuestionResponseEvaluations(
       evaluation.proposal.opportunity.status
     ) ||
       (evaluation.proposal.status ===
@@ -907,29 +907,33 @@ export async function readOneSWUTeamQuestionResponseEvaluation(
 export async function readManySWUTeamQuestionResponseEvaluations(
   connection: Connection,
   session: Session,
-  proposal: SWUProposal
+  opportunity: SWUOpportunity,
+  isConsensus: boolean
 ): Promise<boolean> {
   return (
     !!session &&
     (isAdmin(session) || isGovernment(session)) &&
-    (doesSWUOpportunityStatusAllowGovToViewEvaluations(
-      proposal.opportunity.status
+    (doesSWUOpportunityStatusAllowGovToViewTeamQuestionResponseEvaluations(
+      opportunity.status
     ) ||
-      // Filtered to authored evaluations elsewhere when proposal status is
-      // in individual evaluation
-      ((proposal.status === SWUProposalStatus.TeamQuestionsPanelIndividual ||
-        proposal.status === SWUProposalStatus.TeamQuestionsPanelConsensus) &&
-        (await isSWUOpportunityEvaluationPanelEvaluator(
-          connection,
-          session,
-          proposal.opportunity.id
-        ))) ||
-      (proposal.status === SWUProposalStatus.TeamQuestionsPanelConsensus &&
-        (await isSWUOpportunityEvaluationPanelChair(
-          connection,
-          session,
-          proposal.opportunity.id
-        ))))
+      (isConsensus
+        ? (await isSWUOpportunityEvaluationPanelEvaluator(
+            connection,
+            session,
+            opportunity.id
+          )) ||
+          (await isSWUOpportunityEvaluationPanelChair(
+            connection,
+            session,
+            opportunity.id
+          ))
+        : // Filtered to authored evaluations elsewhere when evaluation is
+          // individual
+          await isSWUOpportunityEvaluationPanelEvaluator(
+            connection,
+            session,
+            opportunity.id
+          )))
   );
 }
 

--- a/src/back-end/lib/permissions.ts
+++ b/src/back-end/lib/permissions.ts
@@ -907,15 +907,13 @@ export async function createSWUTeamQuestionResponseEvaluation(
   return (
     !!session &&
     (isAdmin(session) || isGovernment(session)) &&
-    ((proposal.opportunity.status ===
-      SWUOpportunityStatus.TeamQuestionsPanelEvaluation &&
+    ((proposal.status === SWUProposalStatus.TeamQuestionsPanelIndividual &&
       (await isSWUOpportunityEvaluationPanelEvaluator(
         connection,
         session,
         proposal.opportunity.id
       ))) ||
-      (proposal.opportunity.status ===
-        SWUOpportunityStatus.TeamQuestionsPanelConsensus &&
+      (proposal.status === SWUProposalStatus.TeamQuestionsPanelConsensus &&
         (await isSWUOpportunityEvaluationPanelChair(
           connection,
           session,
@@ -932,11 +930,28 @@ export function editSWUTeamQuestionResponseEvaluation(
     !!session &&
     (isAdmin(session) || isGovernment(session)) &&
     evaluation.evaluationPanelMember.user.id === session.user.id &&
-    ((evaluation.proposal.opportunity.status ===
-      SWUOpportunityStatus.TeamQuestionsPanelEvaluation &&
+    ((evaluation.proposal.status ===
+      SWUProposalStatus.TeamQuestionsPanelIndividual &&
       evaluation.type === SWUTeamQuestionResponseEvaluationType.Individual) ||
-      (evaluation.proposal.opportunity.status ===
-        SWUOpportunityStatus.TeamQuestionsPanelConsensus &&
+      (evaluation.proposal.status ===
+        SWUProposalStatus.TeamQuestionsPanelIndividual &&
+        evaluation.type === SWUTeamQuestionResponseEvaluationType.Conensus))
+  );
+}
+
+export function submitSWUTeamQuestionResponseEvaluation(
+  session: Session,
+  evaluation: SWUTeamQuestionResponseEvaluation
+): boolean {
+  return (
+    !!session &&
+    (isAdmin(session) || isGovernment(session)) &&
+    evaluation.evaluationPanelMember.user.id === session.user.id &&
+    ((evaluation.proposal.status ===
+      SWUProposalStatus.TeamQuestionsPanelIndividual &&
+      evaluation.type === SWUTeamQuestionResponseEvaluationType.Individual) ||
+      (evaluation.proposal.status ===
+        SWUProposalStatus.TeamQuestionsPanelConsensus &&
         evaluation.type === SWUTeamQuestionResponseEvaluationType.Conensus))
   );
 }

--- a/src/back-end/lib/permissions.ts
+++ b/src/back-end/lib/permissions.ts
@@ -937,6 +937,31 @@ export async function readManySWUTeamQuestionResponseEvaluations(
   );
 }
 
+export async function readManyIndividualSWUTeamQuestionResponseEvaluationsForConsensus(
+  connection: Connection,
+  session: Session,
+  proposal: SWUProposal
+): Promise<boolean> {
+  return (
+    !!session &&
+    (isAdmin(session) || isGovernment(session)) &&
+    (doesSWUOpportunityStatusAllowGovToViewTeamQuestionResponseEvaluations(
+      proposal.opportunity.status
+    ) ||
+      (proposal.status === SWUProposalStatus.TeamQuestionsPanelConsensus &&
+        ((await isSWUOpportunityEvaluationPanelEvaluator(
+          connection,
+          session,
+          proposal.opportunity.id
+        )) ||
+          (await isSWUOpportunityEvaluationPanelChair(
+            connection,
+            session,
+            proposal.opportunity.id
+          )))))
+  );
+}
+
 export function readOwnSWUTeamQuestionResponseEvaluations(
   session: Session
 ): boolean {

--- a/src/back-end/lib/permissions.ts
+++ b/src/back-end/lib/permissions.ts
@@ -899,6 +899,12 @@ export async function readManySWUTeamQuestionResponseEvaluations(
   );
 }
 
+export function readOwnSWUTeamQuestionResponseEvaluations(
+  session: Session
+): boolean {
+  return isGovernment(session) || isAdmin(session);
+}
+
 export async function createSWUTeamQuestionResponseEvaluation(
   connection: Connection,
   session: Session,

--- a/src/back-end/lib/permissions.ts
+++ b/src/back-end/lib/permissions.ts
@@ -25,6 +25,7 @@ import {
 } from "shared/lib/resources/opportunity/code-with-us";
 import {
   CreateSWUOpportunityStatus,
+  doesSWUOpportunityStatusAllowGovToViewEvaluations,
   doesSWUOpportunityStatusAllowGovToViewProposals,
   SWUOpportunity,
   SWUOpportunityStatus
@@ -881,15 +882,18 @@ export async function readManySWUTeamQuestionResponseEvaluations(
   return (
     !!session &&
     (isAdmin(session) || isGovernment(session)) &&
-    // Filtered to authored evaluations elsewhere when proposal status is
-    // in individual evaluation
-    (((proposal.status === SWUProposalStatus.TeamQuestionsPanelIndividual ||
-      proposal.status === SWUProposalStatus.TeamQuestionsPanelConsensus) &&
-      (await isSWUOpportunityEvaluationPanelEvaluator(
-        connection,
-        session,
-        proposal.opportunity.id
-      ))) ||
+    (doesSWUOpportunityStatusAllowGovToViewEvaluations(
+      proposal.opportunity.status
+    ) ||
+      // Filtered to authored evaluations elsewhere when proposal status is
+      // in individual evaluation
+      ((proposal.status === SWUProposalStatus.TeamQuestionsPanelIndividual ||
+        proposal.status === SWUProposalStatus.TeamQuestionsPanelConsensus) &&
+        (await isSWUOpportunityEvaluationPanelEvaluator(
+          connection,
+          session,
+          proposal.opportunity.id
+        ))) ||
       (proposal.status === SWUProposalStatus.TeamQuestionsPanelConsensus &&
         (await isSWUOpportunityEvaluationPanelChair(
           connection,

--- a/src/back-end/lib/permissions.ts
+++ b/src/back-end/lib/permissions.ts
@@ -874,6 +874,36 @@ export async function deleteSWUProposal(
 
 // SWU Team Question Response Evaluations
 
+export async function readOneSWUTeamQuestionResponseEvaluation(
+  connection: Connection,
+  session: Session,
+  evaluation: SWUTeamQuestionResponseEvaluation
+): Promise<boolean> {
+  return (
+    !!session &&
+    (isAdmin(session) || isGovernment(session)) &&
+    (doesSWUOpportunityStatusAllowGovToViewEvaluations(
+      evaluation.proposal.opportunity.status
+    ) ||
+      (evaluation.proposal.status ===
+        SWUProposalStatus.TeamQuestionsPanelIndividual &&
+        evaluation.type === SWUTeamQuestionResponseEvaluationType.Individual &&
+        evaluation.evaluationPanelMember.user.id === session.user.id) ||
+      (evaluation.proposal.status ===
+        SWUProposalStatus.TeamQuestionsPanelConsensus &&
+        ((await isSWUOpportunityEvaluationPanelEvaluator(
+          connection,
+          session,
+          evaluation.proposal.opportunity.id
+        )) ||
+          (await isSWUOpportunityEvaluationPanelChair(
+            connection,
+            session,
+            evaluation.proposal.opportunity.id
+          )))))
+  );
+}
+
 export async function readManySWUTeamQuestionResponseEvaluations(
   connection: Connection,
   session: Session,

--- a/src/back-end/lib/permissions.ts
+++ b/src/back-end/lib/permissions.ts
@@ -873,6 +873,32 @@ export async function deleteSWUProposal(
 
 // SWU Team Question Response Evaluations
 
+export async function readManySWUTeamQuestionResponseEvaluations(
+  connection: Connection,
+  session: Session,
+  proposal: SWUProposal
+): Promise<boolean> {
+  return (
+    !!session &&
+    (isAdmin(session) || isGovernment(session)) &&
+    // Filtered to authored evaluations elsewhere when proposal status is
+    // in individual evaluation
+    (((proposal.status === SWUProposalStatus.TeamQuestionsPanelIndividual ||
+      proposal.status === SWUProposalStatus.TeamQuestionsPanelConsensus) &&
+      (await isSWUOpportunityEvaluationPanelEvaluator(
+        connection,
+        session,
+        proposal.opportunity.id
+      ))) ||
+      (proposal.status === SWUProposalStatus.TeamQuestionsPanelConsensus &&
+        (await isSWUOpportunityEvaluationPanelChair(
+          connection,
+          session,
+          proposal.opportunity.id
+        ))))
+  );
+}
+
 export async function createSWUTeamQuestionResponseEvaluation(
   connection: Connection,
   session: Session,

--- a/src/back-end/lib/resources/question-evaluation/sprint-with-us.ts
+++ b/src/back-end/lib/resources/question-evaluation/sprint-with-us.ts
@@ -73,7 +73,7 @@ const readMany: crud.ReadMany<Session, db.Connection> = (
       code: number,
       body: SWUTeamQuestionResponseEvaluation[] | string[]
     ) => basicResponse(code, request.session, makeJsonResponseBody(body));
-    if (request.query.opportunity) {
+    if (request.query.proposal) {
       if (!permissions.isSignedIn(request.session)) {
         return respond(401, [permissions.ERROR_MESSAGE]);
       }
@@ -106,7 +106,7 @@ const readMany: crud.ReadMany<Session, db.Connection> = (
         return respond(503, [db.ERROR_MESSAGE]);
       }
       return respond(200, dbResult.value);
-    } else if (request.query.proposal) {
+    } else if (request.query.opportunity) {
       if (!permissions.isSignedIn(request.session)) {
         return respond(401, [permissions.ERROR_MESSAGE]);
       }

--- a/src/back-end/lib/resources/question-evaluation/sprint-with-us.ts
+++ b/src/back-end/lib/resources/question-evaluation/sprint-with-us.ts
@@ -7,19 +7,27 @@ import {
   makeJsonResponseBody,
   wrapRespond
 } from "back-end/lib/server";
-import { validateSWUProposalId } from "back-end/lib/validation";
+import {
+  validateSWUProposalId,
+  validateSWUTeamQuestionResponseEvaluationId
+} from "back-end/lib/validation";
 import { get, omit } from "lodash";
 import { getString } from "shared/lib";
 import {
+  CreateSWUTeamQuestionResponseEvaluationScoreValidationErrors,
   CreateValidationErrors,
   SWUTeamQuestionResponseEvaluation,
   SWUTeamQuestionResponseEvaluationStatus,
   SWUTeamQuestionResponseEvaluationType,
-  CreateRequestBody as SharedCreateRequestBody
+  CreateRequestBody as SharedCreateRequestBody,
+  UpdateRequestBody,
+  UpdateValidationErrors,
+  isValidStatusChange
 } from "shared/lib/resources/question-evaluation/sprint-with-us";
 import { AuthenticatedSession, Session } from "shared/lib/resources/session";
-import { Id } from "shared/lib/types";
+import { ADT, Id, adt } from "shared/lib/types";
 import {
+  Validation,
   getInvalidValue,
   invalid,
   isInvalid,
@@ -32,6 +40,16 @@ interface ValidatedCreateRequestBody extends SharedCreateRequestBody {
   session: AuthenticatedSession;
   evaluationPanelMember: Id;
 }
+
+interface ValidatedUpdateRequestBody {
+  session: AuthenticatedSession;
+  body: ADT<"edit", ValidatedUpdateEditRequestBody> | ADT<"submit", string>;
+}
+
+type ValidatedUpdateEditRequestBody = Omit<
+  ValidatedCreateRequestBody,
+  "proposal" | "evaluationPanelMember" | "status" | "type" | "session"
+>;
 
 type CreateRequestBody = Omit<SharedCreateRequestBody, "type" | "status"> & {
   status: string;
@@ -186,9 +204,226 @@ const create: crud.Create<
   };
 };
 
+const update: crud.Update<
+  Session,
+  db.Connection,
+  UpdateRequestBody,
+  ValidatedUpdateRequestBody,
+  UpdateValidationErrors
+> = (connection: db.Connection) => {
+  return {
+    async parseRequestBody(request) {
+      const body = request.body.tag === "json" ? request.body.value : {};
+      const tag = get(body, "tag");
+      const value: unknown = get(body, "value");
+      switch (tag) {
+        case "edit":
+          return adt("edit", {
+            scores: get(value, "scores")
+          });
+        case "submit":
+          return adt("submit", getString(body, "value", ""));
+        default:
+          return null;
+      }
+    },
+    async validateRequestBody(request) {
+      if (!request.body) {
+        return invalid({ proposal: adt("parseFailure" as const) });
+      }
+      if (!permissions.isSignedIn(request.session)) {
+        return invalid({
+          permissions: [permissions.ERROR_MESSAGE]
+        });
+      }
+      const validatedSWUTeamQuestionResponseEvaluation =
+        await validateSWUTeamQuestionResponseEvaluationId(
+          connection,
+          request.params.id,
+          request.session
+        );
+      if (isInvalid(validatedSWUTeamQuestionResponseEvaluation)) {
+        return invalid({
+          notFound: getInvalidValue(
+            validatedSWUTeamQuestionResponseEvaluation,
+            undefined
+          )
+        });
+      }
+
+      if (
+        !permissions.editSWUTeamQuestionResponseEvaluation(
+          request.session,
+          validatedSWUTeamQuestionResponseEvaluation.value
+        )
+      ) {
+        return invalid({
+          permissions: [permissions.ERROR_MESSAGE]
+        });
+      }
+
+      switch (request.body.tag) {
+        case "edit": {
+          const scores = request.body.value.scores;
+
+          const fullProposal = await db.readOneSWUProposal(
+            connection,
+            validatedSWUTeamQuestionResponseEvaluation.value.proposal.id,
+            request.session
+          );
+
+          const validatedScores =
+            questionEvaluationValidation.validateSWUTeamQuestionResponseEvaluationScores(
+              scores,
+              fullProposal.value?.teamQuestionResponses ?? []
+            );
+
+          if (isValid(validatedScores)) {
+            return valid(
+              adt(
+                "edit" as const,
+                {
+                  scores: validatedScores.value
+                } as ValidatedUpdateEditRequestBody
+              )
+            );
+          } else {
+            return invalid({
+              evaluation: adt("edit" as const, {
+                scores: getInvalidValue(validatedScores, undefined)
+              })
+            });
+          }
+        }
+        case "submit": {
+          if (
+            !isValidStatusChange(
+              validatedSWUTeamQuestionResponseEvaluation.value.status,
+              SWUTeamQuestionResponseEvaluationStatus.Submitted
+            )
+          ) {
+            return invalid({
+              permissions: [permissions.ERROR_MESSAGE]
+            });
+          }
+
+          const fullProposal = await db.readOneSWUProposal(
+            connection,
+            validatedSWUTeamQuestionResponseEvaluation.value.proposal.id,
+            request.session
+          );
+
+          const validatedScores =
+            questionEvaluationValidation.validateSWUTeamQuestionResponseEvaluationScores(
+              validatedSWUTeamQuestionResponseEvaluation.value.scores,
+              fullProposal.value?.teamQuestionResponses ?? []
+            );
+
+          if (
+            isInvalid<
+              CreateSWUTeamQuestionResponseEvaluationScoreValidationErrors[]
+            >(validatedScores) ||
+            validatedScores.value.length !==
+              fullProposal.value?.teamQuestionResponses.length
+          ) {
+            return invalid({
+              evaluation: adt("submit" as const, [
+                "This evaluation could not be submitted for review because it is incomplete. Please edit, complete and save the appropriate form before trying to submit it again."
+              ])
+            });
+          }
+
+          if (
+            !permissions.submitSWUTeamQuestionResponseEvaluation(
+              request.session,
+              validatedSWUTeamQuestionResponseEvaluation.value
+            )
+          ) {
+            return invalid({
+              permissions: [permissions.ERROR_MESSAGE]
+            });
+          }
+
+          const validatedSubmissionNote =
+            questionEvaluationValidation.validateNote(request.body.value);
+          if (isInvalid(validatedSubmissionNote)) {
+            return invalid({
+              proposal: adt("submit" as const, validatedSubmissionNote.value)
+            });
+          }
+          return valid({
+            session: request.session,
+            body: adt("submit" as const, validatedSubmissionNote.value)
+          } as ValidatedUpdateRequestBody);
+        }
+        default:
+          return invalid({ proposal: adt("parseFailure" as const) });
+      }
+    },
+    respond: wrapRespond<
+      ValidatedUpdateRequestBody,
+      UpdateValidationErrors,
+      JsonResponseBody<SWUTeamQuestionResponseEvaluation>,
+      JsonResponseBody<UpdateValidationErrors>,
+      Session
+    >({
+      valid: async (request) => {
+        let dbResult: Validation<SWUTeamQuestionResponseEvaluation, null>;
+        const { session, body } = request.body;
+        switch (body.tag) {
+          case "edit":
+            dbResult = await db.updateSWUTeamQuestionResponseEvaluation(
+              connection,
+              { ...body.value, id: request.params.id },
+              session
+            );
+            break;
+          case "submit":
+            dbResult = await db.updateSWUProposalStatus(
+              connection,
+              request.params.id,
+              SWUProposalStatus.Submitted,
+              body.value,
+              session
+            );
+            // Notify of submission
+            if (isValid(dbResult)) {
+              swuProposalNotifications.handleSWUProposalSubmitted(
+                connection,
+                request.params.id,
+                request.body.session
+              );
+            }
+            break;
+        }
+        if (isInvalid(dbResult)) {
+          return basicResponse(
+            503,
+            request.session,
+            makeJsonResponseBody({ database: [db.ERROR_MESSAGE] })
+          );
+        }
+        return basicResponse(
+          200,
+          request.session,
+          makeJsonResponseBody(dbResult.value)
+        );
+      },
+      invalid: async (request) => {
+        return basicResponse(
+          400,
+          request.session,
+          makeJsonResponseBody(request.body)
+        );
+      }
+    })
+  };
+};
+
 const resource: crud.BasicCrudResource<Session, db.Connection> = {
   routeNamespace,
-  create
+  create,
+  update
 };
 
 export default resource;

--- a/src/back-end/lib/resources/question-evaluation/sprint-with-us.ts
+++ b/src/back-end/lib/resources/question-evaluation/sprint-with-us.ts
@@ -227,7 +227,7 @@ const create: crud.Create<
         questionEvaluationValidation.validateSWUTeamQuestionResponseEvaluationType(
           type,
           [
-            SWUTeamQuestionResponseEvaluationType.Conensus,
+            SWUTeamQuestionResponseEvaluationType.Consensus,
             SWUTeamQuestionResponseEvaluationType.Individual
           ]
         );
@@ -437,7 +437,7 @@ const update: crud.Update<
             validatedSWUTeamQuestionResponseEvaluation.value.status !==
               SWUTeamQuestionResponseEvaluationStatus.Draft &&
             validatedSWUTeamQuestionResponseEvaluation.value.type !==
-              SWUTeamQuestionResponseEvaluationType.Conensus
+              SWUTeamQuestionResponseEvaluationType.Consensus
           ) {
             return invalid({
               permissions: [permissions.ERROR_MESSAGE]

--- a/src/back-end/lib/resources/question-evaluation/sprint-with-us.ts
+++ b/src/back-end/lib/resources/question-evaluation/sprint-with-us.ts
@@ -147,6 +147,28 @@ const create: crud.Create<
         });
       }
 
+      // Check for existing evaluation on this proposal, authored by this user
+      const dbResultEvaluation =
+        await db.readOneSWUTeamQuestionResponseEvaluationByProposalAndEvaluationPanelMember(
+          connection,
+          validatedSWUProposal.value.id,
+          validatedSWUPanelEvaluationPanelMember.value.id,
+          validatedType.value,
+          request.session
+        );
+      if (isInvalid(dbResultEvaluation)) {
+        return invalid({
+          database: [db.ERROR_MESSAGE]
+        });
+      }
+      if (dbResultEvaluation.value) {
+        return invalid({
+          conflict: [
+            "You already have an team question evaluation for this proposal."
+          ]
+        });
+      }
+
       const validatedScores =
         questionEvaluationValidation.validateSWUTeamQuestionResponseEvaluationScores(
           scores,

--- a/src/back-end/lib/resources/question-evaluation/sprint-with-us.ts
+++ b/src/back-end/lib/resources/question-evaluation/sprint-with-us.ts
@@ -273,10 +273,16 @@ const create: crud.Create<
         });
       }
 
+      const fullOpportunity = await db.readOneSWUOpportunity(
+        connection,
+        validatedSWUProposal.value.opportunity.id,
+        request.session
+      );
+
       const validatedScores =
         questionEvaluationValidation.validateSWUTeamQuestionResponseEvaluationScores(
           scores,
-          validatedSWUProposal.value.teamQuestionResponses
+          fullOpportunity.value?.teamQuestions ?? []
         );
 
       if (isValid(validatedScores)) {
@@ -406,16 +412,17 @@ const update: crud.Update<
             });
           }
 
-          const fullProposal = await db.readOneSWUProposal(
+          const fullOpportunity = await db.readOneSWUOpportunity(
             connection,
-            validatedSWUTeamQuestionResponseEvaluation.value.proposal.id,
+            validatedSWUTeamQuestionResponseEvaluation.value.proposal
+              .opportunity.id,
             request.session
           );
 
           const validatedScores =
             questionEvaluationValidation.validateSWUTeamQuestionResponseEvaluationScores(
               scores,
-              fullProposal.value?.teamQuestionResponses ?? []
+              fullOpportunity.value?.teamQuestions ?? []
             );
 
           if (isValid(validatedScores)) {
@@ -448,16 +455,17 @@ const update: crud.Update<
             });
           }
 
-          const fullProposal = await db.readOneSWUProposal(
+          const fullOpportunity = await db.readOneSWUOpportunity(
             connection,
-            validatedSWUTeamQuestionResponseEvaluation.value.proposal.id,
+            validatedSWUTeamQuestionResponseEvaluation.value.proposal
+              .opportunity.id,
             request.session
           );
 
           const validatedScores =
             questionEvaluationValidation.validateSWUTeamQuestionResponseEvaluationScores(
               validatedSWUTeamQuestionResponseEvaluation.value.scores,
-              fullProposal.value?.teamQuestionResponses ?? []
+              fullOpportunity.value?.teamQuestions ?? []
             );
 
           if (
@@ -465,7 +473,7 @@ const update: crud.Update<
               CreateSWUTeamQuestionResponseEvaluationScoreValidationErrors[]
             >(validatedScores) ||
             validatedScores.value.length !==
-              fullProposal.value?.teamQuestionResponses.length
+              fullOpportunity.value?.teamQuestions.length
           ) {
             return invalid({
               evaluation: adt("submit" as const, [

--- a/src/back-end/lib/validation.ts
+++ b/src/back-end/lib/validation.ts
@@ -80,6 +80,7 @@ import {
   validateSWUEvaluationPanelMemberChair,
   validateSWUEvaluationPanelMemberEvaluator
 } from "shared/lib/validation/opportunity/sprint-with-us";
+import { SWUTeamQuestionResponseEvaluation } from "shared/lib/resources/question-evaluation/sprint-with-us";
 
 /**
  * TWU - Team With Us Validation
@@ -1012,6 +1013,38 @@ export async function validateDraftProposalOrganization(
   return await optionalAsync(organization, (v) =>
     validateOrganizationId(connection, v, session, false)
   );
+}
+
+export async function validateSWUTeamQuestionResponseEvaluationId(
+  connection: db.Connection,
+  evaluationId: Id,
+  session: AuthenticatedSession
+): Promise<Validation<SWUTeamQuestionResponseEvaluation>> {
+  try {
+    const validatedId = validateUUID(evaluationId);
+    if (isInvalid(validatedId)) {
+      return validatedId;
+    }
+    const dbResult = await db.readOneSWUTeamQuestionResponseEvaluation(
+      connection,
+      evaluationId,
+      session
+    );
+    if (isInvalid(dbResult)) {
+      return invalid([db.ERROR_MESSAGE]);
+    }
+    const evaluation = dbResult.value;
+    if (!evaluation) {
+      return invalid([
+        "The specified team question response evaluation was not found."
+      ]);
+    }
+    return valid(evaluation);
+  } catch (exception) {
+    return invalid([
+      "Please select a valid team question response evaluation."
+    ]);
+  }
 }
 
 export async function validateContentId(

--- a/src/front-end/typescript/lib/app/router.ts
+++ b/src/front-end/typescript/lib/app/router.ts
@@ -135,6 +135,68 @@ const router: router_.Router<Route> = {
     },
     {
       path: prefixPath(
+        "/opportunities/sprint-with-us/:opportunityId/proposals/:proposalId/question-evaluations/individual/create"
+      ),
+      makeRoute({ params, query }) {
+        return {
+          tag: "questionEvaluationIndividualSWUCreate",
+          value: {
+            proposalId: params.proposalId || "",
+            opportunityId: params.opportunityId || "",
+            tab: SWUProposalViewTab.parseTabId(query.tab) || undefined
+          }
+        };
+      }
+    },
+    {
+      path: prefixPath(
+        "/opportunities/sprint-with-us/:opportunityId/proposals/:proposalId/question-evaluations/individual/:evaluationId/edit"
+      ),
+      makeRoute({ params, query }) {
+        return {
+          tag: "questionEvaluationIndividualSWUEdit",
+          value: {
+            proposalId: params.proposalId || "",
+            opportunityId: params.opportunityId || "",
+            evaluationId: params.evaluationId || "",
+            tab: SWUProposalViewTab.parseTabId(query.tab) || undefined
+          }
+        };
+      }
+    },
+    {
+      path: prefixPath(
+        "/opportunities/sprint-with-us/:opportunityId/proposals/:proposalId/question-evaluations/consensus/create"
+      ),
+      makeRoute({ params, query }) {
+        return {
+          tag: "questionEvaluationConsensusSWUCreate",
+          value: {
+            proposalId: params.proposalId || "",
+            opportunityId: params.opportunityId || "",
+            tab: SWUProposalViewTab.parseTabId(query.tab) || undefined
+          }
+        };
+      }
+    },
+    {
+      path: prefixPath(
+        "/opportunities/sprint-with-us/:opportunityId/proposals/:proposalId/question-evaluations/consensus/:evaluationId/edit"
+      ),
+      makeRoute({ params, query }) {
+        return {
+          tag: "questionEvaluationConsensusSWUEdit",
+          value: {
+            proposalId: params.proposalId || "",
+            opportunityId: params.opportunityId || "",
+            evaluationId: params.evaluationId || "",
+            tab: SWUProposalViewTab.parseTabId(query.tab) || undefined
+          }
+        };
+      }
+    },
+    {
+      path: prefixPath(
         "/opportunities/sprint-with-us/:opportunityId/proposals/:proposalId/export"
       ),
       makeRoute({ params }) {
@@ -721,6 +783,46 @@ const router: router_.Router<Route> = {
           `/opportunities/sprint-with-us/${
             route.value.opportunityId
           }/proposals/${route.value.proposalId}${
+            route.value.tab ? `?tab=${route.value.tab}` : ""
+          }`
+        );
+      case "questionEvaluationIndividualSWUCreate":
+        return prefixPath(
+          `/opportunities/sprint-with-us/${
+            route.value.opportunityId
+          }/proposals/${
+            route.value.proposalId
+          }/question-evaluations/individual/create${
+            route.value.tab ? `?tab=${route.value.tab}` : ""
+          }`
+        );
+      case "questionEvaluationIndividualSWUEdit":
+        return prefixPath(
+          `/opportunities/sprint-with-us/${
+            route.value.opportunityId
+          }/proposals/${
+            route.value.proposalId
+          }/question-evaluations/individual/${route.value.evaluationId}/edit${
+            route.value.tab ? `?tab=${route.value.tab}` : ""
+          }`
+        );
+      case "questionEvaluationConsensusSWUCreate":
+        return prefixPath(
+          `/opportunities/sprint-with-us/${
+            route.value.opportunityId
+          }/proposals/${
+            route.value.proposalId
+          }/question-evaluations/consensus/create${
+            route.value.tab ? `?tab=${route.value.tab}` : ""
+          }`
+        );
+      case "questionEvaluationConsensusSWUEdit":
+        return prefixPath(
+          `/opportunities/sprint-with-us/${
+            route.value.opportunityId
+          }/proposals/${
+            route.value.proposalId
+          }/question-evaluations/consensus/${route.value.evaluationId}/edit${
             route.value.tab ? `?tab=${route.value.tab}` : ""
           }`
         );

--- a/src/front-end/typescript/lib/app/router.ts
+++ b/src/front-end/typescript/lib/app/router.ts
@@ -14,7 +14,7 @@ import * as SWUProposalEditTab from "front-end/lib/pages/proposal/sprint-with-us
 import * as SWUProposalViewTab from "front-end/lib/pages/proposal/sprint-with-us/view/tab";
 import * as TWUProposalEditTab from "front-end/lib/pages/proposal/team-with-us/edit/tab";
 import * as UserProfileTab from "front-end/lib/pages/user/profile/tab";
-import { getString, getStringArray } from "shared/lib";
+import { getString } from "shared/lib";
 import { adt } from "shared/lib/types";
 
 export function pushState<Msg>(route: Route, msg: Msg): component.Cmd<Msg> {
@@ -123,26 +123,12 @@ const router: router_.Router<Route> = {
         "/opportunities/sprint-with-us/:opportunityId/proposals/:proposalId"
       ),
       makeRoute({ params, query }) {
-        const qEvalIndividual = Array.isArray(query.qEvalIndividual)
-          ? getStringArray(query, "qEvalIndividual")
-          : [getString(query, "qEvalIndividual")].filter(Boolean);
-        const qEvalConsensus = getString(query, "qEvalConsensus");
-        const qEvalMode =
-          query.qEvalMode === "create"
-            ? "create"
-            : query.qEvalMode === "edit"
-            ? "edit"
-            : undefined;
-
         return {
           tag: "proposalSWUView",
           value: {
             proposalId: params.proposalId || "",
             opportunityId: params.opportunityId || "",
-            tab: SWUProposalViewTab.parseTabId(query.tab) || undefined,
-            qEvalIndividual,
-            qEvalConsensus,
-            qEvalMode
+            tab: SWUProposalViewTab.parseTabId(query.tab) || undefined
           }
         };
       }
@@ -730,35 +716,14 @@ const router: router_.Router<Route> = {
             route.value.tab ? `?tab=${route.value.tab}` : ""
           }`
         );
-      case "proposalSWUView": {
-        const params = new URLSearchParams({
-          ...(route.value.tab ? { tab: route.value.tab } : {})
-        });
-        switch (route.value.qEvalMode) {
-          case "create":
-            params.append("qEvalMode", "create");
-            break;
-          case "edit": {
-            params.append("qEvalMode", "edit");
-            route.value.qEvalIndividual?.forEach((q) => {
-              params.append("qEvalIndividual", q);
-            });
-            if (route.value.qEvalConsensus) {
-              params.append("qEvalConsensus", route.value.qEvalConsensus);
-            }
-            break;
-          }
-        }
-
+      case "proposalSWUView":
         return prefixPath(
-          [
-            `/opportunities/sprint-with-us/${route.value.opportunityId}/proposals/${route.value.proposalId}`,
-            params.toString()
-          ]
-            .filter(Boolean)
-            .join("?")
+          `/opportunities/sprint-with-us/${
+            route.value.opportunityId
+          }/proposals/${route.value.proposalId}${
+            route.value.tab ? `?tab=${route.value.tab}` : ""
+          }`
         );
-      }
       case "proposalSWUExportOne":
         return prefixPath(
           `/opportunities/sprint-with-us/${route.value.opportunityId}/proposals/${route.value.proposalId}/export`

--- a/src/front-end/typescript/lib/app/types.ts
+++ b/src/front-end/typescript/lib/app/types.ts
@@ -45,6 +45,10 @@ import * as PageProposalSWUCreate from "front-end/lib/pages/proposal/sprint-with
 import * as PageProposalSWUEdit from "front-end/lib/pages/proposal/sprint-with-us/edit";
 import * as PageProposalSWUExportAll from "front-end/lib/pages/proposal/sprint-with-us/export/all";
 import * as PageProposalSWUExportOne from "front-end/lib/pages/proposal/sprint-with-us/export/one";
+import * as PageEvaluationIndividualSWUCreate from "front-end/lib/pages/question-evaluation/sprint-with-us/create-individual";
+import * as PageEvaluationIndividualSWUEdit from "front-end/lib/pages/question-evaluation/sprint-with-us/edit-individual";
+import * as PageEvaluationConsensusSWUCreate from "front-end/lib/pages/question-evaluation/sprint-with-us/create-consensus";
+import * as PageEvaluationConsensusSWUEdit from "front-end/lib/pages/question-evaluation/sprint-with-us/edit-individual";
 import * as PageProposalSWUView from "front-end/lib/pages/proposal/sprint-with-us/view";
 import * as PageSignIn from "front-end/lib/pages/sign-in";
 import * as PageSignOut from "front-end/lib/pages/sign-out";
@@ -90,6 +94,22 @@ export type Route =
   | ADT<"proposalSWUCreate", PageProposalSWUCreate.RouteParams>
   | ADT<"proposalSWUEdit", PageProposalSWUEdit.RouteParams>
   | ADT<"proposalSWUView", PageProposalSWUView.RouteParams>
+  | ADT<
+      "questionEvaluationIndividualSWUCreate",
+      PageEvaluationIndividualSWUCreate.RouteParams
+    >
+  | ADT<
+      "questionEvaluationIndividualSWUEdit",
+      PageEvaluationIndividualSWUEdit.RouteParams
+    >
+  | ADT<
+      "questionEvaluationConsensusSWUCreate",
+      PageEvaluationConsensusSWUCreate.RouteParams
+    >
+  | ADT<
+      "questionEvaluationConsensusSWUEdit",
+      PageEvaluationConsensusSWUEdit.RouteParams
+    >
   | ADT<"proposalSWUExportOne", PageProposalSWUExportOne.RouteParams>
   | ADT<"proposalSWUExportAll", PageProposalSWUExportAll.RouteParams>
   | ADT<"opportunitySWUCreate", PageOpportunitySWUCreate.RouteParams>

--- a/src/front-end/typescript/lib/app/update.ts
+++ b/src/front-end/typescript/lib/app/update.ts
@@ -54,6 +54,10 @@ import * as PageProposalSWUEdit from "front-end/lib/pages/proposal/sprint-with-u
 import * as PageProposalSWUExportAll from "front-end/lib/pages/proposal/sprint-with-us/export/all";
 import * as PageProposalSWUExportOne from "front-end/lib/pages/proposal/sprint-with-us/export/one";
 import * as PageProposalSWUView from "front-end/lib/pages/proposal/sprint-with-us/view";
+import * as PageQuestionEvaluationIndividualSWUCreate from "front-end/lib/pages/question-evaluation/sprint-with-us/create-individual";
+import * as PageQuestionEvaluationIndividualSWUEdit from "front-end/lib/pages/question-evaluation/sprint-with-us/edit-individual";
+import * as PageQuestionEvaluationConsensusSWUCreate from "front-end/lib/pages/question-evaluation/sprint-with-us/create-consensus";
+import * as PageQuestionEvaluationConsensusSWUEdit from "front-end/lib/pages/question-evaluation/sprint-with-us/edit-individual";
 import * as PageProposalTWUCreate from "front-end/lib/pages/proposal/team-with-us/create";
 import * as PageProposalTWUView from "front-end/lib/pages/proposal/team-with-us/view";
 import * as PageProposalTWUEdit from "front-end/lib/pages/proposal/team-with-us/edit";
@@ -176,6 +180,50 @@ function initPage(
         pageStatePath: ["pages", "proposalSWUView"],
         pageRouteParams: route.value,
         pageInit: PageProposalSWUView.component.init,
+        pageGetMetadata: PageProposalSWUView.component.getMetadata,
+        mapPageMsg(value) {
+          return adt("pageProposalSWUView", value) as Msg;
+        }
+      });
+    case "questionEvaluationIndividualSWUCreate":
+      return component.app.initPage({
+        ...defaultPageInitParams,
+        pageStatePath: ["pages", "proposalSWUView"],
+        pageRouteParams: route.value,
+        pageInit: PageQuestionEvaluationIndividualSWUCreate.component.init,
+        pageGetMetadata: PageProposalSWUView.component.getMetadata,
+        mapPageMsg(value) {
+          return adt("pageProposalSWUView", value) as Msg;
+        }
+      });
+    case "questionEvaluationIndividualSWUEdit":
+      return component.app.initPage({
+        ...defaultPageInitParams,
+        pageStatePath: ["pages", "proposalSWUView"],
+        pageRouteParams: route.value,
+        pageInit: PageQuestionEvaluationIndividualSWUEdit.component.init,
+        pageGetMetadata: PageProposalSWUView.component.getMetadata,
+        mapPageMsg(value) {
+          return adt("pageProposalSWUView", value) as Msg;
+        }
+      });
+    case "questionEvaluationConsensusSWUCreate":
+      return component.app.initPage({
+        ...defaultPageInitParams,
+        pageStatePath: ["pages", "proposalSWUView"],
+        pageRouteParams: route.value,
+        pageInit: PageQuestionEvaluationConsensusSWUCreate.component.init,
+        pageGetMetadata: PageProposalSWUView.component.getMetadata,
+        mapPageMsg(value) {
+          return adt("pageProposalSWUView", value) as Msg;
+        }
+      });
+    case "questionEvaluationConsensusSWUEdit":
+      return component.app.initPage({
+        ...defaultPageInitParams,
+        pageStatePath: ["pages", "proposalSWUView"],
+        pageRouteParams: route.value,
+        pageInit: PageQuestionEvaluationConsensusSWUEdit.component.init,
         pageGetMetadata: PageProposalSWUView.component.getMetadata,
         mapPageMsg(value) {
           return adt("pageProposalSWUView", value) as Msg;

--- a/src/front-end/typescript/lib/app/view/index.tsx
+++ b/src/front-end/typescript/lib/app/view/index.tsx
@@ -261,6 +261,10 @@ function pageToViewPageProps(
         (value) => ({ tag: "pageProposalSWUEdit", value })
       );
 
+    case "questionEvaluationIndividualSWUCreate":
+    case "questionEvaluationIndividualSWUEdit":
+    case "questionEvaluationConsensusSWUCreate":
+    case "questionEvaluationConsensusSWUEdit":
     case "proposalSWUView":
       return makeViewPageProps(
         props,

--- a/src/front-end/typescript/lib/http/api/index.ts
+++ b/src/front-end/typescript/lib/http/api/index.ts
@@ -60,3 +60,4 @@ export * as proposals from "front-end/lib/http/api/proposal";
 export * as sessions from "front-end/lib/http/api/session";
 export * as subscribers from "front-end/lib/http/api/subscribers";
 export * as users from "front-end/lib/http/api/user";
+export * as evaluations from "front-end/lib/http/api/question-evaluation";

--- a/src/front-end/typescript/lib/http/api/question-evaluation/index.ts
+++ b/src/front-end/typescript/lib/http/api/question-evaluation/index.ts
@@ -1,0 +1,1 @@
+export * as swu from "front-end/lib/http/api/question-evaluation/sprint-with-us";

--- a/src/front-end/typescript/lib/http/api/question-evaluation/sprint-with-us.ts
+++ b/src/front-end/typescript/lib/http/api/question-evaluation/sprint-with-us.ts
@@ -23,11 +23,16 @@ export function create<Msg>(): crud.CreateAction<
  * @param opportunityId
  * @param consensus
  */
-export function readMany<Msg>(
-  opportunityId?: Id,
-  consensus?: boolean
-): crud.ReadManyAction<
-  Resource.SWUTeamQuestionResponseEvaluationSlim,
+export function readMany<Msg>({
+  opportunityId,
+  proposalId,
+  consensus
+}: {
+  opportunityId?: Id;
+  proposalId?: Id;
+  consensus?: boolean;
+} = {}): crud.ReadManyAction<
+  Resource.SWUTeamQuestionResponseEvaluation,
   string[],
   Msg
 > {
@@ -35,29 +40,28 @@ export function readMany<Msg>(
     opportunity:
       opportunityId !== undefined
         ? window.encodeURIComponent(opportunityId)
-        : ""
+        : "",
+    proposal:
+      proposalId !== undefined ? window.encodeURIComponent(proposalId) : ""
   });
   if (consensus) {
     params.append("consensus", "true");
   }
   return crud.makeReadManyAction(
     NAMESPACE,
-    rawSWUTeamQuestionResponseEvaluationSlimToSWUTeamQuestionResponseEvaluationSlim,
+    rawSWUTeamQuestionResponseEvaluationToSWUTeamQuestionResponseEvaluation,
     params.toString()
   );
 }
 
-export function readOne<Msg>(
-  opportunityId: Id
-): crud.ReadOneAction<
+export function readOne<Msg>(): crud.ReadOneAction<
   Resource.SWUTeamQuestionResponseEvaluation,
   string[],
   Msg
 > {
   return crud.makeReadOneAction(
     NAMESPACE,
-    rawSWUTeamQuestionResponseEvaluationToSWUTeamQuestionResponseEvaluation,
-    `opportunity=${window.encodeURIComponent(opportunityId)}`
+    rawSWUTeamQuestionResponseEvaluationToSWUTeamQuestionResponseEvaluation
   );
 }
 
@@ -87,26 +91,6 @@ interface RawSWUTeamQuestionResponseEvaluation
 function rawSWUTeamQuestionResponseEvaluationToSWUTeamQuestionResponseEvaluation(
   raw: RawSWUTeamQuestionResponseEvaluation
 ): Resource.SWUTeamQuestionResponseEvaluation {
-  return {
-    ...raw,
-    createdAt: new Date(raw.createdAt),
-    updatedAt: new Date(raw.updatedAt),
-    scores: raw.scores.sort((a, b) => compareNumbers(a.order, b.order))
-  };
-}
-
-interface RawSWUTeamQuestionResponseEvaluationSlim
-  extends Omit<
-    Resource.SWUTeamQuestionResponseEvaluationSlim,
-    "createdAt" | "updatedAt"
-  > {
-  createdAt: string;
-  updatedAt: string;
-}
-
-function rawSWUTeamQuestionResponseEvaluationSlimToSWUTeamQuestionResponseEvaluationSlim(
-  raw: RawSWUTeamQuestionResponseEvaluationSlim
-): Resource.SWUTeamQuestionResponseEvaluationSlim {
   return {
     ...raw,
     createdAt: new Date(raw.createdAt),

--- a/src/front-end/typescript/lib/http/api/question-evaluation/sprint-with-us.ts
+++ b/src/front-end/typescript/lib/http/api/question-evaluation/sprint-with-us.ts
@@ -1,0 +1,116 @@
+import * as crud from "front-end/lib/http/crud";
+import * as Resource from "shared/lib/resources/question-evaluation/sprint-with-us";
+import { compareNumbers } from "shared/lib";
+import { Id } from "shared/lib/types";
+
+const NAMESPACE = "question-evaluations/sprint-with-us";
+
+export function create<Msg>(): crud.CreateAction<
+  Resource.CreateRequestBody,
+  Resource.SWUTeamQuestionResponseEvaluation,
+  Resource.CreateValidationErrors,
+  Msg
+> {
+  return crud.makeCreateAction(
+    NAMESPACE,
+    rawSWUTeamQuestionResponseEvaluationToSWUTeamQuestionResponseEvaluation
+  );
+}
+
+/**
+ * Parses URL parameters prior to creating a read request for many SWU proposals
+ *
+ * @param opportunityId
+ * @param consensus
+ */
+export function readMany<Msg>(
+  opportunityId?: Id,
+  consensus?: boolean
+): crud.ReadManyAction<
+  Resource.SWUTeamQuestionResponseEvaluationSlim,
+  string[],
+  Msg
+> {
+  const params = new URLSearchParams({
+    opportunity:
+      opportunityId !== undefined
+        ? window.encodeURIComponent(opportunityId)
+        : ""
+  });
+  if (consensus) {
+    params.append("consensus", "true");
+  }
+  return crud.makeReadManyAction(
+    NAMESPACE,
+    rawSWUTeamQuestionResponseEvaluationSlimToSWUTeamQuestionResponseEvaluationSlim,
+    params.toString()
+  );
+}
+
+export function readOne<Msg>(
+  opportunityId: Id
+): crud.ReadOneAction<
+  Resource.SWUTeamQuestionResponseEvaluation,
+  string[],
+  Msg
+> {
+  return crud.makeReadOneAction(
+    NAMESPACE,
+    rawSWUTeamQuestionResponseEvaluationToSWUTeamQuestionResponseEvaluation,
+    `opportunity=${window.encodeURIComponent(opportunityId)}`
+  );
+}
+
+export function update<Msg>(): crud.UpdateAction<
+  Resource.UpdateRequestBody,
+  Resource.SWUTeamQuestionResponseEvaluation,
+  Resource.UpdateValidationErrors,
+  Msg
+> {
+  return crud.makeUpdateAction(
+    NAMESPACE,
+    rawSWUTeamQuestionResponseEvaluationToSWUTeamQuestionResponseEvaluation
+  );
+}
+
+// Raw Conversion
+
+interface RawSWUTeamQuestionResponseEvaluation
+  extends Omit<
+    Resource.SWUTeamQuestionResponseEvaluation,
+    "createdAt" | "updatedAt"
+  > {
+  createdAt: string;
+  updatedAt: string;
+}
+
+function rawSWUTeamQuestionResponseEvaluationToSWUTeamQuestionResponseEvaluation(
+  raw: RawSWUTeamQuestionResponseEvaluation
+): Resource.SWUTeamQuestionResponseEvaluation {
+  return {
+    ...raw,
+    createdAt: new Date(raw.createdAt),
+    updatedAt: new Date(raw.updatedAt),
+    scores: raw.scores.sort((a, b) => compareNumbers(a.order, b.order))
+  };
+}
+
+interface RawSWUTeamQuestionResponseEvaluationSlim
+  extends Omit<
+    Resource.SWUTeamQuestionResponseEvaluationSlim,
+    "createdAt" | "updatedAt"
+  > {
+  createdAt: string;
+  updatedAt: string;
+}
+
+function rawSWUTeamQuestionResponseEvaluationSlimToSWUTeamQuestionResponseEvaluationSlim(
+  raw: RawSWUTeamQuestionResponseEvaluationSlim
+): Resource.SWUTeamQuestionResponseEvaluationSlim {
+  return {
+    ...raw,
+    createdAt: new Date(raw.createdAt),
+    updatedAt: new Date(raw.updatedAt),
+    scores: raw.scores.sort((a, b) => compareNumbers(a.order, b.order))
+  };
+}

--- a/src/front-end/typescript/lib/pages/opportunity/sprint-with-us/edit/index.tsx
+++ b/src/front-end/typescript/lib/pages/opportunity/sprint-with-us/edit/index.tsx
@@ -26,7 +26,7 @@ import { User, UserType, isAdmin } from "shared/lib/resources/user";
 import { adt, ADT, Id } from "shared/lib/types";
 import { invalid, valid, Validation } from "shared/lib/validation";
 import { SWUProposalSlim } from "shared/lib/resources/proposal/sprint-with-us";
-import { SWUTeamQuestionResponseEvaluationSlim } from "shared/lib/resources/question-evaluation/sprint-with-us";
+import { SWUTeamQuestionResponseEvaluation } from "shared/lib/resources/question-evaluation/sprint-with-us";
 
 interface ValidState<K extends Tab.TabId> extends Tab.ParentState<K> {
   opportunity: SWUOpportunity | null;
@@ -48,7 +48,7 @@ export type InnerMsg_<K extends Tab.TabId> = Tab.ParentInnerMsg<
       Tab.TabId,
       api.ResponseValidation<SWUOpportunity, string[]>,
       api.ResponseValidation<SWUProposalSlim[], string[]>,
-      api.ResponseValidation<SWUTeamQuestionResponseEvaluationSlim[], string[]>,
+      api.ResponseValidation<SWUTeamQuestionResponseEvaluation[], string[]>,
       User
     ]
   >
@@ -110,10 +110,10 @@ function makeInit<K extends Tab.TabId>(): component_.page.Init<
                 )
               : component_.cmd.dispatch(valid([])),
             Tab.shouldLoadEvaluationsForTab(tabId)
-              ? api.evaluations.swu.readMany(
-                  routeParams.opportunityId,
-                  tabId === "consensus"
-                )((response) => response)
+              ? api.evaluations.swu.readMany({
+                  opportunityId: routeParams.opportunityId,
+                  consensus: tabId === "consensus"
+                })((response) => response)
               : component_.cmd.dispatch(valid([])),
             (opportunity, proposals, evaluations) =>
               adt("onInitResponse", [

--- a/src/front-end/typescript/lib/pages/opportunity/sprint-with-us/edit/tab/index.ts
+++ b/src/front-end/typescript/lib/pages/opportunity/sprint-with-us/edit/tab/index.ts
@@ -5,6 +5,7 @@ import * as AddendaTab from "front-end/lib/pages/opportunity/sprint-with-us/edit
 import * as CodeChallengeTab from "front-end/lib/pages/opportunity/sprint-with-us/edit/tab/code-challenge";
 import * as HistoryTab from "front-end/lib/pages/opportunity/sprint-with-us/edit/tab/history";
 import * as OpportunityTab from "front-end/lib/pages/opportunity/sprint-with-us/edit/tab/opportunity";
+import * as OverviewTab from "front-end/lib/pages/opportunity/sprint-with-us/edit/tab/overview";
 import * as ProposalsTab from "front-end/lib/pages/opportunity/sprint-with-us/edit/tab/proposals";
 import * as SummaryTab from "front-end/lib/pages/opportunity/sprint-with-us/edit/tab/summary";
 import * as TeamQuestionsTab from "front-end/lib/pages/opportunity/sprint-with-us/edit/tab/team-questions";
@@ -20,6 +21,7 @@ import { User } from "shared/lib/resources/user";
 import { adt, Id } from "shared/lib/types";
 import { SWUProposalSlim } from "shared/lib/resources/proposal/sprint-with-us";
 import { GUIDE_AUDIENCE } from "front-end/lib/pages/guide/view";
+import { SWUTeamQuestionResponseEvaluationSlim } from "shared/lib/resources/question-evaluation/sprint-with-us";
 
 // Parent page types & functions.
 
@@ -48,7 +50,11 @@ export type TabPermissions = {
   isChair: boolean;
 };
 
-export type InitResponse = [SWUOpportunity, SWUProposalSlim[]];
+export type InitResponse = [
+  SWUOpportunity,
+  SWUProposalSlim[],
+  SWUTeamQuestionResponseEvaluationSlim[]
+];
 
 export type Component<State, Msg> = TabbedPage.TabComponent<
   Params,
@@ -114,8 +120,8 @@ export interface Tabs {
   >;
   overview: TabbedPage.Tab<
     Params,
-    SummaryTab.State,
-    SummaryTab.InnerMsg,
+    OverviewTab.State,
+    OverviewTab.InnerMsg,
     InitResponse
   >;
   consensus: TabbedPage.Tab<
@@ -231,8 +237,7 @@ export function idToDefinition<K extends TabId>(
       } as TabbedPage.TabDefinition<Tabs, K>;
     case "overview":
       return {
-        // TODO: Create tab
-        component: SummaryTab.component,
+        component: OverviewTab.component,
         icon: "list-check",
         title: "Overview"
       } as TabbedPage.TabDefinition<Tabs, K>;
@@ -330,10 +335,16 @@ export function makeSidebarState(
 
 export function shouldLoadProposalsForTab(tabId: TabId): boolean {
   const proposalTabs: TabId[] = [
+    "overview",
     "proposals",
     "teamQuestions",
     "codeChallenge",
     "teamScenario"
   ];
   return proposalTabs.includes(tabId);
+}
+
+export function shouldLoadEvaluationsForTab(tabId: TabId): boolean {
+  const evaluationTabs: TabId[] = ["overview"];
+  return evaluationTabs.includes(tabId);
 }

--- a/src/front-end/typescript/lib/pages/opportunity/sprint-with-us/edit/tab/index.ts
+++ b/src/front-end/typescript/lib/pages/opportunity/sprint-with-us/edit/tab/index.ts
@@ -21,7 +21,7 @@ import { User } from "shared/lib/resources/user";
 import { adt, Id } from "shared/lib/types";
 import { SWUProposalSlim } from "shared/lib/resources/proposal/sprint-with-us";
 import { GUIDE_AUDIENCE } from "front-end/lib/pages/guide/view";
-import { SWUTeamQuestionResponseEvaluationSlim } from "shared/lib/resources/question-evaluation/sprint-with-us";
+import { SWUTeamQuestionResponseEvaluation } from "shared/lib/resources/question-evaluation/sprint-with-us";
 
 // Parent page types & functions.
 
@@ -53,7 +53,7 @@ export type TabPermissions = {
 export type InitResponse = [
   SWUOpportunity,
   SWUProposalSlim[],
-  SWUTeamQuestionResponseEvaluationSlim[]
+  SWUTeamQuestionResponseEvaluation[]
 ];
 
 export type Component<State, Msg> = TabbedPage.TabComponent<

--- a/src/front-end/typescript/lib/pages/opportunity/sprint-with-us/edit/tab/overview.tsx
+++ b/src/front-end/typescript/lib/pages/opportunity/sprint-with-us/edit/tab/overview.tsx
@@ -1,0 +1,427 @@
+import { EMPTY_STRING } from "front-end/config";
+import { Route } from "front-end/lib/app/types";
+import * as Table from "front-end/lib/components/table";
+import {
+  Immutable,
+  immutable,
+  component as component_
+} from "front-end/lib/framework";
+import * as api from "front-end/lib/http/api";
+import * as Tab from "front-end/lib/pages/opportunity/sprint-with-us/edit/tab";
+import * as toasts from "front-end/lib/pages/opportunity/sprint-with-us/lib/toasts";
+import EditTabHeader from "front-end/lib/pages/opportunity/sprint-with-us/lib/views/edit-tab-header";
+import Link, { routeDest } from "front-end/lib/views/link";
+import ReportCardList, {
+  ReportCard
+} from "front-end/lib/views/report-card-list";
+import React from "react";
+import { Col, Row } from "reactstrap";
+import {
+  canViewSWUOpportunityTeamQuestionResponseEvaluations,
+  isSWUOpportunityAcceptingProposals,
+  SWUOpportunity,
+  SWUOpportunityStatus
+} from "shared/lib/resources/opportunity/sprint-with-us";
+import {
+  compareSWUProposalAnonymousProponentNumber,
+  getSWUProponentName,
+  NUM_SCORE_DECIMALS,
+  SWUProposalSlim,
+  UpdateValidationErrors
+} from "shared/lib/resources/proposal/sprint-with-us";
+import {
+  SWUTeamQuestionResponseEvaluation,
+  SWUTeamQuestionResponseEvaluationSlim,
+  canSWUTeamQuestionResponseEvaluationBeSubmitted
+} from "shared/lib/resources/question-evaluation/sprint-with-us";
+import { ADT, adt } from "shared/lib/types";
+
+export interface State extends Tab.Params {
+  opportunity: SWUOpportunity | null;
+  submitLoading: boolean;
+  canEvaluationsBeSubmitted: boolean;
+  canViewEvaluations: boolean;
+  evaluations: SWUTeamQuestionResponseEvaluationSlim[];
+  proposals: SWUProposalSlim[];
+  table: Immutable<Table.State>;
+}
+
+export type InnerMsg =
+  | ADT<"onInitResponse", Tab.InitResponse>
+  | ADT<"table", Table.Msg>
+  | ADT<"submit">
+  | ADT<
+      "onSubmitResponse",
+      api.ResponseValidation<
+        SWUTeamQuestionResponseEvaluationSlim,
+        UpdateValidationErrors
+      >[]
+    >;
+
+export type Msg = component_.page.Msg<InnerMsg, Route>;
+
+const init: component_.base.Init<Tab.Params, State, Msg> = (params) => {
+  const [tableState, tableCmds] = Table.init({
+    idNamespace: "evaluations-table"
+  });
+  return [
+    {
+      ...params,
+      opportunity: null,
+      submitLoading: false,
+      canViewEvaluations: false,
+      canEvaluationsBeSubmitted: false,
+      evaluations: [],
+      proposals: [],
+      table: immutable(tableState)
+    },
+    component_.cmd.mapMany(tableCmds, (msg) => adt("table", msg) as Msg)
+  ];
+};
+
+const update: component_.page.Update<State, InnerMsg, Route> = ({
+  state,
+  msg
+}) => {
+  switch (msg.tag) {
+    case "onInitResponse": {
+      const opportunity = msg.value[0];
+      const proposals = msg.value[1].sort((a, b) =>
+        compareSWUProposalAnonymousProponentNumber(a, b)
+      );
+      const evaluations = msg.value[2];
+      const canViewEvaluations =
+        canViewSWUOpportunityTeamQuestionResponseEvaluations(opportunity);
+      return [
+        state
+          .set("opportunity", opportunity)
+          .set("evaluations", evaluations)
+          .set("proposals", proposals)
+          .set("canViewEvaluations", canViewEvaluations)
+          // Determine whether the "Submit" button should be shown at all.
+          // Can be submitted if...
+          // - Opportunity has the appropriate status; and
+          // - All questions have been evaluated.
+          .set(
+            "canEvaluationsBeSubmitted",
+            opportunity.status ===
+              SWUOpportunityStatus.EvaluationTeamQuestionsPanel &&
+              evaluations.reduce(
+                (acc, e) =>
+                  acc ||
+                  canSWUTeamQuestionResponseEvaluationBeSubmitted(
+                    e,
+                    opportunity
+                  ),
+                false as boolean
+              )
+          ),
+        [component_.cmd.dispatch(component_.page.readyMsg())]
+      ];
+    }
+
+    case "submit": {
+      const opportunity = state.opportunity;
+      if (!opportunity) return [state, []];
+      return [
+        state.set("submitLoading", true),
+        [
+          component_.cmd.map(
+            component_.cmd.sequence(
+              state.evaluations.map(({ id }) =>
+                api.evaluations.swu.update<
+                  api.ResponseValidation<
+                    SWUTeamQuestionResponseEvaluation,
+                    UpdateValidationErrors
+                  >
+                >()(id, adt("submit", ""), (response) => response)
+              )
+            ),
+            (evaluationResponses) =>
+              adt("onSubmitResponse", evaluationResponses)
+          )
+        ]
+      ];
+    }
+
+    case "onSubmitResponse": {
+      const opportunity = state.opportunity;
+      if (!opportunity) return [state, []];
+      state = state.set("submitLoading", false);
+      const result = msg.value;
+      if (result.some((e) => e.tag === "valid" || e.tag === "unhandled")) {
+        return [
+          state,
+          [
+            component_.cmd.dispatch(
+              component_.global.showToastMsg(
+                adt(
+                  "error",
+                  toasts.statusChanged.error(SWUOpportunityStatus.Awarded)
+                )
+              )
+            )
+          ]
+        ];
+      }
+      return [
+        state,
+        [
+          component_.cmd.dispatch(
+            component_.global.showToastMsg(
+              adt(
+                "success",
+                toasts.statusChanged.success(SWUOpportunityStatus.Awarded)
+              )
+            )
+          ),
+          component_.cmd.join3(
+            api.opportunities.swu.readOne()(opportunity.id, (response) =>
+              api.getValidValue(response, opportunity)
+            ),
+            api.proposals.swu.readMany(opportunity.id)((response) =>
+              api.getValidValue(response, state.proposals)
+            ),
+            api.evaluations.swu.readMany(opportunity.id)((response) =>
+              api.getValidValue(response, state.evaluations)
+            ),
+            (newOpp, newProposals, newEvaluations) =>
+              adt("onInitResponse", [
+                newOpp,
+                newProposals,
+                newEvaluations
+              ]) as Msg
+          )
+        ]
+      ];
+    }
+
+    case "table":
+      return component_.base.updateChild({
+        state,
+        childStatePath: ["table"],
+        childUpdate: Table.update,
+        childMsg: msg.value,
+        mapChildMsg: (value) => ({ tag: "table", value })
+      });
+
+    default:
+      return [state, []];
+  }
+};
+
+const NotAvailable: component_.base.ComponentView<State, Msg> = ({ state }) => {
+  const opportunity = state.opportunity;
+  if (!opportunity) return null;
+  if (isSWUOpportunityAcceptingProposals(opportunity)) {
+    return (
+      <div>
+        Evaluations will be displayed here once this opportunity has closed.
+      </div>
+    );
+  } else {
+    return <div>No proposals were submitted to this opportunity.</div>;
+  }
+};
+
+interface ProponentCellProps {
+  proposal: SWUProposalSlim;
+  opportunity: SWUOpportunity;
+  disabled: boolean;
+}
+
+const ProponentCell: component_.base.View<ProponentCellProps> = ({
+  proposal,
+  opportunity,
+  disabled
+}) => {
+  const proposalRouteParams = {
+    proposalId: proposal.id,
+    opportunityId: opportunity.id,
+    tab: "proposal" as const
+  };
+  return (
+    <div>
+      <Link
+        disabled={disabled}
+        dest={routeDest(adt("proposalSWUView", proposalRouteParams))}>
+        {getSWUProponentName(proposal)}
+      </Link>
+      {(() => {
+        if (!proposal.organization) {
+          return null;
+        }
+        return (
+          <div className="small text-secondary text-uppercase">
+            {proposal.anonymousProponentName}
+          </div>
+        );
+      })()}
+    </div>
+  );
+};
+
+function evaluationTableBodyRows(state: Immutable<State>): Table.BodyRows {
+  const opportunity = state.opportunity;
+  if (!opportunity) return [];
+  const issubmitLoading = !!state.submitLoading;
+  const isLoading = issubmitLoading;
+  return state.proposals.map((p) => {
+    return [
+      {
+        className: "text-wrap",
+        children: (
+          <ProponentCell
+            proposal={p}
+            opportunity={opportunity}
+            disabled={isLoading}
+          />
+        )
+      },
+      ...opportunity.teamQuestions.map((tq) => {
+        const evaluation = state.evaluations.find(
+          (e) => e.proposal.id === p.id
+        );
+        const score = evaluation?.scores.find(
+          (s) => tq.order === s.order
+        )?.score;
+        return {
+          className: "text-center",
+          children: (
+            <div>
+              {score ? `${score.toFixed(NUM_SCORE_DECIMALS)}%` : EMPTY_STRING}
+            </div>
+          )
+        };
+      }),
+      {
+        className: "text-center",
+        children: "PLACEHOLDER"
+      }
+    ];
+  });
+}
+
+function evaluationTableHeadCells(state: Immutable<State>): Table.HeadCells {
+  return [
+    {
+      children: "Participant",
+      className: "text-nowrap",
+      style: { width: "100%", minWidth: "200px" }
+    },
+    ...(state.opportunity?.teamQuestions.map((tq) => ({
+      children: `Q${tq.order + 1}`,
+      className: "text-nowrap text-center",
+      style: { width: "0px" }
+    })) ?? []),
+    {
+      children: "Action",
+      className: "text-nowrap text-center",
+      style: { width: "0px" }
+    }
+  ];
+}
+
+const ProponentEvaluations: component_.base.ComponentView<State, Msg> = ({
+  state,
+  dispatch
+}) => {
+  return (
+    <Table.view
+      headCells={evaluationTableHeadCells(state)}
+      bodyRows={evaluationTableBodyRows(state)}
+      state={state.table}
+      dispatch={component_.base.mapDispatch(dispatch, (msg) =>
+        adt("table" as const, msg)
+      )}
+    />
+  );
+};
+
+const makeCardData = (
+  opportunity: SWUOpportunity,
+  proposals: SWUProposalSlim[]
+): ReportCard[] => {
+  const numProposals = opportunity.reporting?.numProposals || 0;
+  const [highestScore, averageScore] = proposals.reduce(
+    ([highest, average], { totalScore }, i) => {
+      if (!totalScore) {
+        return [highest, average];
+      }
+      return [
+        totalScore > highest ? totalScore : highest,
+        (average * i + totalScore) / (i + 1)
+      ];
+    },
+    [0, 0]
+  );
+  const isAwarded = opportunity.status === SWUOpportunityStatus.Awarded;
+  return [
+    {
+      icon: "comment-dollar",
+      name: `Proposal${numProposals === 1 ? "" : "s"}`,
+      value: numProposals ? String(numProposals) : EMPTY_STRING
+    },
+    {
+      icon: "star-full",
+      iconColor: "c-report-card-icon-highlight",
+      name: "Top Score",
+      value:
+        isAwarded && highestScore
+          ? `${highestScore.toFixed(NUM_SCORE_DECIMALS)}%`
+          : EMPTY_STRING
+    },
+    {
+      icon: "star-half",
+      iconColor: "c-report-card-icon-highlight",
+      name: "Avg. Score",
+      value:
+        isAwarded && averageScore
+          ? `${averageScore.toFixed(NUM_SCORE_DECIMALS)}%`
+          : EMPTY_STRING
+    }
+  ];
+};
+
+const view: component_.page.View<State, InnerMsg, Route> = (props) => {
+  const { state } = props;
+  const opportunity = state.opportunity;
+  if (!opportunity) return null;
+  const cardData = makeCardData(opportunity, state.proposals);
+  return (
+    <div>
+      <EditTabHeader opportunity={opportunity} viewerUser={state.viewerUser} />
+      <Row className="mt-5">
+        <Col xs="12">
+          <ReportCardList reportCards={cardData} />
+        </Col>
+      </Row>
+      <div className="border-top mt-5 pt-5">
+        <Row>
+          <Col
+            xs="12"
+            className="d-flex flex-column flex-md-row justify-content-md-between align-items-start align-items-md-center mb-4">
+            <h4 className="mb-0">Overview</h4>
+          </Col>
+          <Col xs="12">
+            {state.canViewEvaluations && state.proposals.length ? (
+              <ProponentEvaluations {...props} />
+            ) : (
+              <NotAvailable {...props} />
+            )}
+          </Col>
+        </Row>
+      </div>
+    </div>
+  );
+};
+
+export const component: Tab.Component<State, Msg> = {
+  init,
+  update,
+  view,
+
+  onInitResponse(response) {
+    return adt("onInitResponse", response);
+  }
+};

--- a/src/front-end/typescript/lib/pages/opportunity/sprint-with-us/edit/tab/overview.tsx
+++ b/src/front-end/typescript/lib/pages/opportunity/sprint-with-us/edit/tab/overview.tsx
@@ -242,7 +242,7 @@ const ContextMenuCell: component_.base.View<{
           evaluationId: evaluation.id
         })
       )}>
-      {evaluation ? "Edit" : "Start Evaluation"}
+      Edit
     </Link>
   ) : (
     <Link
@@ -250,7 +250,7 @@ const ContextMenuCell: component_.base.View<{
       dest={routeDest(
         adt("questionEvaluationIndividualSWUCreate", proposalRouteParams)
       )}>
-      {evaluation ? "Edit" : "Start Evaluation"}
+      Start Evaluation
     </Link>
   );
 };
@@ -311,12 +311,12 @@ function evaluationTableBodyRows(state: Immutable<State>): Table.BodyRows {
         )
       },
       ...opportunity.teamQuestions.map((tq) => {
-        const score = evaluation?.scores[tq.order].score;
+        const score = evaluation?.scores[tq.order]?.score;
         return {
           className: "text-center",
           children: (
             <div>
-              {score ? `${score.toFixed(NUM_SCORE_DECIMALS)}%` : EMPTY_STRING}
+              {score ? `${score.toFixed(NUM_SCORE_DECIMALS)}` : EMPTY_STRING}
             </div>
           )
         };

--- a/src/front-end/typescript/lib/pages/opportunity/sprint-with-us/lib/index.ts
+++ b/src/front-end/typescript/lib/pages/opportunity/sprint-with-us/lib/index.ts
@@ -18,9 +18,7 @@ export function swuOpportunityStatusToColor(
       return "warning";
     case SWUOpportunityStatus.Published:
       return "success";
-    case SWUOpportunityStatus.TeamQuestionsPanelEvaluation:
-      return "warning";
-    case SWUOpportunityStatus.TeamQuestionsPanelConsensus:
+    case SWUOpportunityStatus.EvaluationTeamQuestionsPanel:
       return "warning";
     case SWUOpportunityStatus.EvaluationTeamQuestions:
       return "warning";
@@ -47,10 +45,8 @@ export function swuOpportunityStatusToTitleCase(
       return "Under Review";
     case SWUOpportunityStatus.Published:
       return "Published";
-    case SWUOpportunityStatus.TeamQuestionsPanelEvaluation:
+    case SWUOpportunityStatus.EvaluationTeamQuestionsPanel:
       return "Evaluation";
-    case SWUOpportunityStatus.TeamQuestionsPanelConsensus:
-      return "Consensus";
     case SWUOpportunityStatus.EvaluationTeamQuestions:
       return "Team Questions";
     case SWUOpportunityStatus.EvaluationCodeChallenge:

--- a/src/front-end/typescript/lib/pages/proposal/sprint-with-us/lib/index.ts
+++ b/src/front-end/typescript/lib/pages/proposal/sprint-with-us/lib/index.ts
@@ -18,6 +18,8 @@ export function swuProposalStatusToColor(
     case SWUProposalStatus.UnderReviewTeamQuestions:
     case SWUProposalStatus.UnderReviewCodeChallenge:
     case SWUProposalStatus.UnderReviewTeamScenario:
+    case SWUProposalStatus.TeamQuestionsPanelIndividual:
+    case SWUProposalStatus.TeamQuestionsPanelConsensus:
       return "warning";
     case SWUProposalStatus.EvaluatedTeamQuestions:
     case SWUProposalStatus.EvaluatedCodeChallenge:
@@ -40,6 +42,14 @@ export function swuProposalStatusToTitleCase(
       return "Draft";
     case SWUProposalStatus.Submitted:
       return "Submitted";
+    case SWUProposalStatus.TeamQuestionsPanelIndividual:
+      return viewerUserType === UserType.Vendor
+        ? "Under Review"
+        : "Panel Evaluation (Individual)";
+    case SWUProposalStatus.TeamQuestionsPanelConsensus:
+      return viewerUserType === UserType.Vendor
+        ? "Under Review"
+        : "Panel Evaluation (Consensus)";
     case SWUProposalStatus.UnderReviewTeamQuestions:
       return viewerUserType === UserType.Vendor
         ? "Under Review"

--- a/src/front-end/typescript/lib/pages/proposal/sprint-with-us/lib/toasts.ts
+++ b/src/front-end/typescript/lib/pages/proposal/sprint-with-us/lib/toasts.ts
@@ -57,6 +57,28 @@ export const scored = {
   })
 };
 
+export const questionEvaluationDraftCreated = {
+  success: {
+    title: "Draft Evaluation Saved",
+    body: "Your draft Sprint With Us evaluation has been saved. You can return to this page to modify your proposal prior to submission."
+  },
+  error: {
+    title: "Unable to Save Draft Evaluation",
+    body: "Your draft Sprint With Us evaluation could not be saved. Please try again later."
+  }
+};
+
+export const questionEvaluationChangesSaved = {
+  success: {
+    title: "Evaluation Changes Saved",
+    body: "Your changes to your Sprint With Us evaluation have been saved."
+  },
+  error: {
+    title: "Unable to Save Evaluation",
+    body: "Your changes to your Sprint With Us evaluation could not be saved. Please try again later."
+  }
+};
+
 export const screenedIn = {
   success: {
     title: "Proposal Screened In",

--- a/src/front-end/typescript/lib/pages/proposal/sprint-with-us/lib/toasts.ts
+++ b/src/front-end/typescript/lib/pages/proposal/sprint-with-us/lib/toasts.ts
@@ -60,7 +60,7 @@ export const scored = {
 export const questionEvaluationDraftCreated = {
   success: {
     title: "Draft Evaluation Saved",
-    body: "Your draft Sprint With Us evaluation has been saved. You can return to this page to modify your proposal prior to submission."
+    body: "Your draft Sprint With Us evaluation has been saved. You can return to this page to modify your evaluation prior to submission."
   },
   error: {
     title: "Unable to Save Draft Evaluation",

--- a/src/front-end/typescript/lib/pages/proposal/sprint-with-us/view/index.tsx
+++ b/src/front-end/typescript/lib/pages/proposal/sprint-with-us/view/index.tsx
@@ -49,6 +49,7 @@ export type InnerMsg_<K extends Tab.TabId> = Tab.ParentInnerMsg<
       RouteParams,
       SWUProposal,
       SWUOpportunity,
+      SWUTeamQuestionResponseEvaluation | undefined,
       SWUTeamQuestionResponseEvaluation[]
     ]
   >
@@ -104,6 +105,7 @@ function makeInit<K extends Tab.TabId>(): component_.page.Init<
                 routeParams,
                 proposal,
                 opportunity,
+                undefined,
                 []
               ]) as Msg;
             }
@@ -157,7 +159,8 @@ function makeComponent<K extends Tab.TabId>(): component_.page.Component<
                 routeParams,
                 proposal,
                 opportunity,
-                questionEvaluations
+                questionEvaluation,
+                panelQuestionEvaluations
               ] = msg.value;
               // Set up the visible tab state.
               const tabId = routeParams.tab || "proposal";
@@ -172,7 +175,8 @@ function makeComponent<K extends Tab.TabId>(): component_.page.Component<
                 viewerUser,
                 proposal,
                 opportunity,
-                questionEvaluations
+                questionEvaluation,
+                panelQuestionEvaluations
               });
               // Everything checks out, return valid state.
               return [

--- a/src/front-end/typescript/lib/pages/proposal/sprint-with-us/view/index.tsx
+++ b/src/front-end/typescript/lib/pages/proposal/sprint-with-us/view/index.tsx
@@ -26,9 +26,11 @@ import { UserType, User } from "shared/lib/resources/user";
 import { adt, ADT, Id } from "shared/lib/types";
 import { invalid, valid, Validation } from "shared/lib/validation";
 import { SWUOpportunity } from "shared/lib/resources/opportunity/sprint-with-us";
+import { SWUTeamQuestionResponseEvaluation } from "shared/lib/resources/question-evaluation/sprint-with-us";
 
 interface ValidState<K extends Tab.TabId> extends Tab.ParentState<K> {
   proposal: SWUProposal | null;
+  questionEvaluations: SWUTeamQuestionResponseEvaluation[];
 }
 
 export type State_<K extends Tab.TabId> = Validation<
@@ -40,7 +42,16 @@ export type State = State_<Tab.TabId>;
 
 export type InnerMsg_<K extends Tab.TabId> = Tab.ParentInnerMsg<
   K,
-  ADT<"onInitResponse", [User, RouteParams, SWUProposal, SWUOpportunity]>
+  ADT<
+    "onInitResponse",
+    [
+      User,
+      RouteParams,
+      SWUProposal,
+      SWUOpportunity,
+      SWUTeamQuestionResponseEvaluation[]
+    ]
+  >
 >;
 
 export type InnerMsg = InnerMsg_<Tab.TabId>;
@@ -71,7 +82,8 @@ function makeInit<K extends Tab.TabId>(): component_.page.Init<
           immutable({
             proposal: null,
             tab: null,
-            sidebar: null
+            sidebar: null,
+            questionEvaluations: []
           })
         ) as State_<K>,
         [
@@ -91,7 +103,8 @@ function makeInit<K extends Tab.TabId>(): component_.page.Init<
                 shared.sessionUser,
                 routeParams,
                 proposal,
-                opportunity
+                opportunity,
+                []
               ]) as Msg;
             }
           )
@@ -139,8 +152,13 @@ function makeComponent<K extends Tab.TabId>(): component_.page.Component<
         extraUpdate: ({ state, msg }) => {
           switch (msg.tag) {
             case "onInitResponse": {
-              const [viewerUser, routeParams, proposal, opportunity] =
-                msg.value;
+              const [
+                viewerUser,
+                routeParams,
+                proposal,
+                opportunity,
+                questionEvaluations
+              ] = msg.value;
               // Set up the visible tab state.
               const tabId = routeParams.tab || "proposal";
               // Initialize the sidebar.
@@ -153,7 +171,8 @@ function makeComponent<K extends Tab.TabId>(): component_.page.Component<
               const [tabState, tabCmds] = tabComponent.init({
                 viewerUser,
                 proposal,
-                opportunity
+                opportunity,
+                questionEvaluations
               });
               // Everything checks out, return valid state.
               return [

--- a/src/front-end/typescript/lib/pages/proposal/sprint-with-us/view/index.tsx
+++ b/src/front-end/typescript/lib/pages/proposal/sprint-with-us/view/index.tsx
@@ -27,6 +27,7 @@ import { adt, ADT, Id } from "shared/lib/types";
 import { invalid, valid, Validation } from "shared/lib/validation";
 import { SWUOpportunity } from "shared/lib/resources/opportunity/sprint-with-us";
 import { SWUTeamQuestionResponseEvaluation } from "shared/lib/resources/question-evaluation/sprint-with-us";
+import { getTeamQuestionsOpportunityTab } from "./tab/team-questions";
 
 interface ValidState<K extends Tab.TabId> extends Tab.ParentState<K> {
   proposal: SWUProposal | null;
@@ -49,6 +50,7 @@ export type InnerMsg_<K extends Tab.TabId> = Tab.ParentInnerMsg<
       RouteParams,
       SWUProposal,
       SWUOpportunity,
+      boolean,
       SWUTeamQuestionResponseEvaluation | undefined,
       SWUTeamQuestionResponseEvaluation[]
     ]
@@ -105,6 +107,7 @@ function makeInit<K extends Tab.TabId>(): component_.page.Init<
                 routeParams,
                 proposal,
                 opportunity,
+                false,
                 undefined,
                 []
               ]) as Msg;
@@ -159,6 +162,7 @@ function makeComponent<K extends Tab.TabId>(): component_.page.Component<
                 routeParams,
                 proposal,
                 opportunity,
+                evaluating,
                 questionEvaluation,
                 panelQuestionEvaluations
               ] = msg.value;
@@ -167,7 +171,11 @@ function makeComponent<K extends Tab.TabId>(): component_.page.Component<
               // Initialize the sidebar.
               const [sidebarState, sidebarCmds] = Tab.makeSidebarState(
                 tabId,
-                proposal
+                proposal,
+                getTeamQuestionsOpportunityTab(
+                  evaluating,
+                  panelQuestionEvaluations
+                )
               );
               // Initialize the tab.
               const tabComponent = Tab.idToDefinition(tabId).component;
@@ -175,6 +183,7 @@ function makeComponent<K extends Tab.TabId>(): component_.page.Component<
                 viewerUser,
                 proposal,
                 opportunity,
+                evaluating,
                 questionEvaluation,
                 panelQuestionEvaluations
               });

--- a/src/front-end/typescript/lib/pages/proposal/sprint-with-us/view/tab/index.ts
+++ b/src/front-end/typescript/lib/pages/proposal/sprint-with-us/view/tab/index.ts
@@ -9,6 +9,7 @@ import * as TeamScenarioTab from "front-end/lib/pages/proposal/sprint-with-us/vi
 import { routeDest } from "front-end/lib/views/link";
 import { SWUOpportunity } from "shared/lib/resources/opportunity/sprint-with-us";
 import { SWUProposal } from "shared/lib/resources/proposal/sprint-with-us";
+import { SWUTeamQuestionResponseEvaluation } from "shared/lib/resources/question-evaluation/sprint-with-us";
 import { User } from "shared/lib/resources/user";
 import { adt } from "shared/lib/types";
 
@@ -33,6 +34,7 @@ export interface Params {
   proposal: SWUProposal;
   opportunity: SWUOpportunity;
   viewerUser: User;
+  questionEvaluations: SWUTeamQuestionResponseEvaluation[];
 }
 
 export type InitResponse = null;
@@ -190,4 +192,9 @@ export function makeSidebarState(
       makeSidebarLink("history", proposal, activeTab)
     ]
   });
+}
+
+export function shouldLoadEvaluationsForTab(tabId: TabId): boolean {
+  const evaluationTabs: TabId[] = ["teamQuestions"];
+  return evaluationTabs.includes(tabId);
 }

--- a/src/front-end/typescript/lib/pages/proposal/sprint-with-us/view/tab/index.ts
+++ b/src/front-end/typescript/lib/pages/proposal/sprint-with-us/view/tab/index.ts
@@ -34,6 +34,7 @@ export interface Params {
   proposal: SWUProposal;
   opportunity: SWUOpportunity;
   viewerUser: User;
+  evaluating: boolean;
   questionEvaluation?: SWUTeamQuestionResponseEvaluation;
   panelQuestionEvaluations: SWUTeamQuestionResponseEvaluation[];
 }
@@ -159,7 +160,8 @@ export function makeSidebarLink(
 
 export function makeSidebarState(
   activeTab: TabId,
-  proposal: SWUProposal
+  proposal: SWUProposal,
+  teamQuestionsTab: "consensus" | "overview" | "teamQuestions"
 ): component.base.InitReturnValue<MenuSidebar.State, MenuSidebar.Msg> {
   return MenuSidebar.init({
     backLink: {
@@ -173,7 +175,7 @@ export function makeSidebarState(
             case "teamScenario":
               return "teamScenario" as const;
             case "teamQuestions":
-              return "teamQuestions" as const;
+              return teamQuestionsTab;
             case "proposal":
             case "history":
             default:

--- a/src/front-end/typescript/lib/pages/proposal/sprint-with-us/view/tab/index.ts
+++ b/src/front-end/typescript/lib/pages/proposal/sprint-with-us/view/tab/index.ts
@@ -9,7 +9,6 @@ import * as TeamScenarioTab from "front-end/lib/pages/proposal/sprint-with-us/vi
 import { routeDest } from "front-end/lib/views/link";
 import { SWUOpportunity } from "shared/lib/resources/opportunity/sprint-with-us";
 import { SWUProposal } from "shared/lib/resources/proposal/sprint-with-us";
-import { SWUTeamQuestionResponseEvaluation } from "shared/lib/resources/question-evaluation/sprint-with-us";
 import { User } from "shared/lib/resources/user";
 import { adt } from "shared/lib/types";
 
@@ -34,8 +33,6 @@ export interface Params {
   proposal: SWUProposal;
   opportunity: SWUOpportunity;
   viewerUser: User;
-  questionEvaluations: SWUTeamQuestionResponseEvaluation[];
-  questionEvaluationMode?: "create" | "edit";
 }
 
 export type InitResponse = null;

--- a/src/front-end/typescript/lib/pages/proposal/sprint-with-us/view/tab/index.ts
+++ b/src/front-end/typescript/lib/pages/proposal/sprint-with-us/view/tab/index.ts
@@ -9,6 +9,7 @@ import * as TeamScenarioTab from "front-end/lib/pages/proposal/sprint-with-us/vi
 import { routeDest } from "front-end/lib/views/link";
 import { SWUOpportunity } from "shared/lib/resources/opportunity/sprint-with-us";
 import { SWUProposal } from "shared/lib/resources/proposal/sprint-with-us";
+import { SWUTeamQuestionResponseEvaluation } from "shared/lib/resources/question-evaluation/sprint-with-us";
 import { User } from "shared/lib/resources/user";
 import { adt } from "shared/lib/types";
 
@@ -33,6 +34,8 @@ export interface Params {
   proposal: SWUProposal;
   opportunity: SWUOpportunity;
   viewerUser: User;
+  questionEvaluations: SWUTeamQuestionResponseEvaluation[];
+  questionEvaluationMode?: "create" | "edit";
 }
 
 export type InitResponse = null;

--- a/src/front-end/typescript/lib/pages/proposal/sprint-with-us/view/tab/index.ts
+++ b/src/front-end/typescript/lib/pages/proposal/sprint-with-us/view/tab/index.ts
@@ -34,7 +34,8 @@ export interface Params {
   proposal: SWUProposal;
   opportunity: SWUOpportunity;
   viewerUser: User;
-  questionEvaluations: SWUTeamQuestionResponseEvaluation[];
+  questionEvaluation?: SWUTeamQuestionResponseEvaluation;
+  panelQuestionEvaluations: SWUTeamQuestionResponseEvaluation[];
 }
 
 export type InitResponse = null;

--- a/src/front-end/typescript/lib/pages/proposal/sprint-with-us/view/tab/proposal.tsx
+++ b/src/front-end/typescript/lib/pages/proposal/sprint-with-us/view/tab/proposal.tsx
@@ -518,6 +518,8 @@ export const component: Tab.Component<State, Msg> = {
             onClick: () => dispatch(adt("showModal", "award" as const))
           }
         ]);
+      case SWUProposalStatus.TeamQuestionsPanelIndividual:
+      case SWUProposalStatus.TeamQuestionsPanelConsensus:
       case SWUProposalStatus.Draft:
       case SWUProposalStatus.Submitted:
       case SWUProposalStatus.Withdrawn:

--- a/src/front-end/typescript/lib/pages/proposal/sprint-with-us/view/tab/team-questions.tsx
+++ b/src/front-end/typescript/lib/pages/proposal/sprint-with-us/view/tab/team-questions.tsx
@@ -1,58 +1,71 @@
 import { EMPTY_STRING } from "front-end/config";
-import { makeStartLoading, makeStopLoading } from "front-end/lib";
+// import { makeStartLoading, makeStopLoading } from "front-end/lib";
 import { Route } from "front-end/lib/app/types";
-import * as FormField from "front-end/lib/components/form-field";
+// import * as FormField from "front-end/lib/components/form-field";
 import * as NumberField from "front-end/lib/components/form-field/number";
+import * as LongText from "front-end/lib/components/form-field/long-text";
 import {
   Immutable,
   immutable,
   component as component_
 } from "front-end/lib/framework";
 import * as api from "front-end/lib/http/api";
-import * as toasts from "front-end/lib/pages/proposal/sprint-with-us/lib/toasts";
 import ViewTabHeader from "front-end/lib/pages/proposal/sprint-with-us/lib/views/view-tab-header";
 import * as Tab from "front-end/lib/pages/proposal/sprint-with-us/view/tab";
 import Accordion from "front-end/lib/views/accordion";
-import { iconLinkSymbol, leftPlacement } from "front-end/lib/views/link";
+// import { iconLinkSymbol, leftPlacement } from "front-end/lib/views/link";
 import { ProposalMarkdown } from "front-end/lib/views/markdown";
 import ReportCardList from "front-end/lib/views/report-card-list";
 import Separator from "front-end/lib/views/separator";
 import React from "react";
 import { Alert, Col, Row } from "reactstrap";
-import { countWords } from "shared/lib";
+import { compareNumbers, countWords } from "shared/lib";
 import {
-  canSWUOpportunityBeScreenedInToCodeChallenge,
+  // canSWUOpportunityBeScreenedInToCodeChallenge,
   getQuestionByOrder,
-  hasSWUOpportunityPassedCodeChallenge,
+  // hasSWUOpportunityPassedCodeChallenge,
   hasSWUOpportunityPassedTeamQuestions,
-  SWUOpportunity
+  hasSWUOpportunityPassedTeamQuestionsEvaluation,
+  SWUEvaluationPanelMember,
+  SWUOpportunity,
+  SWUOpportunityStatus,
+  SWUTeamQuestion
 } from "shared/lib/resources/opportunity/sprint-with-us";
 import {
   NUM_SCORE_DECIMALS,
   SWUProposal,
-  SWUProposalStatus,
+  // SWUProposalStatus,
   SWUProposalTeamQuestionResponse,
-  UpdateTeamQuestionScoreBody,
   UpdateValidationErrors
 } from "shared/lib/resources/proposal/sprint-with-us";
+import {
+  getEvaluationById,
+  getEvaluationScoreByOrder,
+  SWUTeamQuestionResponseEvaluation,
+  SWUTeamQuestionResponseEvaluationScores
+} from "shared/lib/resources/question-evaluation/sprint-with-us";
 import { adt, ADT } from "shared/lib/types";
 import { invalid } from "shared/lib/validation";
-import { validateTeamQuestionScoreScore } from "shared/lib/validation/proposal/sprint-with-us";
+import {
+  validateSWUTeamQuestionResponseEvaluationScoreNotes,
+  validateSWUTeamQuestionResponseEvaluationScoreScore
+} from "shared/lib/validation/question-evaluation/sprint-with-us";
 
-type ModalId = "enterScore";
+interface EvaluationScore {
+  score: Immutable<NumberField.State>;
+  notes: Immutable<LongText.State>;
+}
 
 export interface State extends Tab.Params {
-  showModal: ModalId | null;
   enterScoreLoading: number;
   screenToFromLoading: number;
   openAccordions: Set<number>;
-  scores: Array<Immutable<NumberField.State>>;
+  individualEvaluationScores: EvaluationScore[][];
+  consensusEvaluationScores: EvaluationScore[];
 }
 
 export type InnerMsg =
   | ADT<"toggleAccordion", number>
-  | ADT<"showModal", ModalId>
-  | ADT<"hideModal">
   | ADT<"submitScore">
   | ADT<
       "onSubmitScoreResponse",
@@ -62,50 +75,206 @@ export type InnerMsg =
   | ADT<"onScreenInResponse", SWUProposal | null>
   | ADT<"screenOut">
   | ADT<"onScreenOutResponse", SWUProposal | null>
-  | ADT<"scoreMsg", [number, NumberField.Msg]>; //[index, msg]
+  | ADT<
+      "scoreMsgIndividual",
+      { childMsg: NumberField.Msg; rIndex: number; eIndex: number }
+    >
+  | ADT<
+      "notesMsgIndividual",
+      { childMsg: LongText.Msg; rIndex: number; eIndex: number }
+    >
+  | ADT<"scoreMsgConsensus", { childMsg: NumberField.Msg; rIndex: number }>
+  | ADT<"notesMsgConsensus", { childMsg: LongText.Msg; rIndex: number }>;
 
 export type Msg = component_.page.Msg<InnerMsg, Route>;
 
-function initScores(
+const initScore = (
+  score: SWUTeamQuestionResponseEvaluationScores,
+  question: SWUTeamQuestion | null,
+  order: number,
+  rIndex: number
+): [
+  EvaluationScore,
+  [ReturnType<typeof NumberField.init>[1], ReturnType<typeof LongText.init>[1]]
+] => {
+  const [scoreState, scoreCmds] = NumberField.init({
+    errors: [],
+    validate: (v) => {
+      if (v === null) {
+        return invalid(["Please enter a valid score."]);
+      }
+      return validateSWUTeamQuestionResponseEvaluationScoreScore(
+        v,
+        question?.score || 0
+      );
+    },
+    child: {
+      step: 0.01,
+      value:
+        score.score === null || score.score === undefined ? null : score.score,
+      id: `swu-proposal-question-score-${order}-${rIndex}`
+    }
+  });
+  const [notesState, notesCmds] = LongText.init({
+    errors: [],
+    validate: validateSWUTeamQuestionResponseEvaluationScoreNotes,
+    child: {
+      value: score?.notes ?? "",
+      id: `swu-proposal-question-notes-${order}-${rIndex}`
+    }
+  });
+
+  return [
+    {
+      score: immutable(scoreState),
+      notes: immutable(notesState)
+    },
+    [scoreCmds, notesCmds]
+  ];
+};
+
+function initIndividualScores(
   opp: SWUOpportunity,
-  prop: SWUProposal
-): [Immutable<NumberField.State>[], component_.Cmd<Msg>[]] {
+  prop: SWUProposal,
+  evaluators: SWUEvaluationPanelMember[],
+  evaluations: SWUTeamQuestionResponseEvaluation[]
+): [EvaluationScore[][], component_.Cmd<Msg>[]] {
   return (prop.teamQuestionResponses || []).reduce(
-    ([states, cmds], r, i) => {
+    ([states, cmds], r, rIndex) => {
+      // Gets the opp by response order
       const question = getQuestionByOrder(opp, r.order);
-      const [state, cmd] = NumberField.init({
-        errors: [],
-        validate: (v) => {
-          if (v === null) {
-            return invalid(["Please enter a valid score."]);
+
+      const [questionScoreStates, questionScoreCmds] = evaluators.reduce<
+        component_.base.InitReturnValue<EvaluationScore[], Msg>
+      >(
+        ([scoreStates, scoreCmds], epm, eIndex) => {
+          const evaluation = getEvaluationById(evaluations, epm.user.id);
+          if (!evaluation) {
+            return [scoreStates, scoreCmds];
           }
-          return validateTeamQuestionScoreScore(v, question?.score || 0);
+          const score = getEvaluationScoreByOrder(evaluation, r.order);
+          if (!score) {
+            return [scoreStates, scoreCmds];
+          }
+
+          const [scoreState, [scoreScoreCmds, scoreNotesCmds]] = initScore(
+            score,
+            question,
+            epm.order,
+            rIndex
+          );
+
+          return [
+            [...scoreStates, scoreState],
+            [
+              ...scoreCmds,
+              ...[
+                ...component_.cmd.mapMany(
+                  scoreScoreCmds,
+                  (childMsg) =>
+                    adt("scoreMsgIndividual", {
+                      rIndex,
+                      eIndex,
+                      childMsg
+                    }) as Msg
+                ),
+                ...component_.cmd.mapMany(
+                  scoreNotesCmds,
+                  (childMsg) =>
+                    adt("notesMsgIndividual", {
+                      rIndex,
+                      eIndex,
+                      childMsg
+                    }) as Msg
+                )
+              ]
+            ]
+          ];
         },
-        child: {
-          step: 0.01,
-          value: r.score === null || r.score === undefined ? null : r.score,
-          id: `swu-proposal-question-score-${i}`
-        }
-      });
+        [[], []]
+      );
+
       return [
-        [...states, immutable(state)],
+        [...states, questionScoreStates],
+        [...cmds, ...questionScoreCmds]
+      ];
+    },
+    [[], []] as [EvaluationScore[][], component_.Cmd<Msg>[]]
+  );
+}
+
+function initConsensusScores(
+  opp: SWUOpportunity,
+  prop: SWUProposal,
+  chair: SWUEvaluationPanelMember,
+  evaluations: SWUTeamQuestionResponseEvaluation[]
+): [EvaluationScore[], component_.Cmd<Msg>[]] {
+  return (prop.teamQuestionResponses || []).reduce<
+    [EvaluationScore[], component_.Cmd<Msg>[]]
+  >(
+    ([states, cmds], r, rIndex) => {
+      const question = getQuestionByOrder(opp, r.order);
+
+      const evaluation = getEvaluationById(evaluations, chair.user.id);
+      if (!evaluation) {
+        return [states, cmds];
+      }
+      const score = getEvaluationScoreByOrder(evaluation, r.order);
+      if (!score) {
+        return [states, cmds];
+      }
+
+      const [scoreState, [scoreScoreCmds, scoreNotesCmds]] = initScore(
+        score,
+        question,
+        chair.order,
+        rIndex
+      );
+
+      return [
+        [...states, scoreState],
         [
           ...cmds,
           ...component_.cmd.mapMany(
-            cmd,
-            (msg) => adt("scoreMsg", [i, msg]) as Msg
+            scoreScoreCmds,
+            (childMsg) =>
+              adt("scoreMsgConsensus", {
+                rIndex,
+                childMsg
+              }) as Msg
+          ),
+          ...component_.cmd.mapMany(
+            scoreNotesCmds,
+            (childMsg) =>
+              adt("notesMsgConsensus", {
+                rIndex,
+                childMsg
+              }) as Msg
           )
         ]
       ];
     },
-    [[], []] as [Immutable<NumberField.State>[], component_.Cmd<Msg>[]]
+    [[], []]
   );
 }
 
-const init: component_.base.Init<Tab.Params, State, Msg> = (params) => {
-  const [scoreStates, scoreCmds] = initScores(
+export const init: component_.base.Init<Tab.Params, State, Msg> = (params) => {
+  const sortedEvaluators =
+    params.opportunity.evaluationPanel?.sort((a, b) =>
+      compareNumbers(a.order, b.order)
+    ) ?? [];
+  const chair = sortedEvaluators.filter((epm) => epm.chair)[0];
+  const [individualScoreStates, individualScoreCmds] = initIndividualScores(
     params.opportunity,
-    params.proposal
+    params.proposal,
+    sortedEvaluators.filter((epm) => epm.evaluator),
+    params.questionEvaluations
+  );
+  const [consensusScoreStates, consensusScoreCmds] = initConsensusScores(
+    params.opportunity,
+    params.proposal,
+    chair,
+    params.questionEvaluations
   );
   return [
     {
@@ -116,16 +285,17 @@ const init: component_.base.Init<Tab.Params, State, Msg> = (params) => {
       openAccordions: new Set(
         params.proposal.teamQuestionResponses.map((p, i) => i)
       ),
-      scores: scoreStates
+      individualEvaluationScores: individualScoreStates,
+      consensusEvaluationScores: consensusScoreStates
     },
-    scoreCmds
+    [...individualScoreCmds, ...consensusScoreCmds]
   ];
 };
 
-const startScreenToFromLoading = makeStartLoading<State>("screenToFromLoading");
-const stopScreenToFromLoading = makeStopLoading<State>("screenToFromLoading");
-const startEnterScoreLoading = makeStartLoading<State>("enterScoreLoading");
-const stopEnterScoreLoading = makeStopLoading<State>("enterScoreLoading");
+// const startScreenToFromLoading = makeStartLoading<State>("screenToFromLoading");
+// const stopScreenToFromLoading = makeStopLoading<State>("screenToFromLoading");
+// const startEnterScoreLoading = makeStartLoading<State>("enterScoreLoading");
+// const stopEnterScoreLoading = makeStopLoading<State>("enterScoreLoading");
 
 const update: component_.base.Update<State, Msg> = ({ state, msg }) => {
   switch (msg.tag) {
@@ -141,191 +311,244 @@ const update: component_.base.Update<State, Msg> = ({ state, msg }) => {
         }),
         []
       ];
-    case "showModal":
-      return [state.set("showModal", msg.value), []];
-    case "hideModal":
-      if (state.enterScoreLoading > 0) {
-        return [state, []];
-      }
-      return [state.set("showModal", null), []];
-    case "submitScore": {
-      const scores = state.proposal.teamQuestionResponses.reduce(
-        (acc, r, i) => {
-          if (!acc) {
-            return null;
-          }
-          const field = state.scores[i];
-          if (!field) {
-            return null;
-          }
-          const score = FormField.getValue(field);
-          if (score === null) {
-            return null;
-          }
-          acc.push({
-            order: r.order,
-            score
-          });
-          return acc;
-        },
-        [] as UpdateTeamQuestionScoreBody[] | null
-      );
-      if (scores === null) {
-        return [state, []];
-      }
-      return [
-        startEnterScoreLoading(state),
-        [
-          api.proposals.swu.update<Msg>()(
-            state.proposal.id,
-            adt("scoreQuestions", scores),
-            (response) => adt("onSubmitScoreResponse", response)
-          )
-        ]
-      ];
-    }
-    case "onSubmitScoreResponse": {
-      state = stopEnterScoreLoading(state);
-      const result = msg.value;
-      switch (result.tag) {
-        case "valid": {
-          const [scoreStates, scoreCmds] = initScores(
-            state.opportunity,
-            result.value
-          );
-          return [
-            state
-              .set("scores", scoreStates)
-              .set("showModal", null)
-              .set("proposal", result.value),
-            [
-              ...scoreCmds,
-              component_.cmd.dispatch(
-                component_.global.showToastMsg(
-                  adt("success", toasts.scored.success("Team Questions"))
-                )
-              )
-            ]
-          ];
-        }
-        case "invalid": {
-          let scores = state.scores;
-          if (
-            result.value.proposal &&
-            result.value.proposal.tag === "scoreQuestions"
-          ) {
-            scores = result.value.proposal.value.map((e, i) =>
-              FormField.setErrors(scores[i], e.score || [])
-            );
-          }
-          return [
-            state.set("scores", scores),
-            [
-              component_.cmd.dispatch(
-                component_.global.showToastMsg(
-                  adt("error", toasts.scored.error("Team Questions"))
-                )
-              )
-            ]
-          ];
-        }
-        case "unhandled":
-        default:
-          return [
-            state,
-            [
-              component_.cmd.dispatch(
-                component_.global.showToastMsg(
-                  adt("error", toasts.scored.error("Team Questions"))
-                )
-              )
-            ]
-          ];
-      }
-    }
-    case "screenIn":
-      return [
-        startScreenToFromLoading(state).set("showModal", null),
-        [
-          api.proposals.swu.update<Msg>()(
-            state.proposal.id,
-            adt("screenInToCodeChallenge", ""),
-            (response) =>
-              adt(
-                "onScreenInResponse",
-                api.isValid(response) ? response.value : null
-              )
-          )
-        ]
-      ];
-    case "onScreenInResponse": {
-      state = stopScreenToFromLoading(state);
-      const proposal = msg.value;
-      if (proposal) {
-        const [scoreStates, scoreCmds] = initScores(
-          state.opportunity,
-          proposal
-        );
-        return [
-          state.set("scores", scoreStates).set("proposal", proposal),
-          [
-            ...scoreCmds,
-            component_.cmd.dispatch(
-              component_.global.showToastMsg(
-                adt("success", toasts.screenedIn.success)
-              )
-            )
-          ]
-        ];
-      } else {
-        return [state, []];
-      }
-    }
-    case "screenOut":
-      return [
-        startScreenToFromLoading(state).set("showModal", null),
-        [
-          api.proposals.swu.update<Msg>()(
-            state.proposal.id,
-            adt("screenOutFromCodeChallenge", ""),
-            (response) =>
-              adt(
-                "onScreenOutResponse",
-                api.isValid(response) ? response.value : null
-              )
-          )
-        ]
-      ];
-    case "onScreenOutResponse": {
-      state = stopScreenToFromLoading(state);
-      const proposal = msg.value;
-      if (proposal) {
-        const [scoreStates, scoreCmds] = initScores(
-          state.opportunity,
-          proposal
-        );
-        return [
-          state.set("scores", scoreStates).set("proposal", proposal),
-          [
-            ...scoreCmds,
-            component_.cmd.dispatch(
-              component_.global.showToastMsg(
-                adt("success", toasts.screenedOut.success)
-              )
-            )
-          ]
-        ];
-      } else {
-        return [state, []];
-      }
-    }
-    case "scoreMsg":
+    // case "submitScore": {
+    //   const scores = state.proposal.teamQuestionResponses.reduce(
+    //     (acc, r, i) => {
+    //       if (!acc) {
+    //         return null;
+    //       }
+    //       const field = state.scores[i];
+    //       if (!field) {
+    //         return null;
+    //       }
+    //       const score = FormField.getValue(field);
+    //       if (score === null) {
+    //         return null;
+    //       }
+    //       acc.push({
+    //         order: r.order,
+    //         score
+    //       });
+    //       return acc;
+    //     },
+    //     [] as UpdateTeamQuestionScoreBody[] | null
+    //   );
+    //   if (scores === null) {
+    //     return [state, []];
+    //   }
+    //   return [
+    //     startEnterScoreLoading(state),
+    //     [
+    //       api.proposals.swu.update<Msg>()(
+    //         state.proposal.id,
+    //         adt("scoreQuestions", scores),
+    //         (response) => adt("onSubmitScoreResponse", response)
+    //       )
+    //     ]
+    //   ];
+    // }
+    // case "onSubmitScoreResponse": {
+    //   state = stopEnterScoreLoading(state);
+    //   const result = msg.value;
+    //   switch (result.tag) {
+    //     case "valid": {
+    //       const [scoreStates, scoreCmds] = initScores(
+    //         state.opportunity,
+    //         result.value
+    //       );
+    //       return [
+    //         state
+    //           .set("scores", scoreStates)
+    //           .set("showModal", null)
+    //           .set("proposal", result.value),
+    //         [
+    //           ...scoreCmds,
+    //           component_.cmd.dispatch(
+    //             component_.global.showToastMsg(
+    //               adt("success", toasts.scored.success("Team Questions"))
+    //             )
+    //           )
+    //         ]
+    //       ];
+    //     }
+    //     case "invalid": {
+    //       let scores = state.scores;
+    //       if (
+    //         result.value.proposal &&
+    //         result.value.proposal.tag === "scoreQuestions"
+    //       ) {
+    //         scores = result.value.proposal.value.map((e, i) =>
+    //           FormField.setErrors(scores[i], e.score || [])
+    //         );
+    //       }
+    //       return [
+    //         state.set("scores", scores),
+    //         [
+    //           component_.cmd.dispatch(
+    //             component_.global.showToastMsg(
+    //               adt("error", toasts.scored.error("Team Questions"))
+    //             )
+    //           )
+    //         ]
+    //       ];
+    //     }
+    //     case "unhandled":
+    //     default:
+    //       return [
+    //         state,
+    //         [
+    //           component_.cmd.dispatch(
+    //             component_.global.showToastMsg(
+    //               adt("error", toasts.scored.error("Team Questions"))
+    //             )
+    //           )
+    //         ]
+    //       ];
+    //   }
+    // }
+    // case "screenIn":
+    //   return [
+    //     startScreenToFromLoading(state).set("showModal", null),
+    //     [
+    //       api.proposals.swu.update<Msg>()(
+    //         state.proposal.id,
+    //         adt("screenInToCodeChallenge", ""),
+    //         (response) =>
+    //           adt(
+    //             "onScreenInResponse",
+    //             api.isValid(response) ? response.value : null
+    //           )
+    //       )
+    //     ]
+    //   ];
+    // case "onScreenInResponse": {
+    //   state = stopScreenToFromLoading(state);
+    //   const proposal = msg.value;
+    //   if (proposal) {
+    //     const [scoreStates, scoreCmds] = initScores(
+    //       state.opportunity,
+    //       proposal
+    //     );
+    //     return [
+    //       state.set("scores", scoreStates).set("proposal", proposal),
+    //       [
+    //         ...scoreCmds,
+    //         component_.cmd.dispatch(
+    //           component_.global.showToastMsg(
+    //             adt("success", toasts.screenedIn.success)
+    //           )
+    //         )
+    //       ]
+    //     ];
+    //   } else {
+    //     return [state, []];
+    //   }
+    // }
+    // case "screenOut":
+    //   return [
+    //     startScreenToFromLoading(state).set("showModal", null),
+    //     [
+    //       api.proposals.swu.update<Msg>()(
+    //         state.proposal.id,
+    //         adt("screenOutFromCodeChallenge", ""),
+    //         (response) =>
+    //           adt(
+    //             "onScreenOutResponse",
+    //             api.isValid(response) ? response.value : null
+    //           )
+    //       )
+    //     ]
+    //   ];
+    // case "onScreenOutResponse": {
+    //   state = stopScreenToFromLoading(state);
+    //   const proposal = msg.value;
+    //   if (proposal) {
+    //     const [scoreStates, scoreCmds] = initScores(
+    //       state.opportunity,
+    //       proposal
+    //     );
+    //     return [
+    //       state.set("scores", scoreStates).set("proposal", proposal),
+    //       [
+    //         ...scoreCmds,
+    //         component_.cmd.dispatch(
+    //           component_.global.showToastMsg(
+    //             adt("success", toasts.screenedOut.success)
+    //           )
+    //         )
+    //       ]
+    //     ];
+    //   } else {
+    //     return [state, []];
+    //   }
+    // }
+    case "scoreMsgIndividual":
       return component_.base.updateChild({
         state,
-        childStatePath: ["scores", String(msg.value[0])],
+        childStatePath: [
+          "individualEvaluationScores",
+          String(msg.value.rIndex),
+          String(msg.value.eIndex),
+          "score"
+        ],
         childUpdate: NumberField.update,
-        childMsg: msg.value[1],
-        mapChildMsg: (value) => adt("scoreMsg", [msg.value[0], value]) as Msg
+        childMsg: msg.value.childMsg,
+        mapChildMsg: (value) =>
+          adt("scoreMsgIndividual", {
+            rIndex: msg.value.rIndex,
+            eIndex: msg.value.eIndex,
+            childMsg: value
+          }) as Msg
+      });
+    case "notesMsgIndividual":
+      return component_.base.updateChild({
+        state,
+        childStatePath: [
+          "individualEvaluationScores",
+          String(msg.value.rIndex),
+          String(msg.value.eIndex),
+          "notes"
+        ],
+        childUpdate: LongText.update,
+        childMsg: msg.value.childMsg,
+        mapChildMsg: (value) =>
+          adt("notesMsgIndividual", {
+            rIndex: msg.value.rIndex,
+            eIndex: msg.value.eIndex,
+            childMsg: value
+          }) as Msg
+      });
+    case "scoreMsgConsensus":
+      return component_.base.updateChild({
+        state,
+        childStatePath: [
+          "consensusEvaluationScores",
+          String(msg.value.rIndex),
+          "score"
+        ],
+        childUpdate: NumberField.update,
+        childMsg: msg.value.childMsg,
+        mapChildMsg: (value) =>
+          adt("scoreMsgConsensus", {
+            rIndex: msg.value.rIndex,
+            childMsg: value
+          }) as Msg
+      });
+    case "notesMsgConsensus":
+      return component_.base.updateChild({
+        state,
+        childStatePath: [
+          "consensusEvaluationScores",
+          String(msg.value.rIndex),
+          "notes"
+        ],
+        childUpdate: LongText.update,
+        childMsg: msg.value.childMsg,
+        mapChildMsg: (value) =>
+          adt("notesMsgConsensus", {
+            rIndex: msg.value.rIndex,
+            childMsg: value
+          }) as Msg
       });
     default:
       return [state, []];
@@ -385,10 +608,10 @@ const TeamQuestionResponseView: component_.base.View<
   );
 };
 
-const view: component_.base.ComponentView<State, Msg> = ({
-  state,
-  dispatch
-}) => {
+const TeamQuestionResponsesView: component_.base.View<{
+  state: State;
+  dispatch: component_.base.Dispatch<Msg>;
+}> = ({ state, dispatch }) => {
   const show = hasSWUOpportunityPassedTeamQuestions(state.opportunity);
   return (
     <div>
@@ -440,12 +663,125 @@ const view: component_.base.ComponentView<State, Msg> = ({
   );
 };
 
-function isValid(state: Immutable<State>): boolean {
-  return state.scores.reduce(
-    (acc, s) => acc && FormField.isValid(s),
-    true as boolean
+const TeamQuestionResponseEvalView: component_.base.View<
+  TeamQuestionResponseViewProps
+> = ({ opportunity, response, index, isOpen, className, toggleAccordion }) => {
+  const question = getQuestionByOrder(opportunity, response.order);
+  if (!question) {
+    return null;
+  }
+  return (
+    <Accordion
+      className={className}
+      toggle={() => toggleAccordion()}
+      color="info"
+      title={`Question ${index + 1}`}
+      titleClassName="h3 mb-0"
+      chevronWidth={1.5}
+      chevronHeight={1.5}
+      open={isOpen}>
+      <p style={{ whiteSpace: "pre-line" }}>{question.question}</p>
+      <div className="mb-3 small text-secondary d-flex flex-column flex-sm-row flex-nowrap">
+        <div className="mb-2 mb-sm-0">
+          {countWords(response.response)} / {question.wordLimit} word
+          {question.wordLimit === 1 ? "" : "s"}
+        </div>
+        <Separator spacing="2" color="secondary" className="d-none d-sm-block">
+          |
+        </Separator>
+        <div>
+          {response.score === undefined || response.score === null
+            ? `Unscored (${question.score} point${
+                question.score === 1 ? "" : "s"
+              } available)`
+            : `${response.score} / ${question.score} point${
+                question.score === 1 ? "" : "s"
+              }`}
+        </div>
+      </div>
+      <Alert color="primary" fade={false} className="mb-4">
+        <div style={{ whiteSpace: "pre-line" }}>{question.guideline}</div>
+      </Alert>
+      <ProposalMarkdown box source={response.response || EMPTY_STRING} />
+    </Accordion>
   );
-}
+};
+
+const TeamQuestionResponsesEvalView: component_.base.View<{
+  state: State;
+  dispatch: component_.base.Dispatch<Msg>;
+}> = ({ state, dispatch }) => {
+  const show = hasSWUOpportunityPassedTeamQuestionsEvaluation(
+    state.opportunity
+  );
+  return (
+    <div>
+      <ViewTabHeader proposal={state.proposal} viewerUser={state.viewerUser} />
+      {state.proposal.questionsScore !== null &&
+      state.proposal.questionsScore !== undefined ? (
+        <Row className="mt-5">
+          <Col xs="12">
+            <ReportCardList
+              reportCards={[
+                {
+                  icon: "star-full",
+                  iconColor: "c-report-card-icon-highlight",
+                  name: "Team Questions Score",
+                  value: `${String(
+                    state.proposal.questionsScore.toFixed(NUM_SCORE_DECIMALS)
+                  )}%`
+                }
+              ]}
+            />
+          </Col>
+        </Row>
+      ) : null}
+      <div className="mt-5 pt-5 border-top">
+        <Row>
+          <Col xs="12">
+            {show ? (
+              <div>
+                <h3 className="mb-4">Team Questions{"'"} Responses</h3>
+                {state.proposal.teamQuestionResponses.map((r, i, rs) => (
+                  <TeamQuestionResponseEvalView
+                    key={`swu-proposal-team-question-response-${i}`}
+                    className={i < rs.length - 1 ? "mb-4" : ""}
+                    opportunity={state.opportunity}
+                    isOpen={state.openAccordions.has(i)}
+                    toggleAccordion={() => dispatch(adt("toggleAccordion", i))}
+                    index={i}
+                    response={r}
+                  />
+                ))}
+              </div>
+            ) : (
+              "This proposal's team questions will be available once the opportunity closes."
+            )}
+          </Col>
+        </Row>
+      </div>
+    </div>
+  );
+};
+
+const view: component_.base.ComponentView<State, Msg> = ({
+  state,
+  dispatch
+}) => {
+  return state.opportunity.status ===
+    SWUOpportunityStatus.EvaluationTeamQuestionsPanel ? (
+    <TeamQuestionResponsesEvalView state={state} dispatch={dispatch} />
+  ) : (
+    <TeamQuestionResponsesView state={state} dispatch={dispatch} />
+  );
+};
+
+// function isValid(state: Immutable<State>): boolean {
+//   return state.scores.reduce(
+//     (acc, s) => acc && FormField.isValid(s),
+//     true as boolean
+//   );
+// }
 
 export const component: Tab.Component<State, Msg> = {
   init,
@@ -456,116 +792,116 @@ export const component: Tab.Component<State, Msg> = {
     return component_.page.readyMsg();
   },
 
-  getModal: (state) => {
-    const isEnterScoreLoading = state.enterScoreLoading > 0;
-    const valid = isValid(state);
-    switch (state.showModal) {
-      case "enterScore":
-        return component_.page.modal.show({
-          title: "Enter Score",
-          onCloseMsg: adt("hideModal") as Msg,
-          actions: [
-            {
-              text: "Submit Score",
-              icon: "star-full",
-              color: "primary",
-              button: true,
-              loading: isEnterScoreLoading,
-              disabled: isEnterScoreLoading || !valid,
-              msg: adt("submitScore")
-            },
-            {
-              text: "Cancel",
-              color: "secondary",
-              disabled: isEnterScoreLoading,
-              msg: adt("hideModal")
-            }
-          ],
-          body: (dispatch) => (
-            <div>
-              <p>
-                Provide a score for each team question response submitted by the
-                proponent.
-              </p>
-              {state.scores.map((s, i) => {
-                return (
-                  <NumberField.view
-                    key={`swu-proposal-question-score-field-${i}`}
-                    extraChildProps={{ suffix: "point(s)" }}
-                    required
-                    disabled={isEnterScoreLoading}
-                    label={`Question ${i + 1} Score`}
-                    placeholder="Score"
-                    dispatch={component_.base.mapDispatch(
-                      dispatch,
-                      (v) => adt("scoreMsg" as const, [i, v]) as Msg
-                    )}
-                    state={s}
-                  />
-                );
-              })}
-            </div>
-          )
-        });
-      case null:
-        return component_.page.modal.hide();
-    }
-  },
+  // getModal: (state) => {
+  //   const isEnterScoreLoading = state.enterScoreLoading > 0;
+  //   const valid = isValid(state);
+  //   switch (state.showModal) {
+  //     case "enterScore":
+  //       return component_.page.modal.show({
+  //         title: "Enter Score",
+  //         onCloseMsg: adt("hideModal") as Msg,
+  //         actions: [
+  //           {
+  //             text: "Submit Score",
+  //             icon: "star-full",
+  //             color: "primary",
+  //             button: true,
+  //             loading: isEnterScoreLoading,
+  //             disabled: isEnterScoreLoading || !valid,
+  //             msg: adt("submitScore")
+  //           },
+  //           {
+  //             text: "Cancel",
+  //             color: "secondary",
+  //             disabled: isEnterScoreLoading,
+  //             msg: adt("hideModal")
+  //           }
+  //         ],
+  //         body: (dispatch) => (
+  //           <div>
+  //             <p>
+  //               Provide a score for each team question response submitted by the
+  //               proponent.
+  //             </p>
+  //             {state.scores.map((s, i) => {
+  //               return (
+  //                 <NumberField.view
+  //                   key={`swu-proposal-question-score-field-${i}`}
+  //                   extraChildProps={{ suffix: "point(s)" }}
+  //                   required
+  //                   disabled={isEnterScoreLoading}
+  //                   label={`Question ${i + 1} Score`}
+  //                   placeholder="Score"
+  //                   dispatch={component_.base.mapDispatch(
+  //                     dispatch,
+  //                     (v) => adt("scoreMsg" as const, [i, v]) as Msg
+  //                   )}
+  //                   state={s}
+  //                 />
+  //               );
+  //             })}
+  //           </div>
+  //         )
+  //       });
+  //     case null:
+  //       return component_.page.modal.hide();
+  //   }
+  // },
 
-  getActions: ({ state, dispatch }) => {
+  getActions: ({ state }) => {
     const proposal = state.proposal;
     const propStatus = proposal.status;
-    const isScreenToFromLoading = state.screenToFromLoading > 0;
+    // const isScreenToFromLoading = state.screenToFromLoading > 0;
     switch (propStatus) {
-      case SWUProposalStatus.UnderReviewTeamQuestions:
-        return component_.page.actions.links([
-          {
-            children: "Enter Score",
-            symbol_: leftPlacement(iconLinkSymbol("star-full")),
-            button: true,
-            color: "primary",
-            onClick: () => dispatch(adt("showModal", "enterScore" as const))
-          }
-        ]);
-      case SWUProposalStatus.EvaluatedTeamQuestions:
-        return component_.page.actions.links([
-          ...(canSWUOpportunityBeScreenedInToCodeChallenge(state.opportunity)
-            ? [
-                {
-                  children: "Screen In",
-                  symbol_: leftPlacement(iconLinkSymbol("stars")),
-                  loading: isScreenToFromLoading,
-                  disabled: isScreenToFromLoading,
-                  button: true,
-                  color: "primary" as const,
-                  onClick: () => dispatch(adt("screenIn" as const))
-                }
-              ]
-            : []),
-          {
-            children: "Edit Score",
-            symbol_: leftPlacement(iconLinkSymbol("star-full")),
-            disabled: isScreenToFromLoading,
-            button: true,
-            color: "info",
-            onClick: () => dispatch(adt("showModal", "enterScore" as const))
-          }
-        ]) as component_.page.Actions;
-      case SWUProposalStatus.UnderReviewCodeChallenge:
-        if (hasSWUOpportunityPassedCodeChallenge(state.opportunity)) {
-          return component_.page.actions.none();
-        }
-        return component_.page.actions.links([
-          {
-            children: "Screen Out",
-            symbol_: leftPlacement(iconLinkSymbol("ban")),
-            loading: isScreenToFromLoading,
-            disabled: isScreenToFromLoading,
-            button: true,
-            color: "danger",
-            onClick: () => dispatch(adt("screenOut" as const))
-          }
-        ]);
+      // case SWUProposalStatus.UnderReviewTeamQuestions:
+      //   return component_.page.actions.links([
+      //     {
+      //       children: "Enter Score",
+      //       symbol_: leftPlacement(iconLinkSymbol("star-full")),
+      //       button: true,
+      //       color: "primary",
+      //       onClick: () => dispatch(adt("showModal", "enterScore" as const))
+      //     }
+      //   ]);
+      // case SWUProposalStatus.EvaluatedTeamQuestions:
+      //   return component_.page.actions.links([
+      //     ...(canSWUOpportunityBeScreenedInToCodeChallenge(state.opportunity)
+      //       ? [
+      //           {
+      //             children: "Screen In",
+      //             symbol_: leftPlacement(iconLinkSymbol("stars")),
+      //             loading: isScreenToFromLoading,
+      //             disabled: isScreenToFromLoading,
+      //             button: true,
+      //             color: "primary" as const,
+      //             onClick: () => dispatch(adt("screenIn" as const))
+      //           }
+      //         ]
+      //       : []),
+      //     {
+      //       children: "Edit Score",
+      //       symbol_: leftPlacement(iconLinkSymbol("star-full")),
+      //       disabled: isScreenToFromLoading,
+      //       button: true,
+      //       color: "info",
+      //       onClick: () => dispatch(adt("showModal", "enterScore" as const))
+      //     }
+      //   ]) as component_.page.Actions;
+      // case SWUProposalStatus.UnderReviewCodeChallenge:
+      //   if (hasSWUOpportunityPassedCodeChallenge(state.opportunity)) {
+      //     return component_.page.actions.none();
+      //   }
+      //   return component_.page.actions.links([
+      //     {
+      //       children: "Screen Out",
+      //       symbol_: leftPlacement(iconLinkSymbol("ban")),
+      //       loading: isScreenToFromLoading,
+      //       disabled: isScreenToFromLoading,
+      //       button: true,
+      //       color: "danger",
+      //       onClick: () => dispatch(adt("screenOut" as const))
+      //     }
+      //   ]);
       default:
         return component_.page.actions.none();
     }

--- a/src/front-end/typescript/lib/pages/question-evaluation/sprint-with-us/create-consensus.tsx
+++ b/src/front-end/typescript/lib/pages/question-evaluation/sprint-with-us/create-consensus.tsx
@@ -59,6 +59,7 @@ function makeInit<K extends Tab.TabId>(): component_.page.Init<
                 routeParams,
                 proposal,
                 opportunity,
+                true,
                 undefined,
                 panelEvaluations
               ]) as Msg;

--- a/src/front-end/typescript/lib/pages/question-evaluation/sprint-with-us/create-consensus.tsx
+++ b/src/front-end/typescript/lib/pages/question-evaluation/sprint-with-us/create-consensus.tsx
@@ -1,0 +1,84 @@
+import { Route, SharedState } from "front-end/lib/app/types";
+import { immutable, component as component_ } from "front-end/lib/framework";
+import * as api from "front-end/lib/http/api";
+import { adt, Id } from "shared/lib/types";
+import { invalid, valid } from "shared/lib/validation";
+import * as Tab from "front-end/lib/pages/proposal/sprint-with-us/view/tab";
+import {
+  component as proposalComponent,
+  State_,
+  InnerMsg_,
+  Msg
+} from "front-end/lib/pages/proposal/sprint-with-us/view";
+import { isUserType } from "front-end/lib/access-control";
+import { UserType } from "shared/lib/resources/user";
+
+export type RouteParams = {
+  opportunityId: Id;
+  proposalId: Id;
+  tab?: Tab.TabId;
+};
+
+function makeInit<K extends Tab.TabId>(): component_.page.Init<
+  RouteParams,
+  SharedState,
+  State_<K>,
+  InnerMsg_<K>,
+  Route
+> {
+  return isUserType({
+    userType: [UserType.Admin, UserType.Government],
+    success({ routePath, routeParams, shared }) {
+      const { opportunityId, proposalId } = routeParams;
+      return [
+        valid(
+          immutable({
+            proposal: null,
+            tab: null,
+            sidebar: null
+          })
+        ) as State_<K>,
+        [
+          component_.cmd.join3(
+            api.proposals.swu.readOne(opportunityId)(proposalId, (response) =>
+              api.isValid(response) ? response.value : null
+            ),
+            api.opportunities.swu.readOne()(opportunityId, (response) =>
+              api.isValid(response) ? response.value : null
+            ),
+            api.evaluations.swu.readMany({ proposalId })((response) =>
+              api.isValid(response) ? response.value : null
+            ),
+            (proposal, opportunity, individualEvaluations) => {
+              if (!proposal || !opportunity || !individualEvaluations)
+                return component_.global.replaceRouteMsg(
+                  adt("notFound" as const, { path: routePath })
+                );
+              return adt("onInitResponse", [
+                shared.sessionUser,
+                routeParams,
+                proposal,
+                opportunity,
+                individualEvaluations
+              ]) as Msg;
+            }
+          )
+        ]
+      ];
+    },
+    fail({ routePath }) {
+      return [
+        invalid(null),
+        [
+          component_.cmd.dispatch(
+            component_.global.replaceRouteMsg(
+              adt("notFound" as const, { path: routePath })
+            )
+          )
+        ]
+      ];
+    }
+  });
+}
+
+export const component = { ...proposalComponent, init: makeInit() };

--- a/src/front-end/typescript/lib/pages/question-evaluation/sprint-with-us/create-consensus.tsx
+++ b/src/front-end/typescript/lib/pages/question-evaluation/sprint-with-us/create-consensus.tsx
@@ -49,8 +49,8 @@ function makeInit<K extends Tab.TabId>(): component_.page.Init<
             api.evaluations.swu.readMany({ proposalId })((response) =>
               api.isValid(response) ? response.value : null
             ),
-            (proposal, opportunity, individualEvaluations) => {
-              if (!proposal || !opportunity || !individualEvaluations)
+            (proposal, opportunity, panelEvaluations) => {
+              if (!proposal || !opportunity || !panelEvaluations)
                 return component_.global.replaceRouteMsg(
                   adt("notFound" as const, { path: routePath })
                 );
@@ -59,7 +59,8 @@ function makeInit<K extends Tab.TabId>(): component_.page.Init<
                 routeParams,
                 proposal,
                 opportunity,
-                individualEvaluations
+                undefined,
+                panelEvaluations
               ]) as Msg;
             }
           )

--- a/src/front-end/typescript/lib/pages/question-evaluation/sprint-with-us/create-individual.tsx
+++ b/src/front-end/typescript/lib/pages/question-evaluation/sprint-with-us/create-individual.tsx
@@ -56,6 +56,7 @@ function makeInit<K extends Tab.TabId>(): component_.page.Init<
                 routeParams,
                 proposal,
                 opportunity,
+                undefined,
                 [] // No evaluations to load
               ]) as Msg;
             }

--- a/src/front-end/typescript/lib/pages/question-evaluation/sprint-with-us/create-individual.tsx
+++ b/src/front-end/typescript/lib/pages/question-evaluation/sprint-with-us/create-individual.tsx
@@ -56,6 +56,7 @@ function makeInit<K extends Tab.TabId>(): component_.page.Init<
                 routeParams,
                 proposal,
                 opportunity,
+                true,
                 undefined,
                 [] // No evaluations to load
               ]) as Msg;

--- a/src/front-end/typescript/lib/pages/question-evaluation/sprint-with-us/create-individual.tsx
+++ b/src/front-end/typescript/lib/pages/question-evaluation/sprint-with-us/create-individual.tsx
@@ -1,0 +1,81 @@
+import { Route, SharedState } from "front-end/lib/app/types";
+import { immutable, component as component_ } from "front-end/lib/framework";
+import * as api from "front-end/lib/http/api";
+import { adt, Id } from "shared/lib/types";
+import { invalid, valid } from "shared/lib/validation";
+import * as Tab from "front-end/lib/pages/proposal/sprint-with-us/view/tab";
+import {
+  component as proposalComponent,
+  State_,
+  InnerMsg_,
+  Msg
+} from "front-end/lib/pages/proposal/sprint-with-us/view";
+import { isUserType } from "front-end/lib/access-control";
+import { UserType } from "shared/lib/resources/user";
+
+export type RouteParams = {
+  opportunityId: Id;
+  proposalId: Id;
+  tab?: Tab.TabId;
+};
+
+function makeInit<K extends Tab.TabId>(): component_.page.Init<
+  RouteParams,
+  SharedState,
+  State_<K>,
+  InnerMsg_<K>,
+  Route
+> {
+  return isUserType({
+    userType: [UserType.Admin, UserType.Government],
+    success({ routePath, routeParams, shared }) {
+      const { opportunityId, proposalId } = routeParams;
+      return [
+        valid(
+          immutable({
+            proposal: null,
+            tab: null,
+            sidebar: null
+          })
+        ) as State_<K>,
+        [
+          component_.cmd.join(
+            api.proposals.swu.readOne(opportunityId)(proposalId, (response) =>
+              api.isValid(response) ? response.value : null
+            ),
+            api.opportunities.swu.readOne()(opportunityId, (response) =>
+              api.isValid(response) ? response.value : null
+            ),
+            (proposal, opportunity) => {
+              if (!proposal || !opportunity)
+                return component_.global.replaceRouteMsg(
+                  adt("notFound" as const, { path: routePath })
+                );
+              return adt("onInitResponse", [
+                shared.sessionUser,
+                routeParams,
+                proposal,
+                opportunity,
+                [] // No evaluations to load
+              ]) as Msg;
+            }
+          )
+        ]
+      ];
+    },
+    fail({ routePath }) {
+      return [
+        invalid(null),
+        [
+          component_.cmd.dispatch(
+            component_.global.replaceRouteMsg(
+              adt("notFound" as const, { path: routePath })
+            )
+          )
+        ]
+      ];
+    }
+  });
+}
+
+export const component = { ...proposalComponent, init: makeInit() };

--- a/src/front-end/typescript/lib/pages/question-evaluation/sprint-with-us/edit-consensus.tsx
+++ b/src/front-end/typescript/lib/pages/question-evaluation/sprint-with-us/edit-consensus.tsx
@@ -53,13 +53,8 @@ function makeInit<K extends Tab.TabId>(): component_.page.Init<
             api.evaluations.swu.readMany({ proposalId })((response) =>
               api.isValid(response) ? response.value : null
             ),
-            (proposal, opportunity, consensus, individualEvaluations) => {
-              if (
-                !proposal ||
-                !opportunity ||
-                !consensus ||
-                !individualEvaluations
-              )
+            (proposal, opportunity, evaluation, panelEvaluations) => {
+              if (!proposal || !opportunity || !evaluation || !panelEvaluations)
                 return component_.global.replaceRouteMsg(
                   adt("notFound" as const, { path: routePath })
                 );
@@ -68,12 +63,8 @@ function makeInit<K extends Tab.TabId>(): component_.page.Init<
                 routeParams,
                 proposal,
                 opportunity,
-                [
-                  consensus,
-                  ...(Array.isArray(individualEvaluations)
-                    ? individualEvaluations
-                    : [])
-                ]
+                evaluation,
+                panelEvaluations
               ]) as Msg;
             }
           )

--- a/src/front-end/typescript/lib/pages/question-evaluation/sprint-with-us/edit-consensus.tsx
+++ b/src/front-end/typescript/lib/pages/question-evaluation/sprint-with-us/edit-consensus.tsx
@@ -1,0 +1,98 @@
+import { Route, SharedState } from "front-end/lib/app/types";
+import { immutable, component as component_ } from "front-end/lib/framework";
+import * as api from "front-end/lib/http/api";
+import { adt, Id } from "shared/lib/types";
+import { invalid, valid } from "shared/lib/validation";
+import * as Tab from "front-end/lib/pages/proposal/sprint-with-us/view/tab";
+import {
+  component as proposalComponent,
+  State_,
+  InnerMsg_,
+  Msg
+} from "front-end/lib/pages/proposal/sprint-with-us/view";
+import { isUserType } from "front-end/lib/access-control";
+import { UserType } from "shared/lib/resources/user";
+
+export type RouteParams = {
+  opportunityId: Id;
+  proposalId: Id;
+  evaluationId: Id;
+  tab?: Tab.TabId;
+};
+
+function makeInit<K extends Tab.TabId>(): component_.page.Init<
+  RouteParams,
+  SharedState,
+  State_<K>,
+  InnerMsg_<K>,
+  Route
+> {
+  return isUserType({
+    userType: [UserType.Admin, UserType.Government],
+    success({ routePath, routeParams, shared }) {
+      const { opportunityId, proposalId, evaluationId } = routeParams;
+      return [
+        valid(
+          immutable({
+            proposal: null,
+            tab: null,
+            sidebar: null
+          })
+        ) as State_<K>,
+        [
+          component_.cmd.join4(
+            api.proposals.swu.readOne(opportunityId)(proposalId, (response) =>
+              api.isValid(response) ? response.value : null
+            ),
+            api.opportunities.swu.readOne()(opportunityId, (response) =>
+              api.isValid(response) ? response.value : null
+            ),
+            api.evaluations.swu.readOne()(evaluationId, (response) =>
+              api.isValid(response) ? response.value : null
+            ),
+            api.evaluations.swu.readMany({ proposalId })((response) =>
+              api.isValid(response) ? response.value : null
+            ),
+            (proposal, opportunity, consensus, individualEvaluations) => {
+              if (
+                !proposal ||
+                !opportunity ||
+                !consensus ||
+                !individualEvaluations
+              )
+                return component_.global.replaceRouteMsg(
+                  adt("notFound" as const, { path: routePath })
+                );
+              return adt("onInitResponse", [
+                shared.sessionUser,
+                routeParams,
+                proposal,
+                opportunity,
+                [
+                  consensus,
+                  ...(Array.isArray(individualEvaluations)
+                    ? individualEvaluations
+                    : [])
+                ]
+              ]) as Msg;
+            }
+          )
+        ]
+      ];
+    },
+    fail({ routePath }) {
+      return [
+        invalid(null),
+        [
+          component_.cmd.dispatch(
+            component_.global.replaceRouteMsg(
+              adt("notFound" as const, { path: routePath })
+            )
+          )
+        ]
+      ];
+    }
+  });
+}
+
+export const component = { ...proposalComponent, init: makeInit() };

--- a/src/front-end/typescript/lib/pages/question-evaluation/sprint-with-us/edit-consensus.tsx
+++ b/src/front-end/typescript/lib/pages/question-evaluation/sprint-with-us/edit-consensus.tsx
@@ -63,6 +63,7 @@ function makeInit<K extends Tab.TabId>(): component_.page.Init<
                 routeParams,
                 proposal,
                 opportunity,
+                true,
                 evaluation,
                 panelEvaluations
               ]) as Msg;

--- a/src/front-end/typescript/lib/pages/question-evaluation/sprint-with-us/edit-individual.tsx
+++ b/src/front-end/typescript/lib/pages/question-evaluation/sprint-with-us/edit-individual.tsx
@@ -60,7 +60,8 @@ function makeInit<K extends Tab.TabId>(): component_.page.Init<
                 routeParams,
                 proposal,
                 opportunity,
-                [evaluation]
+                evaluation,
+                []
               ]) as Msg;
             }
           )

--- a/src/front-end/typescript/lib/pages/question-evaluation/sprint-with-us/edit-individual.tsx
+++ b/src/front-end/typescript/lib/pages/question-evaluation/sprint-with-us/edit-individual.tsx
@@ -60,6 +60,7 @@ function makeInit<K extends Tab.TabId>(): component_.page.Init<
                 routeParams,
                 proposal,
                 opportunity,
+                true,
                 evaluation,
                 []
               ]) as Msg;

--- a/src/front-end/typescript/lib/pages/question-evaluation/sprint-with-us/edit-individual.tsx
+++ b/src/front-end/typescript/lib/pages/question-evaluation/sprint-with-us/edit-individual.tsx
@@ -1,0 +1,85 @@
+import { Route, SharedState } from "front-end/lib/app/types";
+import { immutable, component as component_ } from "front-end/lib/framework";
+import * as api from "front-end/lib/http/api";
+import { adt, Id } from "shared/lib/types";
+import { invalid, valid } from "shared/lib/validation";
+import * as Tab from "front-end/lib/pages/proposal/sprint-with-us/view/tab";
+import {
+  component as proposalComponent,
+  State_,
+  InnerMsg_,
+  Msg
+} from "front-end/lib/pages/proposal/sprint-with-us/view";
+import { isUserType } from "front-end/lib/access-control";
+import { UserType } from "shared/lib/resources/user";
+
+export type RouteParams = {
+  opportunityId: Id;
+  proposalId: Id;
+  evaluationId: Id;
+  tab?: Tab.TabId;
+};
+
+function makeInit<K extends Tab.TabId>(): component_.page.Init<
+  RouteParams,
+  SharedState,
+  State_<K>,
+  InnerMsg_<K>,
+  Route
+> {
+  return isUserType({
+    userType: [UserType.Admin, UserType.Government],
+    success({ routePath, routeParams, shared }) {
+      const { opportunityId, proposalId, evaluationId } = routeParams;
+      return [
+        valid(
+          immutable({
+            proposal: null,
+            tab: null,
+            sidebar: null
+          })
+        ) as State_<K>,
+        [
+          component_.cmd.join3(
+            api.proposals.swu.readOne(opportunityId)(proposalId, (response) =>
+              api.isValid(response) ? response.value : null
+            ),
+            api.opportunities.swu.readOne()(opportunityId, (response) =>
+              api.isValid(response) ? response.value : null
+            ),
+            api.evaluations.swu.readOne()(evaluationId, (response) =>
+              api.isValid(response) ? response.value : null
+            ),
+            (proposal, opportunity, evaluation) => {
+              if (!proposal || !opportunity || !evaluation)
+                return component_.global.replaceRouteMsg(
+                  adt("notFound" as const, { path: routePath })
+                );
+              return adt("onInitResponse", [
+                shared.sessionUser,
+                routeParams,
+                proposal,
+                opportunity,
+                [evaluation]
+              ]) as Msg;
+            }
+          )
+        ]
+      ];
+    },
+    fail({ routePath }) {
+      return [
+        invalid(null),
+        [
+          component_.cmd.dispatch(
+            component_.global.replaceRouteMsg(
+              adt("notFound" as const, { path: routePath })
+            )
+          )
+        ]
+      ];
+    }
+  });
+}
+
+export const component = { ...proposalComponent, init: makeInit() };

--- a/src/shared/lib/resources/opportunity/sprint-with-us.ts
+++ b/src/shared/lib/resources/opportunity/sprint-with-us.ts
@@ -57,8 +57,7 @@ export enum SWUOpportunityStatus {
   Draft = "DRAFT",
   UnderReview = "UNDER_REVIEW",
   Published = "PUBLISHED",
-  TeamQuestionsPanelEvaluation = "QUESTIONS_PANEL_EVAL",
-  TeamQuestionsPanelConsensus = "QUESTIONS_PANEL_CONSENSUS",
+  EvaluationTeamQuestionsPanel = "EVAL_QUESTIONS_PANEL",
   EvaluationTeamQuestions = "EVAL_QUESTIONS",
   EvaluationCodeChallenge = "EVAL_CC",
   EvaluationTeamScenario = "EVAL_SCENARIO",
@@ -124,8 +123,7 @@ export function isSWUOpportunityStatusInEvaluation(
 
 export const publicOpportunityStatuses: readonly SWUOpportunityStatus[] = [
   SWUOpportunityStatus.Published,
-  SWUOpportunityStatus.TeamQuestionsPanelEvaluation,
-  SWUOpportunityStatus.TeamQuestionsPanelConsensus,
+  SWUOpportunityStatus.EvaluationTeamQuestionsPanel,
   SWUOpportunityStatus.EvaluationTeamQuestions,
   SWUOpportunityStatus.EvaluationCodeChallenge,
   SWUOpportunityStatus.EvaluationTeamScenario,

--- a/src/shared/lib/resources/opportunity/sprint-with-us.ts
+++ b/src/shared/lib/resources/opportunity/sprint-with-us.ts
@@ -112,6 +112,7 @@ export function isSWUOpportunityStatusInEvaluation(
   s: SWUOpportunityStatus
 ): boolean {
   switch (s) {
+    case SWUOpportunityStatus.EvaluationTeamQuestionsPanel:
     case SWUOpportunityStatus.EvaluationTeamQuestions:
     case SWUOpportunityStatus.EvaluationCodeChallenge:
     case SWUOpportunityStatus.EvaluationTeamScenario:
@@ -557,6 +558,23 @@ export function canViewSWUOpportunityProposals(o: SWUOpportunity): boolean {
   );
 }
 
+export function canViewSWUOpportunityTeamQuestionResponseEvaluations(
+  o: SWUOpportunity
+): boolean {
+  // Return true if the opportunity has ever had the `Panel` status.
+  return (
+    !!o.history &&
+    o.history.reduce((acc, record) => {
+      return (
+        acc ||
+        (record.type.tag === "status" &&
+          record.type.value ===
+            SWUOpportunityStatus.EvaluationTeamQuestionsPanel)
+      );
+    }, false as boolean)
+  );
+}
+
 export function canSWUOpportunityDetailsBeEdited(
   o: SWUOpportunity,
   adminsOnly: boolean
@@ -610,6 +628,29 @@ export function isSWUOpportunityClosed(o: SWUOpportunity): boolean {
     o.status !== SWUOpportunityStatus.UnderReview &&
     o.status !== SWUOpportunityStatus.Suspended
   );
+}
+
+export function hasSWUOpportunityPassedTeamQuestionsEvaluation(
+  o: Pick<SWUOpportunity, "history">
+): boolean {
+  if (!o.history) {
+    return false;
+  }
+  return o.history.reduce((acc, h) => {
+    if (acc || h.type.tag !== "status") {
+      return acc;
+    }
+    switch (h.type.value) {
+      case SWUOpportunityStatus.EvaluationTeamQuestionsPanel:
+      case SWUOpportunityStatus.EvaluationTeamQuestions:
+      case SWUOpportunityStatus.EvaluationCodeChallenge:
+      case SWUOpportunityStatus.EvaluationTeamScenario:
+      case SWUOpportunityStatus.Awarded:
+        return true;
+      default:
+        return false;
+    }
+  }, false as boolean);
 }
 
 export function hasSWUOpportunityPassedTeamQuestions(
@@ -692,6 +733,20 @@ export function doesSWUOpportunityStatusAllowGovToViewFullProposal(
   s: SWUOpportunityStatus
 ): boolean {
   switch (s) {
+    case SWUOpportunityStatus.EvaluationCodeChallenge:
+    case SWUOpportunityStatus.EvaluationTeamScenario:
+    case SWUOpportunityStatus.Awarded:
+      return true;
+    default:
+      return false;
+  }
+}
+
+export function doesSWUOpportunityStatusAllowGovToViewTeamQuestionResponseEvaluations(
+  s: SWUOpportunityStatus
+): boolean {
+  switch (s) {
+    case SWUOpportunityStatus.EvaluationTeamQuestions:
     case SWUOpportunityStatus.EvaluationCodeChallenge:
     case SWUOpportunityStatus.EvaluationTeamScenario:
     case SWUOpportunityStatus.Awarded:

--- a/src/shared/lib/resources/proposal/sprint-with-us.ts
+++ b/src/shared/lib/resources/proposal/sprint-with-us.ts
@@ -128,6 +128,20 @@ function quantifySWUProposalStatusForSort(a: SWUProposalStatus): number {
   }
 }
 
+function getSWUProposalAnonymousProponentNumber(proposal: SWUProposalSlim) {
+  return Number(proposal.anonymousProponentName.match(/\d+/)?.at(0));
+}
+
+export function compareSWUProposalAnonymousProponentNumber(
+  a: SWUProposalSlim,
+  b: SWUProposalSlim
+) {
+  return compareNumbers(
+    getSWUProposalAnonymousProponentNumber(a),
+    getSWUProposalAnonymousProponentNumber(b)
+  );
+}
+
 export function compareSWUProposalStatuses(
   a: SWUProposalStatus,
   b: SWUProposalStatus

--- a/src/shared/lib/resources/proposal/sprint-with-us.ts
+++ b/src/shared/lib/resources/proposal/sprint-with-us.ts
@@ -50,6 +50,8 @@ export function swuProposalPhaseTypeToTitleCase(
 export enum SWUProposalStatus {
   Draft = "DRAFT",
   Submitted = "SUBMITTED",
+  TeamQuestionsPanelIndividual = "QUESTIONS_PANEL_INDIVIDUAL",
+  TeamQuestionsPanelConsensus = "QUESTIONS_PANEL_CONESENSUS",
   UnderReviewTeamQuestions = "UNDER_REVIEW_QUESTIONS",
   EvaluatedTeamQuestions = "EVALUATED_QUESTIONS",
   UnderReviewCodeChallenge = "UNDER_REVIEW_CODE_CHALLENGE",
@@ -107,6 +109,8 @@ function quantifySWUProposalStatusForSort(a: SWUProposalStatus): number {
       return 0;
     case SWUProposalStatus.NotAwarded:
       return 1;
+    case SWUProposalStatus.TeamQuestionsPanelIndividual:
+    case SWUProposalStatus.TeamQuestionsPanelConsensus:
     case SWUProposalStatus.UnderReviewTeamQuestions:
     case SWUProposalStatus.EvaluatedTeamQuestions:
     case SWUProposalStatus.UnderReviewCodeChallenge:

--- a/src/shared/lib/resources/question-evaluation/sprint-with-us.ts
+++ b/src/shared/lib/resources/question-evaluation/sprint-with-us.ts
@@ -10,8 +10,8 @@ export function parseSWUTeamQuestionResponseEvaluationType(
   raw: string
 ): SWUTeamQuestionResponseEvaluationType | null {
   switch (raw) {
-    case SWUTeamQuestionResponseEvaluationType.Conensus:
-      return SWUTeamQuestionResponseEvaluationType.Conensus;
+    case SWUTeamQuestionResponseEvaluationType.Consensus:
+      return SWUTeamQuestionResponseEvaluationType.Consensus;
     case SWUTeamQuestionResponseEvaluationType.Individual:
       return SWUTeamQuestionResponseEvaluationType.Individual;
     default:
@@ -33,7 +33,7 @@ export function parseSWUTeamQuestionResponseEvaluationStatus(
 }
 
 export enum SWUTeamQuestionResponseEvaluationType {
-  Conensus = "CONSENSUS",
+  Consensus = "CONSENSUS",
   Individual = "INDIVIDUAL"
 }
 

--- a/src/shared/lib/resources/question-evaluation/sprint-with-us.ts
+++ b/src/shared/lib/resources/question-evaluation/sprint-with-us.ts
@@ -1,6 +1,9 @@
 import { ADT, BodyWithErrors, Id } from "shared/lib/types";
 import { ErrorTypeFrom } from "shared/lib/validation";
-import { SWUEvaluationPanelMember } from "src/shared/lib/resources/opportunity/sprint-with-us";
+import {
+  SWUEvaluationPanelMember,
+  SWUOpportunity
+} from "src/shared/lib/resources/opportunity/sprint-with-us";
 import { SWUProposalSlim } from "src/shared/lib/resources/proposal/sprint-with-us";
 
 export function parseSWUTeamQuestionResponseEvaluationType(
@@ -56,12 +59,20 @@ export interface SWUTeamQuestionResponseEvaluation {
   updatedAt: Date;
 }
 
-export interface SWUTeamQuestionResponseEvaluationSlim
-  extends Omit<
-    SWUTeamQuestionResponseEvaluation,
-    "proposal" | "evaluationPanelMember" | "scores"
-  > {
-  scores: Omit<SWUTeamQuestionResponseEvaluationScores, "notes">[];
+export function getEvaluationById(
+  evaluations: SWUTeamQuestionResponseEvaluation[],
+  id: Id
+): SWUTeamQuestionResponseEvaluation | null {
+  return (
+    evaluations.find((e) => e.evaluationPanelMember.user.id === id) ?? null
+  );
+}
+
+export function getEvaluationScoreByOrder(
+  evaluation: SWUTeamQuestionResponseEvaluation,
+  order: number
+): SWUTeamQuestionResponseEvaluationScores | null {
+  return evaluation.scores.find((s) => s.order === order) ?? null;
 }
 
 // Create.
@@ -126,4 +137,14 @@ export function isValidStatusChange(
     default:
       return false;
   }
+}
+
+export function canSWUTeamQuestionResponseEvaluationBeSubmitted(
+  e: Pick<SWUTeamQuestionResponseEvaluation, "status" | "scores">,
+  o: Pick<SWUOpportunity, "teamQuestions">
+): boolean {
+  return (
+    e.status === SWUTeamQuestionResponseEvaluationStatus.Draft &&
+    o.teamQuestions.length === e.scores.length
+  );
 }

--- a/src/shared/lib/resources/question-evaluation/sprint-with-us.ts
+++ b/src/shared/lib/resources/question-evaluation/sprint-with-us.ts
@@ -90,4 +90,32 @@ export type UpdateRequestBody =
   | ADT<"edit", UpdateEditRequestBody>
   | ADT<"submit", string>;
 
-export type UpdateEditRequestBody = CreateRequestBody;
+export type UpdateEditRequestBody = Omit<
+  CreateRequestBody,
+  "proposal" | "type" | "status"
+>;
+
+type UpdateADTErrors =
+  | ADT<"edit", UpdateEditValidationErrors>
+  | ADT<"submit", string[]>
+  | ADT<"parseFailure">;
+
+export interface UpdateEditValidationErrors {
+  scores?: CreateSWUTeamQuestionResponseEvaluationScoreValidationErrors[];
+}
+
+export interface UpdateValidationErrors extends BodyWithErrors {
+  evaluation?: UpdateADTErrors;
+}
+
+export function isValidStatusChange(
+  from: SWUTeamQuestionResponseEvaluationStatus,
+  to: SWUTeamQuestionResponseEvaluationStatus
+): boolean {
+  switch (from) {
+    case SWUTeamQuestionResponseEvaluationStatus.Draft:
+      return SWUTeamQuestionResponseEvaluationStatus.Submitted === to;
+    default:
+      return false;
+  }
+}

--- a/src/shared/lib/resources/question-evaluation/sprint-with-us.ts
+++ b/src/shared/lib/resources/question-evaluation/sprint-with-us.ts
@@ -59,20 +59,11 @@ export interface SWUTeamQuestionResponseEvaluation {
   updatedAt: Date;
 }
 
-export function getEvaluationById(
-  evaluations: SWUTeamQuestionResponseEvaluation[],
-  id: Id
-): SWUTeamQuestionResponseEvaluation | null {
-  return (
-    evaluations.find((e) => e.evaluationPanelMember.user.id === id) ?? null
-  );
-}
-
 export function getEvaluationScoreByOrder(
-  evaluation: SWUTeamQuestionResponseEvaluation,
+  evaluation: SWUTeamQuestionResponseEvaluation | null,
   order: number
 ): SWUTeamQuestionResponseEvaluationScores | null {
-  return evaluation.scores.find((s) => s.order === order) ?? null;
+  return evaluation?.scores.find((s) => s.order === order) ?? null;
 }
 
 // Create.

--- a/src/shared/lib/resources/question-evaluation/sprint-with-us.ts
+++ b/src/shared/lib/resources/question-evaluation/sprint-with-us.ts
@@ -56,6 +56,14 @@ export interface SWUTeamQuestionResponseEvaluation {
   updatedAt: Date;
 }
 
+export interface SWUTeamQuestionResponseEvaluationSlim
+  extends Omit<
+    SWUTeamQuestionResponseEvaluation,
+    "proposal" | "evaluationPanelMember" | "scores"
+  > {
+  scores: Omit<SWUTeamQuestionResponseEvaluationScores, "notes">[];
+}
+
 // Create.
 
 export type CreateSWUTeamQuestionResponseEvaluationStatus =

--- a/src/shared/lib/validation/question-evaluation/sprint-with-us.ts
+++ b/src/shared/lib/validation/question-evaluation/sprint-with-us.ts
@@ -16,6 +16,7 @@ import {
   isInvalid,
   valid,
   validateArrayCustom,
+  validateGenericString,
   validateGenericStringWords,
   validateNumber,
   Validation
@@ -148,4 +149,8 @@ export function validateSWUTeamQuestionResponseEvaluationScores(
       ),
     {}
   );
+}
+
+export function validateNote(raw: string): Validation<string> {
+  return validateGenericString(raw, "Note", 0, 5000);
 }


### PR DESCRIPTION
@sutherlanda , this has the back-end and front-end up to displaying the "overview" and new "team questions" evaluation pages. I think you should be able to look at the new files in src/front-end/typescript/lib/pages/question-evaluation/sprint-with-us/.* and work your way through the code from there. They are designed to initialize the team-questions proposal page with different data depending on the state of the opportunity/proposal.

Note:
- I tried to rely on opportunity/proposal state as much as possible, but I still needed to imperatively provide the evaluationId because the pages don't have that context at initialization time.