### PR TITLE
feat: update total opportunity stats, include twu values

### DIFF
--- a/src/back-end/config.ts
+++ b/src/back-end/config.ts
@@ -8,9 +8,9 @@ import { parseBooleanEnvironmentVariable } from "shared/config";
 
 // HARDCODED CONFIG
 // Offset for total opportunity metrics displayed on landing page
-export const TOTAL_AWARDED_COUNT_OFFSET = 94;
+export const TOTAL_AWARDED_COUNT_OFFSET = 93;
 
-export const TOTAL_AWARDED_VALUE_OFFSET = 13211500;
+export const TOTAL_AWARDED_VALUE_OFFSET = 13736500;
 
 export const DB_MIGRATIONS_TABLE_NAME = "migrations";
 

--- a/src/back-end/lib/db/metrics.ts
+++ b/src/back-end/lib/db/metrics.ts
@@ -1,10 +1,12 @@
 import { tryDb } from "back-end/lib/db";
 import { generateCWUOpportunityQuery as cwuQuery } from "back-end/lib/db/opportunity/code-with-us";
 import { generateSWUOpportunityQuery as swuQuery } from "back-end/lib/db/opportunity/sprint-with-us";
+import { generateTWUOpportunityQuery as twuQuery } from "back-end/lib/db/opportunity/team-with-us";
 import { valid } from "shared/lib/http";
 import { OpportunityMetrics } from "shared/lib/resources/metrics";
 import { CWUOpportunityStatus } from "shared/lib/resources/opportunity/code-with-us";
 import { SWUOpportunityStatus } from "shared/lib/resources/opportunity/sprint-with-us";
+import { TWUOpportunityStatus } from "shared/lib/resources/opportunity/team-with-us";
 
 export const readOpportunityMetrics = tryDb<[], OpportunityMetrics>(
   async (connection) => {
@@ -29,6 +31,16 @@ export const readOpportunityMetrics = tryDb<[], OpportunityMetrics>(
     totals.totalCount += swuResult?.length || 0;
     totals.totalAwarded += swuResult.reduce(
       (acc: number, val: Record<string, number>) => acc + val.totalMaxBudget,
+      0
+    );
+
+    const twuResult = await twuQuery(connection).where({
+      "statuses.status": TWUOpportunityStatus.Awarded
+    });
+
+    totals.totalCount += twuResult?.length || 0;
+    totals.totalAwarded += twuResult.reduce(
+      (acc: number, val: Record<string, number>) => acc + val.maxBudget,
       0
     );
 


### PR DESCRIPTION
This PR closes issue: [issue #DMM-494]

Includes tests? [N]
Updated docs? [N]

Proposed changes:
- Updated `TOTAL_AWARDED_COUNT_OFFSET` and `TOTAL_AWARDED_VALUE_OFFSET` to align with spreadsheet values
- Updated metrics to include information from completed Team With Us opportunities (count and award values)

Additional notes:
- DMM-494 ticket stated to update `TOTAL_AWARDED_VALUE_OFFSET` to 1376500, however spreadsheet had 13736500. Implemented the latter value (13736500) as it appears to be more correct since it's derived directly from the spreadsheet calculation.
