### PR TITLE
fix: show cancel action for opportunities in Processing status

### DIFF
--- a/src/front-end/typescript/lib/pages/opportunity/code-with-us/edit/tab/opportunity.tsx
+++ b/src/front-end/typescript/lib/pages/opportunity/code-with-us/edit/tab/opportunity.tsx
@@ -1128,6 +1128,7 @@ export const component: Tab.Component<State, Msg> = {
           return component_.page.actions.none();
         }
       case CWUOpportunityStatus.Evaluation:
+      case CWUOpportunityStatus.Processing:
         return adt("links", [
           {
             children: "Cancel",

--- a/src/front-end/typescript/lib/pages/opportunity/sprint-with-us/edit/tab/opportunity.tsx
+++ b/src/front-end/typescript/lib/pages/opportunity/sprint-with-us/edit/tab/opportunity.tsx
@@ -1153,6 +1153,7 @@ export const component: Tab.Component<State, Msg> = {
       case SWUOpportunityStatus.EvaluationTeamQuestionsConsensus:
       case SWUOpportunityStatus.EvaluationCodeChallenge:
       case SWUOpportunityStatus.EvaluationTeamScenario:
+      case SWUOpportunityStatus.Processing:
         if (!viewerIsAdmin) {
           return component_.page.actions.none();
         }

--- a/src/front-end/typescript/lib/pages/opportunity/team-with-us/edit/tab/opportunity.tsx
+++ b/src/front-end/typescript/lib/pages/opportunity/team-with-us/edit/tab/opportunity.tsx
@@ -1156,6 +1156,7 @@ export const component: Tab.Component<State, Msg> = {
       case TWUOpportunityStatus.EvaluationResourceQuestionsIndividual:
       case TWUOpportunityStatus.EvaluationResourceQuestionsConsensus:
       case TWUOpportunityStatus.EvaluationChallenge:
+      case TWUOpportunityStatus.Processing:
         if (!viewerIsAdmin) {
           return component_.page.actions.none();
         }


### PR DESCRIPTION
## Summary
- The frontend `getActions` switch in the opportunity edit tabs for **TWU**, **SWU**, and **CWU** did not include a `Processing` case, so the Cancel button was hidden when an opportunity reached Processing status
- The backend `isValidStatusChange` already allows `Processing → Canceled` for all three opportunity types — this was purely a frontend omission introduced when the Processing status was added (commit `f42bedfd`)
- Added `Processing` as a fall-through case in all three opportunity type edit tabs so admins can cancel from the UI

## Test plan
- [ ] Navigate to a TWU opportunity in Processing status as an admin — verify the Cancel action appears
- [ ] Repeat for a SWU opportunity in Processing status
- [ ] Repeat for a CWU opportunity in Processing status
- [ ] Cancel a Processing opportunity and verify it transitions to Canceled and notifications are sent
- [ ] Verify cancel still works from Evaluation statuses (regression check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)