### PR TITLE
feat: awarded opportunity notification updates

### DIFF
--- a/src/back-end/lib/mailer/notifications/opportunity/team-with-us.tsx
+++ b/src/back-end/lib/mailer/notifications/opportunity/team-with-us.tsx
@@ -199,11 +199,11 @@ export function makeTWUOpportunityInformation(
     { name: "Value", value: `$${formatAmount(opportunity.maxBudget)}` },
     ...serviceAreas,
     {
-      name: "Contract Start Date",
+      name: "Estimated Contract Start Date",
       value: formatDate(opportunity.startDate, false)
     },
     {
-      name: "Contract End Date",
+      name: "Estimated Contract End Date",
       value: opportunity.completionDate
         ? formatDate(opportunity.completionDate, false)
         : ""

--- a/src/back-end/lib/mailer/notifications/proposal/code-with-us.tsx
+++ b/src/back-end/lib/mailer/notifications/proposal/code-with-us.tsx
@@ -262,24 +262,26 @@ export async function unsuccessfulCWUProposalSubmissionT(
   opportunity: CWUOpportunity,
   proposal: CWUProposal | CWUProposalSlim
 ): Promise<Emails> {
-  const title = "A Code With Us Opportunity Has Closed";
+  const title = "A Code With Us Opportunity: Award Decision Made";
   const description =
-    "The following Digital Marketplace opportunity that you submitted a proposal to has closed:";
+    "The following Digital Marketplace opportunity that you submitted a proposal to has been awarded:";
+
+  // Get opportunity details from the standard information function
+  const opportunityDetails = makeCWUOpportunityInformation(opportunity, false);
+
   return [
     {
       summary: "CWU opportunity awarded; sent to unsuccessful proponents.",
       to: recipient.email || [],
       subject: title,
-      html: templates.simple({
+      html: templates.awardDecision({
         title,
         description,
-        descriptionLists: [makeCWUOpportunityInformation(opportunity, false)],
+        opportunityTitle: opportunity.title,
+        awardedTo: opportunity.successfulProponent?.name || EMPTY_STRING,
+        opportunityDetails: opportunityDetails.items,
         body: (
           <div>
-            <p>
-              The opportunity has been awarded to{" "}
-              {opportunity.successfulProponent?.name || EMPTY_STRING}.
-            </p>
             <p>
               If you would like to view your total score,{" "}
               <templates.Link

--- a/src/back-end/lib/mailer/notifications/proposal/sprint-with-us.tsx
+++ b/src/back-end/lib/mailer/notifications/proposal/sprint-with-us.tsx
@@ -272,24 +272,26 @@ export async function unsuccessfulSWUProposalSubmissionT(
   opportunity: SWUOpportunity,
   proposal: SWUProposal | SWUProposalSlim
 ): Promise<Emails> {
-  const title = "A Sprint With Us Opportunity Has Closed";
+  const title = "A Sprint With Us Opportunity: Award Decision Made";
   const description =
-    "The following Digital Marketplace opportunity that you submitted a proposal to has closed:";
+    "The following Digital Marketplace opportunity that you submitted a proposal to has been awarded:";
+
+  // Get opportunity details from the standard information function
+  const opportunityDetails = makeSWUOpportunityInformation(opportunity, false);
+
   return [
     {
       summary: "SWU opportunity awarded; sent to unsuccessful proponents.",
       to: recipient.email || [],
       subject: title,
-      html: templates.simple({
+      html: templates.awardDecision({
         title,
         description,
-        descriptionLists: [makeSWUOpportunityInformation(opportunity, false)],
+        opportunityTitle: opportunity.title,
+        awardedTo: opportunity.successfulProponent?.name || EMPTY_STRING,
+        opportunityDetails: opportunityDetails.items,
         body: (
           <div>
-            <p>
-              The opportunity has been awarded to{" "}
-              {opportunity.successfulProponent?.name || EMPTY_STRING}.
-            </p>
             <p>
               If you would like to view your scores for each stage of the
               opportunity,{" "}

--- a/src/back-end/lib/mailer/notifications/proposal/team-with-us.tsx
+++ b/src/back-end/lib/mailer/notifications/proposal/team-with-us.tsx
@@ -272,24 +272,26 @@ export async function unsuccessfulTWUProposalSubmissionT(
   opportunity: TWUOpportunity,
   proposal: TWUProposal | TWUProposalSlim
 ): Promise<Emails> {
-  const title = "A Team With Us Opportunity Has Closed";
+  const title = "A Team With Us Opportunity: Award Decision Made";
   const description =
-    "The following Digital Marketplace opportunity that you submitted a proposal to has closed:";
+    "The following Digital Marketplace opportunity that you submitted a proposal to has been awarded:";
+
+  // Get opportunity details from the standard information function
+  const opportunityDetails = makeTWUOpportunityInformation(opportunity, false);
+
   return [
     {
       summary: "TWU opportunity awarded; sent to unsuccessful proponents.",
       to: recipient.email || [],
       subject: title,
-      html: templates.simple({
+      html: templates.awardDecision({
         title,
         description,
-        descriptionLists: [makeTWUOpportunityInformation(opportunity, false)],
+        opportunityTitle: opportunity.title,
+        awardedTo: opportunity.successfulProponent?.name || EMPTY_STRING,
+        opportunityDetails: opportunityDetails.items,
         body: (
           <div>
-            <p>
-              The opportunity has been awarded to{" "}
-              {opportunity.successfulProponent?.name || EMPTY_STRING}.
-            </p>
             <p>
               If you would like to view your scores for each stage of the
               opportunity,{" "}

--- a/src/back-end/lib/mailer/templates.tsx
+++ b/src/back-end/lib/mailer/templates.tsx
@@ -1,7 +1,7 @@
 import { prefixPath } from "back-end/lib";
 import { CSSProperties, default as React, Fragment, ReactElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
-import { SHOW_TEST_INDICATOR } from "shared/config";
+import { EMPTY_STRING, SHOW_TEST_INDICATOR } from "shared/config";
 import { VIEWER_USER_ROUTE_PARAM } from "shared/lib/resources/user";
 
 // Styles.
@@ -467,3 +467,67 @@ const Simple: View<SimpleProps> = (props) => {
 };
 
 export const simple: Template<SimpleProps> = makeTemplate(Simple);
+
+// Award Decision template - special format for award decision notifications
+
+export interface AwardDecisionProps extends TemplateBaseProps {
+  opportunityTitle: string;
+  awardedTo: string;
+  opportunityDetails: DescriptionItemProps[];
+  callsToAction?: LinkProps[];
+  body?: string | ReactElement;
+}
+
+const AwardDecision: View<AwardDecisionProps> = (props) => {
+  const {
+    opportunityTitle,
+    awardedTo,
+    opportunityDetails,
+    callsToAction,
+    body
+  } = props;
+  return (
+    <Layout {...props}>
+      {/* Display the opportunity title */}
+      <Row style={styles.utilities.text.center}>
+        <b>{opportunityTitle}</b>
+      </Row>
+
+      {/* Display "Awarded to" */}
+      <Row style={styles.utilities.text.center}>
+        <p>
+          The opportunity has been awarded to:{" "}
+          <b>{awardedTo || EMPTY_STRING}</b>
+        </p>
+      </Row>
+
+      {/* Display opportunity details as a standard description list */}
+      <Row style={styles.utilities.text.center}>
+        <Fragment>
+          {opportunityDetails.map((item, i) => (
+            <DescriptionItem key={`award-detail-${i}`} {...item} />
+          ))}
+        </Fragment>
+      </Row>
+
+      {/* Display the body content */}
+      <Fragment>
+        {body ? <Row style={{ textAlign: "center" }}>{body}</Row> : null}
+      </Fragment>
+
+      {/* Display call to action buttons */}
+      <Fragment>
+        {callsToAction ? (
+          <Row style={{ ...styles.utilities.text.center }}>
+            {callsToAction.map((call, i) => (
+              <CallToAction key={`award-call-to-action-${i}`} {...call} />
+            ))}
+          </Row>
+        ) : null}
+      </Fragment>
+    </Layout>
+  );
+};
+
+export const awardDecision: Template<AwardDecisionProps> =
+  makeTemplate(AwardDecision);

--- a/src/back-end/lib/routers/admin/index.tsx
+++ b/src/back-end/lib/routers/admin/index.tsx
@@ -28,6 +28,18 @@ import {
   suspendedSWUOpportunitySubscribedT,
   updatedSWUOpportunityT
 } from "back-end/lib/mailer/notifications/opportunity/sprint-with-us";
+import {
+  cancelledTWUOpportunityActionedT,
+  cancelledTWUOpportunitySubscribedT,
+  newTWUOpportunityPublishedT,
+  newTWUOpportunitySubmittedForReviewAuthorT,
+  newTWUOpportunitySubmittedForReviewT,
+  readyForEvalTWUOpportunityT,
+  successfulTWUPublicationT,
+  suspendedTWUOpportunityActionedT,
+  suspendedTWUOpportunitySubscribedT,
+  updatedTWUOpportunityT
+} from "back-end/lib/mailer/notifications/opportunity/team-with-us";
 import { organizationArchivedT } from "back-end/lib/mailer/notifications/organization";
 import {
   awardedCWUProposalSubmissionT,
@@ -43,6 +55,13 @@ import {
   withdrawnSWUProposalSubmissionProposalAuthorT,
   withdrawnSWUProposalSubmissionT
 } from "back-end/lib/mailer/notifications/proposal/sprint-with-us";
+import {
+  awardedTWUProposalSubmissionT,
+  successfulTWUProposalSubmissionT,
+  unsuccessfulTWUProposalSubmissionT,
+  withdrawnTWUProposalSubmissionProposalAuthorT,
+  withdrawnTWUProposalSubmissionT
+} from "back-end/lib/mailer/notifications/proposal/team-with-us";
 import { vendorTermsChangedT } from "back-end/lib/mailer/notifications/terms-updated";
 import {
   accountDeactivatedAdminT,
@@ -390,6 +409,126 @@ async function makeEmailNotificationReference(): Promise<
           mocks.govUser,
           mocks.vendorUser,
           mocks.swuOpportunity
+        ))
+      ]
+    },
+    {
+      title: "TWU Opportunity Submitted For Review",
+      emails: [
+        ...(await newTWUOpportunitySubmittedForReviewT(
+          mocks.adminUser,
+          mocks.twuOpportunity
+        )),
+        ...(await newTWUOpportunitySubmittedForReviewAuthorT(
+          mocks.govUser,
+          mocks.twuOpportunity
+        ))
+      ]
+    },
+    {
+      title: "TWU Opportunity Published",
+      emails: [
+        ...(await newTWUOpportunityPublishedT(
+          [mocks.vendorUser],
+          mocks.twuOpportunity,
+          false
+        )),
+        ...(await successfulTWUPublicationT(
+          mocks.govUser,
+          mocks.twuOpportunity,
+          false
+        ))
+      ]
+    },
+    {
+      title: "TWU Opportunity Re-published after being suspended",
+      emails: [
+        ...(await newTWUOpportunityPublishedT(
+          [mocks.vendorUser],
+          mocks.publishedTWUOpportunity,
+          true
+        )),
+        ...(await successfulTWUPublicationT(
+          mocks.govUser,
+          mocks.publishedTWUOpportunity,
+          true
+        ))
+      ]
+    },
+    {
+      title: "TWU Opportunity Updated",
+      emails: await updatedTWUOpportunityT(
+        [mocks.vendorUser],
+        mocks.twuOpportunity
+      )
+    },
+    {
+      title: "TWU Opportunity Cancelled",
+      emails: [
+        ...(await cancelledTWUOpportunitySubscribedT(
+          mocks.vendorUser,
+          mocks.twuOpportunity
+        )),
+        ...(await cancelledTWUOpportunityActionedT(
+          mocks.govUser,
+          mocks.twuOpportunity
+        ))
+      ]
+    },
+    {
+      title: "TWU Opportunity Suspended",
+      emails: [
+        ...(await suspendedTWUOpportunitySubscribedT(
+          mocks.vendorUser,
+          mocks.twuOpportunity
+        )),
+        ...(await suspendedTWUOpportunityActionedT(
+          mocks.govUser,
+          mocks.twuOpportunity
+        ))
+      ]
+    },
+    {
+      title: "TWU Opportunity Proposal Deadline Passed",
+      emails: await readyForEvalTWUOpportunityT(
+        mocks.govUser,
+        mocks.twuOpportunity
+      )
+    },
+    {
+      title: "TWU Proposal Submitted",
+      emails: await successfulTWUProposalSubmissionT(
+        mocks.vendorUser,
+        mocks.twuOpportunity,
+        mocks.twuProposal
+      )
+    },
+    {
+      title: "TWU Proposal Awarded",
+      emails: [
+        ...(await awardedTWUProposalSubmissionT(
+          mocks.vendorUser,
+          mocks.twuOpportunity,
+          mocks.twuProposal
+        )),
+        ...(await unsuccessfulTWUProposalSubmissionT(
+          mocks.vendorUser,
+          mocks.twuOpportunity,
+          mocks.twuProposal
+        ))
+      ]
+    },
+    {
+      title: "TWU Proposal Withdrawn",
+      emails: [
+        ...(await withdrawnTWUProposalSubmissionProposalAuthorT(
+          mocks.vendorUser,
+          mocks.twuOpportunity
+        )),
+        ...(await withdrawnTWUProposalSubmissionT(
+          mocks.govUser,
+          mocks.vendorUser,
+          mocks.twuOpportunity
         ))
       ]
     },

--- a/src/back-end/lib/routers/admin/mocks.ts
+++ b/src/back-end/lib/routers/admin/mocks.ts
@@ -21,6 +21,13 @@ import {
   SWUTeamQuestion
 } from "shared/lib/resources/opportunity/sprint-with-us";
 import {
+  TWUOpportunity,
+  TWUOpportunitySlim,
+  TWUOpportunityStatus,
+  TWUServiceArea,
+  TWUResourceQuestion
+} from "shared/lib/resources/opportunity/team-with-us";
+import {
   Organization,
   OrganizationSlim
 } from "shared/lib/resources/organization";
@@ -34,6 +41,10 @@ import {
   SWUProposalStatus,
   SWUProposalTeamQuestionResponse
 } from "shared/lib/resources/proposal/sprint-with-us";
+import {
+  TWUProposal,
+  TWUProposalStatus
+} from "shared/lib/resources/proposal/team-with-us";
 import {
   User,
   UserSlim,
@@ -308,4 +319,93 @@ export const affiliation: Affiliation = {
   organization,
   membershipType: MembershipType.Member,
   membershipStatus: MembershipStatus.Active
+};
+
+export const twuResourceQuestion: TWUResourceQuestion = {
+  question: "Question",
+  guideline: "Guideline",
+  score: 5,
+  wordLimit: 300,
+  order: 1,
+  createdAt: date,
+  createdBy: vendorUserSlim
+};
+
+export const twuOpportunity: TWUOpportunity = {
+  id,
+  createdAt: date,
+  updatedAt: date,
+  title: "TWU Title",
+  teaser: "",
+  remoteOk: true,
+  remoteDesc: "",
+  location: "Location",
+  maxBudget: 1500000,
+  description: "Description",
+  proposalDeadline: date,
+  assignmentDate: date,
+  startDate: date,
+  completionDate: date,
+  questionsWeight: 20,
+  challengeWeight: 30,
+  priceWeight: 20,
+  status: TWUOpportunityStatus.Published,
+  resourceQuestions: [twuResourceQuestion],
+  resources: [
+    {
+      id,
+      serviceArea: TWUServiceArea.DataProfessional,
+      targetAllocation: 100,
+      mandatorySkills: ["Mandatory Skill"],
+      optionalSkills: [],
+      order: 1
+    }
+  ],
+  successfulProponent: {
+    id,
+    name: "Successful Proponent",
+    email: "donotreply_DigitalMarketplace@gov.bc.ca",
+    createdBy: vendorUserSlim
+  },
+  attachments: [],
+  addenda: []
+};
+
+export const publishedTWUOpportunity: TWUOpportunity = {
+  ...twuOpportunity,
+  publishedAt: date
+};
+
+export const twuOpportunitySlim: TWUOpportunitySlim = {
+  id: twuOpportunity.id,
+  title: twuOpportunity.title,
+  teaser: twuOpportunity.teaser,
+  remoteOk: twuOpportunity.remoteOk,
+  location: twuOpportunity.location,
+  maxBudget: twuOpportunity.maxBudget,
+  createdAt: twuOpportunity.createdAt,
+  updatedAt: twuOpportunity.updatedAt,
+  status: twuOpportunity.status,
+  proposalDeadline: twuOpportunity.proposalDeadline
+};
+
+export const twuProposal: TWUProposal = {
+  id,
+  createdBy: vendorUserSlim,
+  createdAt: date,
+  updatedBy: vendorUserSlim,
+  updatedAt: date,
+  opportunity: twuOpportunitySlim,
+  status: TWUProposalStatus.Submitted,
+  attachments: [],
+  resourceQuestionResponses: [],
+  team: [
+    {
+      member: vendorUserSlim,
+      idpUsername: "vendor_user",
+      hourlyRate: 100,
+      resource: id
+    }
+  ],
+  anonymousProponentName: "Proponent 1"
 };


### PR DESCRIPTION
This PR closes issue: [issue #DMM-481]

Includes tests? [N]
Updated docs? [N]

Proposed changes:
- Added 'Estimated' before contract dates for Code with us
- Restructured template for awarded opportunities to surface the winner more obviously
- Changed email title and subtitle from 'closed' to 'awarded'
- Added missing email mocks to admin page for code with us emails and notifications

Additional notes:
- Needed to create a separate template as the original simple template did not have the flexibility to allow a custom layout where the "Awarded to" text is displayed between the title and the opportunity details.
