### PR TITLE
Refactor/down migration

### DIFF
--- a/src/front-end/typescript/lib/pages/opportunity/sprint-with-us/edit/tab/consensus.tsx
+++ b/src/front-end/typescript/lib/pages/opportunity/sprint-with-us/edit/tab/consensus.tsx
@@ -24,7 +24,6 @@ import { Badge, Col, Row } from "reactstrap";
 import {
   canViewSWUOpportunityTeamQuestionResponseEvaluations,
   hasSWUOpportunityPassedTeamQuestions,
-  isSWUOpportunityStatusInEvaluation,
   SWUOpportunity,
   SWUOpportunityStatus,
   UpdateValidationErrors
@@ -304,18 +303,9 @@ const update: component_.page.Update<State, InnerMsg, Route> = ({
   }
 };
 
-const NotAvailable: component_.base.ComponentView<State, Msg> = ({ state }) => {
-  const opportunity = state.opportunity;
-  if (!opportunity) return null;
-  if (
-    isSWUOpportunityStatusInEvaluation(opportunity.status) ||
-    state.opportunity.status === SWUOpportunityStatus.Awarded
-  ) {
-    return <div>Evaluators have not completed their evaluations yet.</div>;
-  } else {
-    return <div>No proposals were submitted to this opportunity.</div>;
-  }
-};
+const WaitForConsensus: component_.base.ComponentView<State, Msg> = () => (
+  <div>Evaluators have not completed their evaluations yet.</div>
+);
 
 const ContextMenuCell: component_.base.View<{
   disabled: boolean;
@@ -558,7 +548,7 @@ const view: component_.page.View<State, InnerMsg, Route> = (props) => {
             {state.canViewEvaluations && state.proposals.length ? (
               <ProponentEvaluations {...props} />
             ) : (
-              <NotAvailable {...props} />
+              <WaitForConsensus {...props} />
             )}
           </Col>
         </Row>

--- a/src/migrations/tasks/20240718222006_swu-evaluation-tables.ts
+++ b/src/migrations/tasks/20240718222006_swu-evaluation-tables.ts
@@ -187,7 +187,7 @@ export async function up(connection: Knex): Promise<void> {
     .join("swuEvaluationPanelMembers as members", function () {
       this.on("versions.id", "=", "members.opportunityVersion");
     })
-    .whereNotNull("responses.score")
+    .whereNot("proposals.anonymousProponentName", "")
     .andWhere({
       "versions.rn": 1
     })
@@ -196,8 +196,8 @@ export async function up(connection: Knex): Promise<void> {
       "responses.order as questionOrder",
       "members.user as evaluationPanelMember",
       connection.raw("? as createdAt", [now]),
-      connection.raw(" ? as updatedAt", [now]),
-      "responses.score as score",
+      connection.raw("? as updatedAt", [now]),
+      connection.raw("COALESCE(responses.score, 0) as score"),
       connection.raw("? as notes", [migrationNotes])
     );
 

--- a/src/shared/lib/resources/opportunity/sprint-with-us.ts
+++ b/src/shared/lib/resources/opportunity/sprint-with-us.ts
@@ -579,7 +579,7 @@ export function canViewSWUOpportunityTeamQuestionResponseEvaluations(
   o: SWUOpportunity,
   status: SWUOpportunityStatus
 ): boolean {
-  // Return true if the opportunity has ever had the individual evaluation status.
+  // Return true if the opportunity has ever had the status.
   return (
     !!o.history &&
     o.history.reduce((acc, record) => {


### PR DESCRIPTION
The scores seem to map 1:1 between SWUTeamQuestionResponses and SWUTeamQuestionResponseChairEvaluations, so I think this is all we need to do to preserve them.

Note: We only port proposals with anonymous proponent names; proponents without anonymous proponent names have null scores, so there is nothing to repopulate when the score column added back to SWUTeamQuestionResponses.
