### PR TITLE
feat: evaluations tab for gov users

### DIFF
--- a/src/back-end/lib/db/opportunity/sprint-with-us.ts
+++ b/src/back-end/lib/db/opportunity/sprint-with-us.ts
@@ -619,18 +619,33 @@ export const readManyTeamQuestions = tryDb<[Id], SWUTeamQuestion[]>(
   }
 );
 
-export const readManySWUOpportunities = tryDb<[Session], SWUOpportunitySlim[]>(
-  async (connection, session) => {
-    let query = generateSWUOpportunityQuery(connection);
+export const readManySWUOpportunities = tryDb<
+  [Session, boolean?],
+  SWUOpportunitySlim[]
+>(async (connection, session, isPanelMember = false) => {
+  let query = generateSWUOpportunityQuery(connection);
 
-    if (!session || session.user.type === UserType.Vendor) {
-      // Anonymous users and vendors can only see public opportunities
-      query = query.whereIn(
-        "statuses.status",
-        publicOpportunityStatuses as SWUOpportunityStatus[]
-      );
+  if (!session || session.user.type === UserType.Vendor) {
+    // Anonymous users and vendors can only see public opportunities
+    query = query.whereIn(
+      "statuses.status",
+      publicOpportunityStatuses as SWUOpportunityStatus[]
+    );
+  } else if (
+    session.user.type === UserType.Government ||
+    session.user.type === UserType.Admin
+  ) {
+    if (isPanelMember) {
+      // When isPanelMember=true, ONLY include opportunities where user is on evaluation panel
+      // works for admin and gov basic users
+      query = query.whereIn("versions.id", function () {
+        this.select("opportunityVersion")
+          .from("swuEvaluationPanelMembers")
+          .where("user", "=", session.user.id);
+      });
     } else if (session.user.type === UserType.Government) {
-      // Gov basic users should only see private opportunities that they own, and public opportunities
+      // Regular behavior - show public opportunities and private ones the user created
+      // works for gov basic users only
       query = query
         .whereIn(
           "statuses.status",
@@ -643,33 +658,33 @@ export const readManySWUOpportunities = tryDb<[Session], SWUOpportunitySlim[]>(
           ).andWhere({ "opportunities.createdBy": session.user?.id });
         });
     }
-    // Admins can see all opportunities, so no additional filter necessary if none of the previous conditions match
-    // Process results to eliminate fields not viewable by the current role
-    const results = await Promise.all(
-      (
-        await query
-      ).map(async (result: RawSWUOpportunity | RawSWUOpportunitySlim) => {
-        if (session) {
-          result.subscribed = await isSubscribed(
-            connection,
-            result.id,
-            session.user.id
-          );
-        }
-        return processForRole(result, session);
-      })
-    );
-
-    return valid(
-      await Promise.all(
-        results.map(
-          async (raw) =>
-            await rawSWUOpportunitySlimToSWUOpportunitySlim(connection, raw)
-        )
-      )
-    );
   }
-);
+  // Admins can see all opportunities, so no additional filter necessary if none of the previous conditions match
+  // Process results to eliminate fields not viewable by the current role
+  const results = await Promise.all(
+    (
+      await query
+    ).map(async (result: RawSWUOpportunity | RawSWUOpportunitySlim) => {
+      if (session) {
+        result.subscribed = await isSubscribed(
+          connection,
+          result.id,
+          session.user.id
+        );
+      }
+      return processForRole(result, session);
+    })
+  );
+
+  return valid(
+    await Promise.all(
+      results.map(
+        async (raw) =>
+          await rawSWUOpportunitySlimToSWUOpportunitySlim(connection, raw)
+      )
+    )
+  );
+});
 
 export const readOneSWUOpportunityPhase = tryDb<[Id], SWUOpportunityPhase>(
   async (connection, id) => {

--- a/src/back-end/lib/resources/opportunity/sprint-with-us/index.ts
+++ b/src/back-end/lib/resources/opportunity/sprint-with-us/index.ts
@@ -163,9 +163,14 @@ const readMany: crud.ReadMany<Session, db.Connection> = (
   >(async (request) => {
     const respond = (code: number, body: SWUOpportunitySlim[] | string[]) =>
       basicResponse(code, request.session, makeJsonResponseBody(body));
+
+    // Read and validate the panelMember flag
+    const isPanelMember = request.query.panelMember === "true";
+
     const dbResult = await db.readManySWUOpportunities(
       connection,
-      request.session
+      request.session,
+      isPanelMember
     );
     if (isInvalid(dbResult)) {
       return respond(503, [db.ERROR_MESSAGE]);

--- a/src/front-end/typescript/lib/http/api/opportunity/sprint-with-us/index.ts
+++ b/src/front-end/typescript/lib/http/api/opportunity/sprint-with-us/index.ts
@@ -26,7 +26,7 @@ export function readMany<Msg>(
   query?: string
 ): crud.ReadManyAction<Resource.SWUOpportunitySlim, string[], Msg> {
   return crud.makeReadManyAction(
-    query ? `${NAMESPACE}${query}` : NAMESPACE,
+    `${NAMESPACE}${query ?? ""}`,
     (a: Resource.SWUOpportunitySlim) => a
   );
 }

--- a/src/front-end/typescript/lib/http/api/opportunity/sprint-with-us/index.ts
+++ b/src/front-end/typescript/lib/http/api/opportunity/sprint-with-us/index.ts
@@ -26,8 +26,9 @@ export function readMany<Msg>(
   query?: string
 ): crud.ReadManyAction<Resource.SWUOpportunitySlim, string[], Msg> {
   return crud.makeReadManyAction(
-    `${NAMESPACE}${query ?? ""}`,
-    (a: Resource.SWUOpportunitySlim) => a
+    NAMESPACE,
+    (a: Resource.SWUOpportunitySlim) => a,
+    query
   );
 }
 

--- a/src/front-end/typescript/lib/http/api/opportunity/sprint-with-us/index.ts
+++ b/src/front-end/typescript/lib/http/api/opportunity/sprint-with-us/index.ts
@@ -22,13 +22,11 @@ export function create<Msg>(): crud.CreateAction<
   return crud.makeCreateAction(NAMESPACE, rawSWUOpportunityToSWUOpportunity);
 }
 
-export function readMany<Msg>(): crud.ReadManyAction<
-  Resource.SWUOpportunitySlim,
-  string[],
-  Msg
-> {
+export function readMany<Msg>(
+  query?: string
+): crud.ReadManyAction<Resource.SWUOpportunitySlim, string[], Msg> {
   return crud.makeReadManyAction(
-    NAMESPACE,
+    query ? `${NAMESPACE}${query}` : NAMESPACE,
     (a: Resource.SWUOpportunitySlim) => a
   );
 }

--- a/src/front-end/typescript/lib/pages/dashboard.tsx
+++ b/src/front-end/typescript/lib/pages/dashboard.tsx
@@ -273,6 +273,57 @@ function makePublicSectorBodyRows(
     });
 }
 
+function makePanelBodyRows(
+  swuOpportunities: SWUO.SWUOpportunitySlim[],
+  _viewerUser: User
+): Table.BodyRows {
+  return swuOpportunities
+    .sort((a, b) => compareDates(a.createdAt, b.createdAt) * -1)
+    .map((opportunity) => {
+      return [
+        {
+          children: (
+            <div>
+              <Link
+                dest={routeDest(
+                  adt("opportunitySWUEdit" as const, {
+                    opportunityId: opportunity.id
+                  })
+                )}>
+                {opportunity.title || "Untitled Sprint With Us Opportunity"}
+              </Link>
+              <div className="small text-secondary text-uppercase">
+                Sprint With Us
+              </div>
+            </div>
+          )
+        },
+        {
+          children: (
+            <Badge
+              color={oppHelpers(
+                adt("swu" as const, opportunity)
+              ).dashboard.getOppStatusColor(opportunity.status)}
+              text={oppHelpers(
+                adt("swu" as const, opportunity)
+              ).dashboard.getOppStatusText(opportunity.status)}
+            />
+          )
+        },
+        {
+          children: (
+            <div>
+              {formatDate(opportunity.createdAt)}
+              <div className="small text-secondary text-uppercase">
+                {opportunity.createdBy?.name}
+              </div>
+            </div>
+          )
+        }
+      ];
+    });
+}
+
 const init: component_.page.Init<
   RouteParams,
   SharedState,
@@ -503,12 +554,7 @@ const update: component_.page.Update<State, InnerMsg, Route> = updateValid(
                 )
                 .setIn(
                   ["panelTable", "bodyRows"],
-                  makePublicSectorBodyRows(
-                    [],
-                    panelOpportunities,
-                    [],
-                    state.viewerUser
-                  )
+                  makePanelBodyRows(panelOpportunities, state.viewerUser)
                 ),
               [component_.cmd.dispatch(component_.page.readyMsg())]
             ];
@@ -666,7 +712,7 @@ const GovTabs: component_.base.View<GovTabsProps> = ({
     },
     {
       ...getTabInfo("panel-opportunities"),
-      text: "Panel Opportunities"
+      text: "Evaluations"
     }
   ];
 

--- a/src/front-end/typescript/lib/pages/dashboard.tsx
+++ b/src/front-end/typescript/lib/pages/dashboard.tsx
@@ -78,10 +78,21 @@ interface ValidState {
     bodyRows: Table.BodyRows;
     state: Immutable<Table.State>;
   };
+  panelTable: {
+    title: string;
+    link?: {
+      text: string;
+      route: Route;
+    };
+    headCells: Table.HeadCells;
+    bodyRows: Table.BodyRows;
+    state: Immutable<Table.State>;
+  };
   viewerUser: User;
   isSWUQualified?: boolean;
   isTWUQualified?: boolean;
   activeProposalsTab: ProposalsTab;
+  activeTab: "my-opportunities" | "panel-opportunities";
 }
 
 export type State = Validation<Immutable<ValidState>, null>;
@@ -104,14 +115,16 @@ type InitResponse =
       [
         CWUO.CWUOpportunitySlim[],
         SWUO.SWUOpportunitySlim[],
-        TWUO.TWUOpportunitySlim[]
+        TWUO.TWUOpportunitySlim[],
+        SWUO.SWUOpportunitySlim[]
       ]
     >;
 
 export type InnerMsg =
   | ADT<"table", Table.Msg>
   | ADT<"onInitResponse", InitResponse>
-  | ADT<"setActiveProposalsTab", ProposalsTab>;
+  | ADT<"setActiveProposalsTab", ProposalsTab>
+  | ADT<"setActiveTab", "my-opportunities" | "panel-opportunities">;
 
 export type Msg = component_.page.Msg<InnerMsg, Route>;
 
@@ -299,7 +312,8 @@ const init: component_.page.Init<
         immutable({
           isSWUQualified: false,
           isTWUQualified: false,
-          activeProposalsTab: "my-proposals",
+          activeProposalsTab: "my-proposals", // active tab for vendor
+          activeTab: "my-opportunities", // active tab for public sector
           viewerUser,
           table: {
             title,
@@ -324,6 +338,16 @@ const init: component_.page.Init<
                   text: "View all opportunities",
                   route: adt("opportunities", null)
                 }
+          },
+          panelTable: {
+            title: "Evaluations",
+            headCells,
+            bodyRows,
+            state: immutable(tableState),
+            link: {
+              text: "View all opportunities",
+              route: adt("opportunities", null)
+            }
           }
         })
       ),
@@ -369,7 +393,7 @@ const init: component_.page.Init<
                   ] as const)
                 ) as Msg
             )
-          : component_.cmd.join3(
+          : component_.cmd.join4(
               api.opportunities.cwu.readMany()((response) =>
                 api.getValidValue(response, [])
               ),
@@ -379,10 +403,19 @@ const init: component_.page.Init<
               api.opportunities.twu.readMany()((response) =>
                 api.getValidValue(response, [])
               ),
-              (cwu, swu, twu) =>
+              // get panel opportunities
+              api.opportunities.swu.readMany("?panelMember=true")((response) =>
+                api.getValidValue(response, [])
+              ),
+              (cwu, swu, twu, panelOpps) =>
                 adt(
                   "onInitResponse",
-                  adt("publicSector", [cwu, swu, twu]) as InitResponse
+                  adt("publicSector", [
+                    cwu,
+                    swu,
+                    twu,
+                    panelOpps
+                  ] as const) as InitResponse
                 ) as Msg
             )
       ]
@@ -450,17 +483,30 @@ const update: component_.page.Update<State, InnerMsg, Route> = updateValid(
           }
           case "publicSector":
           default: {
-            const [cwuOpportunities, swuOpportunities, twuOpportunities] =
-              msg.value.value;
+            const [
+              cwuOpportunities,
+              swuOpportunities,
+              twuOpportunities,
+              panelOpportunities
+            ] = msg.value.value;
             return [
               state
-                .set("activeProposalsTab", state.activeProposalsTab)
+                .set("activeTab", state.activeTab)
                 .setIn(
                   ["table", "bodyRows"],
                   makePublicSectorBodyRows(
                     cwuOpportunities,
                     swuOpportunities,
                     twuOpportunities,
+                    state.viewerUser
+                  )
+                )
+                .setIn(
+                  ["panelTable", "bodyRows"],
+                  makePublicSectorBodyRows(
+                    [],
+                    panelOpportunities,
+                    [],
                     state.viewerUser
                   )
                 ),
@@ -471,6 +517,8 @@ const update: component_.page.Update<State, InnerMsg, Route> = updateValid(
       }
       case "setActiveProposalsTab":
         return [state.set("activeProposalsTab", msg.value), []];
+      case "setActiveTab":
+        return [state.set("activeTab", msg.value), []];
       case "table":
         return component_.base.updateChild({
           state,
@@ -523,11 +571,23 @@ const view: component_.page.View<State, InnerMsg, Route> = viewValid(
             <Col xs="12" md="9">
               <div className="rounded-lg bg-white p-4 p-sm-4h shadow-hover">
                 {state.table ? (
-                  <Dashboard
-                    dispatch={dispatch}
-                    viewerUser={state.viewerUser}
-                    table={state.table}
-                  />
+                  state.activeTab === "my-opportunities" ? (
+                    <Dashboard
+                      dispatch={dispatch}
+                      viewerUser={state.viewerUser}
+                      table={state.table}
+                      showTabs={true}
+                      activeTab={state.activeTab}
+                    />
+                  ) : (
+                    <Dashboard
+                      dispatch={dispatch}
+                      viewerUser={state.viewerUser}
+                      table={state.panelTable}
+                      showTabs={true}
+                      activeTab={state.activeTab}
+                    />
+                  )
                 ) : (
                   <Welcome viewerUser={state.viewerUser} />
                 )}
@@ -584,17 +644,59 @@ const Welcome: component_.base.View<Pick<ValidState, "viewerUser">> = ({
   );
 };
 
+// Tabs for government users
+interface GovTabsProps {
+  activeTab: "my-opportunities" | "panel-opportunities";
+  dispatch: component_.base.Dispatch<Msg>;
+}
+
+const GovTabs: component_.base.View<GovTabsProps> = ({
+  activeTab,
+  dispatch
+}) => {
+  const getTabInfo = (tab: "my-opportunities" | "panel-opportunities") => ({
+    active: activeTab === tab,
+    onClick: () => dispatch(adt("setActiveTab", tab))
+  });
+
+  const tabs: Tab[] = [
+    {
+      ...getTabInfo("my-opportunities"),
+      text: "My Opportunities"
+    },
+    {
+      ...getTabInfo("panel-opportunities"),
+      text: "Panel Opportunities"
+    }
+  ];
+
+  return (
+    <Row className="mb-2">
+      <Col xs="12">
+        <TabbedNav tabs={tabs} />
+      </Col>
+    </Row>
+  );
+};
+
 interface DashboardProps extends Pick<ValidState, "viewerUser"> {
   table: Defined<ValidState["table"]>;
   dispatch: component_.base.Dispatch<Msg>;
+  showTabs?: boolean;
+  activeTab?: "my-opportunities" | "panel-opportunities";
 }
 
 const Dashboard: component_.base.View<DashboardProps> = ({
   table,
-  dispatch
+  dispatch,
+  showTabs = false,
+  activeTab
 }) => {
   return (
     <div>
+      {showTabs && activeTab ? (
+        <GovTabs activeTab={activeTab} dispatch={dispatch} />
+      ) : null}
       <div className="d-flex flex-column flex-md-row align-items-start align-items-md-center mb-3">
         <div className="font-weight-bold mr-sm-3">{table.title}</div>
         {table.link ? (

--- a/src/front-end/typescript/lib/pages/dashboard.tsx
+++ b/src/front-end/typescript/lib/pages/dashboard.tsx
@@ -455,7 +455,7 @@ const init: component_.page.Init<
                 api.getValidValue(response, [])
               ),
               // get panel opportunities
-              api.opportunities.swu.readMany("?panelMember=true")((response) =>
+              api.opportunities.swu.readMany("panelMember=true")((response) =>
                 api.getValidValue(response, [])
               ),
               (cwu, swu, twu, panelOpps) =>


### PR DESCRIPTION
This PR closes issue: [issue #NA]

Includes tests? [N]
Updated docs? [N]

Proposed changes:
- added a tabbed view for the government users on the dashboard
- added a new tab "Evaluations" that shows only opportunities on which the user is on the panel