### PR TITLE
Refactor/populate evaluations migration

### DIFF
--- a/src/back-end/lib/db/evaluations/sprint-with-us/team-questions.ts
+++ b/src/back-end/lib/db/evaluations/sprint-with-us/team-questions.ts
@@ -192,7 +192,10 @@ export const readManySWUTeamQuestionResponseEvaluations = tryDb<
   )
     .join("swuProposals", "swuProposals.id", "=", "evaluations.proposal")
     .where({
-      "evaluations.evaluationPanelMember": session.user.id,
+      // There are many evaluations, but only one consensus
+      ...(consensus
+        ? {}
+        : { "evaluations.evaluationPanelMember": session.user.id }),
       "swuProposals.opportunity": id
     });
 

--- a/src/back-end/lib/permissions.ts
+++ b/src/back-end/lib/permissions.ts
@@ -938,20 +938,21 @@ export async function readManySWUTeamQuestionResponseConsensuses(
 ): Promise<boolean> {
   return (
     !!session &&
-    (isAdmin(session) || isGovernment(session)) &&
-    (doesSWUOpportunityStatusAllowGovToViewTeamQuestionResponseEvaluations(
-      opportunity.status
-    ) ||
-      (await isSWUOpportunityEvaluationPanelEvaluator(
-        connection,
-        session,
-        opportunity.id
-      )) ||
-      (await isSWUOpportunityEvaluationPanelChair(
-        connection,
-        session,
-        opportunity.id
-      )))
+    (isAdmin(session) ||
+      (isGovernment(session) &&
+        (doesSWUOpportunityStatusAllowGovToViewTeamQuestionResponseEvaluations(
+          opportunity.status
+        ) ||
+          (await isSWUOpportunityEvaluationPanelEvaluator(
+            connection,
+            session,
+            opportunity.id
+          )) ||
+          (await isSWUOpportunityEvaluationPanelChair(
+            connection,
+            session,
+            opportunity.id
+          )))))
   );
 }
 

--- a/src/back-end/lib/permissions.ts
+++ b/src/back-end/lib/permissions.ts
@@ -901,13 +901,14 @@ export async function readOneSWUTeamQuestionResponseConsensus(
 ): Promise<boolean> {
   return (
     !!session &&
-    (isAdmin(session) || isGovernment(session)) &&
-    (doesSWUOpportunityStatusAllowGovToViewTeamQuestionResponseEvaluations(
-      evaluation.proposal.opportunity.status
-    ) ||
-      (evaluation.proposal.opportunity.status ===
-        SWUOpportunityStatus.EvaluationTeamQuestionsConsensus &&
-        evaluation.evaluationPanelMember.user.id === session.user.id))
+    (isAdmin(session) ||
+      (isGovernment(session) &&
+        (doesSWUOpportunityStatusAllowGovToViewTeamQuestionResponseEvaluations(
+          evaluation.proposal.opportunity.status
+        ) ||
+          (evaluation.proposal.opportunity.status ===
+            SWUOpportunityStatus.EvaluationTeamQuestionsConsensus &&
+            evaluation.evaluationPanelMember.user.id === session.user.id))))
   );
 }
 
@@ -963,22 +964,23 @@ export async function readManySWUTeamQuestionResponseEvaluationsForConsensus(
 ): Promise<boolean> {
   return (
     !!session &&
-    (isAdmin(session) || isGovernment(session)) &&
-    (doesSWUOpportunityStatusAllowGovToViewTeamQuestionResponseEvaluations(
-      proposal.opportunity.status
-    ) ||
-      (proposal.opportunity.status ===
-        SWUOpportunityStatus.EvaluationTeamQuestionsConsensus &&
-        ((await isSWUOpportunityEvaluationPanelEvaluator(
-          connection,
-          session,
-          proposal.opportunity.id
-        )) ||
-          (await isSWUOpportunityEvaluationPanelChair(
-            connection,
-            session,
-            proposal.opportunity.id
-          )))))
+    (isAdmin(session) ||
+      (isGovernment(session) &&
+        (doesSWUOpportunityStatusAllowGovToViewTeamQuestionResponseEvaluations(
+          proposal.opportunity.status
+        ) ||
+          (proposal.opportunity.status ===
+            SWUOpportunityStatus.EvaluationTeamQuestionsConsensus &&
+            ((await isSWUOpportunityEvaluationPanelEvaluator(
+              connection,
+              session,
+              proposal.opportunity.id
+            )) ||
+              (await isSWUOpportunityEvaluationPanelChair(
+                connection,
+                session,
+                proposal.opportunity.id
+              )))))))
   );
 }
 

--- a/src/front-end/typescript/lib/pages/opportunity/sprint-with-us/edit/tab/consensus.tsx
+++ b/src/front-end/typescript/lib/pages/opportunity/sprint-with-us/edit/tab/consensus.tsx
@@ -243,7 +243,7 @@ const ContextMenuCell: component_.base.View<{
       )}>
       {isChair ? "Edit" : "View"}
     </Link>
-  ) : (
+  ) : isChair ? (
     <Link
       disabled={disabled}
       dest={routeDest(
@@ -251,7 +251,7 @@ const ContextMenuCell: component_.base.View<{
       )}>
       Start Evaluation
     </Link>
-  );
+  ) : null;
 };
 
 interface ProponentCellProps {

--- a/src/front-end/typescript/lib/pages/opportunity/sprint-with-us/edit/tab/consensus.tsx
+++ b/src/front-end/typescript/lib/pages/opportunity/sprint-with-us/edit/tab/consensus.tsx
@@ -43,7 +43,7 @@ import { isValid } from "shared/lib/validation";
 import { validateSWUTeamQuestionResponseEvaluationScores } from "shared/lib/validation/evaluations/sprint-with-us/team-questions";
 import { isAdmin } from "shared/lib/resources/user";
 
-type ModalId = "submit";
+type ModalId = "submit" | "complete";
 
 export interface State extends Tab.Params {
   opportunity: SWUOpportunity | null;
@@ -522,6 +522,36 @@ export const component: Tab.Component<State, Msg> = {
             "By submitting this consensus, you, as the chair, along with the" +
             "panelists, confirm your agreement with the consensus scores and" +
             "comments."
+        });
+      case "complete":
+        return component_.page.modal.show({
+          title: "Please Confirm",
+          onCloseMsg: adt("hideModal") as Msg,
+          actions: [
+            {
+              text: "Submit Final Consensus Scores",
+              icon: "paper-plane",
+              color: "info",
+              button: true,
+              msg: adt("hideModal") as Msg
+            },
+            {
+              text: "Cancel",
+              color: "secondary",
+              msg: adt("hideModal")
+            }
+          ],
+          body: () => (
+            <>
+              <p className="mb-4">
+                By submitting final consensus scores, you are about to lock in
+                all proponent scores and move on to short-listing stage
+              </p>
+              <p className="mb-0">
+                Are you sure you want to submit final consensus scores?
+              </p>
+            </>
+          )
         });
       case null:
         return component_.page.modal.hide();

--- a/src/front-end/typescript/lib/pages/opportunity/sprint-with-us/edit/tab/index.ts
+++ b/src/front-end/typescript/lib/pages/opportunity/sprint-with-us/edit/tab/index.ts
@@ -16,8 +16,9 @@ import * as InstructionsTab from "front-end/lib/pages/opportunity/sprint-with-us
 import { routeDest } from "front-end/lib/views/link";
 import {
   canAddAddendumToSWUOpportunity,
-  canViewSWUEvaluationConsensus,
-  SWUOpportunity
+  doesSWUOpportunityStatusAllowGovToViewTeamQuestionResponseEvaluations,
+  SWUOpportunity,
+  SWUOpportunityStatus
 } from "shared/lib/resources/opportunity/sprint-with-us";
 import { User } from "shared/lib/resources/user";
 import { adt, Id } from "shared/lib/types";
@@ -189,7 +190,16 @@ export function canGovUserViewTab(
     case "overview":
       return isEvaluator;
     case "consensus":
-      return isChair || canViewSWUEvaluationConsensus(opportunity.status);
+      return (
+        isChair ||
+        isOpportunityOwnerOrAdmin ||
+        (isEvaluator &&
+          opportunity.status ===
+            SWUOpportunityStatus.EvaluationTeamQuestionsConsensus) ||
+        doesSWUOpportunityStatusAllowGovToViewTeamQuestionResponseEvaluations(
+          opportunity.status
+        )
+      );
   }
 }
 

--- a/src/front-end/typescript/lib/pages/proposal/sprint-with-us/view/tab/team-questions.tsx
+++ b/src/front-end/typescript/lib/pages/proposal/sprint-with-us/view/tab/team-questions.tsx
@@ -69,6 +69,7 @@ export interface State extends Tab.Params {
   openAccordions: Set<number>;
   evaluationScores: EvaluationScore[];
   isEditing: boolean;
+  isAuthor: boolean;
 }
 
 export type InnerMsg =
@@ -233,7 +234,10 @@ export const init: component_.base.Init<Tab.Params, State, Msg> = (params) => {
         params.proposal.teamQuestionResponses.map((p, i) => i)
       ),
       evaluationScores: evaluationScoreStates,
-      isEditing: !params.questionEvaluation
+      isEditing: !params.questionEvaluation,
+      isAuthor:
+        params.questionEvaluation?.evaluationPanelMember.user.id ===
+        params.viewerUser.id
     },
     evaluationScoreCmds
   ];
@@ -1395,7 +1399,11 @@ const TeamQuestionResponsesChairEvalView: component_.base.View<{
                     response={r}
                     score={state.evaluationScores[i]}
                     dispatch={dispatch}
-                    disabled={!state.isEditing || isLoading}
+                    disabled={
+                      !state.isEditing ||
+                      isLoading ||
+                      Boolean(state.questionEvaluation && !state.isAuthor)
+                    }
                     panelEvaluationScores={state.panelQuestionEvaluations}
                   />
                 ))}
@@ -1540,17 +1548,19 @@ export const component: Tab.Component<State, Msg> = {
         return component_.page.actions.links(
           state.evaluating
             ? state.questionEvaluation
-              ? [
-                  {
-                    children: "Edit",
-                    onClick: () => dispatch(adt("startEditingConsensus")),
-                    button: true,
-                    loading: isStartEditingLoading,
-                    disabled: isLoading,
-                    symbol_: leftPlacement(iconLinkSymbol("edit")),
-                    color: "primary"
-                  }
-                ]
+              ? state.isAuthor
+                ? [
+                    {
+                      children: "Edit",
+                      onClick: () => dispatch(adt("startEditingConsensus")),
+                      button: true,
+                      loading: isStartEditingLoading,
+                      disabled: isLoading,
+                      symbol_: leftPlacement(iconLinkSymbol("edit")),
+                      color: "primary"
+                    }
+                  ]
+                : []
               : [
                   {
                     children: "Save Draft",

--- a/src/migrations/tasks/20240527213854_add-evaluation-committee-panel-tables.ts
+++ b/src/migrations/tasks/20240527213854_add-evaluation-committee-panel-tables.ts
@@ -59,7 +59,6 @@ export async function up(connection: Knex): Promise<void> {
       "evaluator" = true OR "chair" = true
     )
   `);
-
   logger.info("Created swuEvaluationPanelMembers table.");
 
   const swuOpportunitiesQuery = connection("swuOpportunities as opportunities")
@@ -95,12 +94,11 @@ export async function up(connection: Knex): Promise<void> {
       swuOpportunitiesQuery.select(
         "versions.id as opportunityVersion",
         "opportunities.createdBy as user",
-        connection.raw("(SELECT true as chair)"),
-        connection.raw("(SELECT true as evaluator)"),
-        connection.raw("(SELECT 0 as order)")
+        connection.raw("true as chair"),
+        connection.raw("true as evaluator"),
+        connection.raw("0 as order")
       )
     );
-
   logger.info("Ported opportunity creator to SWU evaluation panel chair");
 
   await connection
@@ -115,20 +113,15 @@ export async function up(connection: Knex): Promise<void> {
       ])
     )
     .insert(
-      swuOpportunitiesQuery.clearSelect().select(
-        "versions.id as opportunityVersion",
-        connection.raw("??", [
-          connection("users")
-            .select("id")
-            .where({
-              idpUsername: MIGRATION_IDP_USERNAME
-            })
-            .as("user")
-        ]),
-        connection.raw("(SELECT false as chair)"),
-        connection.raw("(SELECT true as evaluator)"),
-        connection.raw("(SELECT 1 as order)")
-      )
+      swuOpportunitiesQuery
+        .clearSelect()
+        .select(
+          "versions.id as opportunityVersion",
+          connection.raw("? as user", [id]),
+          connection.raw("false as chair"),
+          connection.raw("true as evaluator"),
+          connection.raw("1 as order")
+        )
     );
 
   logger.info("Added migration user as SWU evaluation panel evaluator");
@@ -158,7 +151,6 @@ export async function up(connection: Knex): Promise<void> {
       "evaluator" = true OR "chair" = true
     )
   `);
-
   logger.info("Created twuEvaluationPanelMembers table.");
 
   const twuOpportunitiesQuery = connection("twuOpportunities as opportunities")
@@ -194,12 +186,11 @@ export async function up(connection: Knex): Promise<void> {
       twuOpportunitiesQuery.select(
         "versions.id as opportunityVersion",
         "opportunities.createdBy as user",
-        connection.raw("(SELECT true as chair)"),
-        connection.raw("(SELECT true as evaluator)"),
-        connection.raw("(SELECT 0 as order)")
+        connection.raw("true as chair"),
+        connection.raw("true as evaluator"),
+        connection.raw("0 as order")
       )
     );
-
   logger.info("Ported opportunity creator to TWU evaluation panel chair");
 
   await connection
@@ -214,22 +205,16 @@ export async function up(connection: Knex): Promise<void> {
       ])
     )
     .insert(
-      twuOpportunitiesQuery.clearSelect().select(
-        "versions.id as opportunityVersion",
-        connection.raw("??", [
-          connection("users")
-            .select("id")
-            .where({
-              idpUsername: MIGRATION_IDP_USERNAME
-            })
-            .as("user")
-        ]),
-        connection.raw("(SELECT false as chair)"),
-        connection.raw("(SELECT true as evaluator)"),
-        connection.raw("(SELECT 1 as order)")
-      )
+      twuOpportunitiesQuery
+        .clearSelect()
+        .select(
+          "versions.id as opportunityVersion",
+          connection.raw("? as user", [id]),
+          connection.raw("false as chair"),
+          connection.raw("true as evaluator"),
+          connection.raw("1 as order")
+        )
     );
-
   logger.info("Added migration user as TWU evaluation panel evaluator");
 }
 

--- a/src/migrations/tasks/20240527213854_add-evaluation-committee-panel-tables.ts
+++ b/src/migrations/tasks/20240527213854_add-evaluation-committee-panel-tables.ts
@@ -19,6 +19,7 @@ export async function up(connection: Knex): Promise<void> {
       type: UserType.Government,
       status: UserStatus.Active,
       name: MIGRATION_IDP_USERNAME.toUpperCase(),
+      email: `${MIGRATION_IDP_USERNAME}@gov.bc.ca`,
       idpUsername: MIGRATION_IDP_USERNAME,
       idpId: MIGRATION_IDP_USERNAME
     },

--- a/src/migrations/tasks/20240527213854_add-evaluation-committee-panel-tables.ts
+++ b/src/migrations/tasks/20240527213854_add-evaluation-committee-panel-tables.ts
@@ -1,10 +1,39 @@
+import { generateUuid } from "back-end/lib";
 import { makeDomainLogger } from "back-end/lib/logger";
 import { console as consoleAdapter } from "back-end/lib/logger/adapters";
 import { Knex } from "knex";
+import { UserStatus, UserType } from "shared/lib/resources/user";
 
 const logger = makeDomainLogger(consoleAdapter, "migrations");
 
+const MIGRATION_IDP_USERNAME = "migration_evaluation_panel_member";
+
 export async function up(connection: Knex): Promise<void> {
+  const now = new Date();
+  const id = generateUuid();
+  await connection("users").insert(
+    {
+      id,
+      createdAt: now,
+      updatedAt: now,
+      type: UserType.Government,
+      status: UserStatus.Active,
+      name: MIGRATION_IDP_USERNAME.toUpperCase(),
+      idpUsername: MIGRATION_IDP_USERNAME,
+      idpId: MIGRATION_IDP_USERNAME
+    },
+    [
+      "id",
+      "createdAt",
+      "updatedAt",
+      "type",
+      "status",
+      "name",
+      "idpUsername",
+      "idpId"
+    ]
+  );
+
   await connection.schema.createTable("swuEvaluationPanelMembers", (table) => {
     table
       .uuid("opportunityVersion")
@@ -32,6 +61,77 @@ export async function up(connection: Knex): Promise<void> {
   `);
 
   logger.info("Created swuEvaluationPanelMembers table.");
+
+  const swuOpportunitiesQuery = connection("swuOpportunities as opportunities")
+    .join(
+      connection.raw(
+        "(??) as versions",
+        connection("swuOpportunityVersions")
+          .select("opportunity", "id")
+          .rowNumber("rn", function () {
+            this.orderBy("createdAt", "desc").partitionBy("opportunity");
+          })
+      ),
+      function () {
+        this.on("opportunities.id", "=", "versions.opportunity");
+      }
+    )
+    .where({
+      "versions.rn": 1
+    });
+
+  await connection
+    .from(
+      connection.raw("?? (??, ??, ??, ??, ??)", [
+        "swuEvaluationPanelMembers",
+        "opportunityVersion",
+        "user",
+        "chair",
+        "evaluator",
+        "order"
+      ])
+    )
+    .insert(
+      swuOpportunitiesQuery.select(
+        "versions.id as opportunityVersion",
+        "opportunities.createdBy as user",
+        connection.raw("(SELECT true as chair)"),
+        connection.raw("(SELECT true as evaluator)"),
+        connection.raw("(SELECT 0 as order)")
+      )
+    );
+
+  logger.info("Ported opportunity creator to SWU evaluation panel chair");
+
+  await connection
+    .from(
+      connection.raw("?? (??, ??, ??, ??, ??)", [
+        "swuEvaluationPanelMembers",
+        "opportunityVersion",
+        "user",
+        "chair",
+        "evaluator",
+        "order"
+      ])
+    )
+    .insert(
+      swuOpportunitiesQuery.clearSelect().select(
+        "versions.id as opportunityVersion",
+        connection.raw("??", [
+          connection("users")
+            .select("id")
+            .where({
+              idpUsername: MIGRATION_IDP_USERNAME
+            })
+            .as("user")
+        ]),
+        connection.raw("(SELECT false as chair)"),
+        connection.raw("(SELECT true as evaluator)"),
+        connection.raw("(SELECT 1 as order)")
+      )
+    );
+
+  logger.info("Added migration user as SWU evaluation panel evaluator");
 
   await connection.schema.createTable("twuEvaluationPanelMembers", (table) => {
     table
@@ -63,6 +163,10 @@ export async function up(connection: Knex): Promise<void> {
 }
 
 export async function down(connection: Knex): Promise<void> {
+  await connection("users")
+    .where({ idpUsername: MIGRATION_IDP_USERNAME })
+    .del();
+
   await connection.schema.dropTable("swuEvaluationPanelMembers");
   logger.info("Dropped table swuEvaluationPanelMembers");
 

--- a/src/migrations/tasks/20240718222006_swu-evaluation-tables.ts
+++ b/src/migrations/tasks/20240718222006_swu-evaluation-tables.ts
@@ -155,7 +155,7 @@ export async function up(connection: Knex): Promise<void> {
       .onDelete("CASCADE");
     table.timestamp("createdAt").notNullable();
     table.timestamp("updatedAt").notNullable();
-    table.float("score").notNullable();
+    table.float("score");
     table.text("notes").notNullable();
     table.primary(["proposal", "evaluationPanelMember", "questionOrder"]);
   }

--- a/src/shared/lib/resources/opportunity/sprint-with-us.ts
+++ b/src/shared/lib/resources/opportunity/sprint-with-us.ts
@@ -780,21 +780,10 @@ export function doesSWUOpportunityStatusAllowGovToViewTeamQuestionResponseEvalua
   s: SWUOpportunityStatus
 ): boolean {
   switch (s) {
-    case SWUOpportunityStatus.EvaluationTeamQuestions:
     case SWUOpportunityStatus.EvaluationCodeChallenge:
     case SWUOpportunityStatus.EvaluationTeamScenario:
     case SWUOpportunityStatus.Awarded:
       return true;
-    default:
-      return false;
-  }
-}
-
-export function canViewSWUEvaluationConsensus(
-  s: SWUOpportunityStatus
-): boolean {
-  switch (s) {
-    // TODO: Add statuses
     default:
       return false;
   }


### PR DESCRIPTION
Schema changes to allow for backwards compatibility; relevant changes were made to: src/migrations/tasks/20240527213854_add-evaluation-committee-panel-tables.ts and src/migrations/tasks/20240718222006_swu-evaluation-tables.ts

NOTE: swuTeamQuestionResponses still have a score column; I'd prefer to not delete the column on the off chance that we need to migrate back, but was figuring we could rename it to denote that it's deprecated?