### PR TITLE
chore: bump setup-node to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v4
         with:
           node-version: "16"
           cache: "yarn"


### PR DESCRIPTION
This PR closes issue: N/A

Includes tests? N
Updated docs? N

Proposed changes:
- Bump setup-node to v4