### PR TITLE
fix(twu): reject stale resource IDs on proposal save

### DIFF
--- a/src/back-end/lib/resources/proposal/team-with-us/index.ts
+++ b/src/back-end/lib/resources/proposal/team-with-us/index.ts
@@ -447,7 +447,8 @@ const create: crud.Create<
       const validatedTeamMembers = await validateTWUProposalTeamMembers(
         connection,
         team,
-        validatedOrganization.value.id
+        validatedOrganization.value.id,
+        new Set(validatedTWUOpportunity.value.resources.map((r) => r.id))
       );
 
       /**
@@ -753,7 +754,8 @@ const update: crud.Update<
           const validatedProposalTeam = await validateTWUProposalTeamMembers(
             connection,
             team,
-            validatedOrganization.value.id
+            validatedOrganization.value.id,
+            new Set(twuOpportunity.resources.map((r) => r.id))
           );
 
           /**
@@ -845,7 +847,8 @@ const update: crud.Update<
                     resource
                   })
                 ) ?? [],
-                validatedOrganization.value.id
+                validatedOrganization.value.id,
+                new Set(twuOpportunity.resources.map((r) => r.id))
               ),
               proposalValidation.validateTWUProposalOrganizationServiceAreas(
                 twuOpportunity,

--- a/src/back-end/lib/validation.ts
+++ b/src/back-end/lib/validation.ts
@@ -360,7 +360,8 @@ function hasDuplicates(arr: string[]): boolean {
 export async function validateTWUProposalTeamMembers(
   connection: db.Connection,
   raw: CreateTWUProposalTeamMemberBody[],
-  organization: Id
+  organization: Id,
+  validResourceIds: Set<Id>
 ): Promise<
   ArrayValidation<
     CreateTWUProposalTeamMemberBody,
@@ -385,19 +386,21 @@ export async function validateTWUProposalTeamMembers(
       const validatedHourlyRate = validateTWUHourlyRate(
         getNumber<number>(rawMember, "hourlyRate")
       );
-      const validatedResource = getValidValue(
-        await db.readOneResource(connection, getString(rawMember, "resource")),
-        null
-      );
+      // Resource must belong to the current opportunity version. This guards
+      // against saves from a form that was opened before the opportunity was
+      // amended; without this, stale resource IDs silently overwrite members
+      // that the opportunity-update porting code already migrated.
+      const rawResource = getString(rawMember, "resource");
+      const isResourceCurrent = validResourceIds.has(rawResource);
       if (
         isValid(validatedMember) &&
         isValid(validatedHourlyRate) &&
-        validatedResource
+        isResourceCurrent
       ) {
         return valid({
           member: validatedMember.value.id,
           hourlyRate: validatedHourlyRate.value,
-          resource: validatedResource.id
+          resource: rawResource
         });
       } else {
         return invalid({
@@ -406,7 +409,11 @@ export async function validateTWUProposalTeamMembers(
             undefined
           ),
           hourlyRate: getInvalidValue(validatedHourlyRate, undefined),
-          resource: ["This resource cannot be found."]
+          resource: isResourceCurrent
+            ? ["This resource cannot be found."]
+            : [
+                "This opportunity was amended after this form was opened. Please refresh the page and re-select your team before saving."
+              ]
         }) as Validation<
           CreateTWUProposalTeamMemberBody,
           CreateTWUProposalTeamMemberValidationErrors


### PR DESCRIPTION
## Summary

When a Team With Us opportunity is amended (e.g. deadline extension), a new opportunity version is created with brand-new resource UUIDs. The back end's [updateTWUOpportunityVersion](../blob/development/src/back-end/lib/db/opportunity/team-with-us.ts) already migrates any existing draft proposal's `twuProposalMember` rows from the old resource IDs to the new ones, so editors-in-flight stay correctly attached.

However, **a vendor proposal save coming in from a form that was opened before the amendment will silently overwrite that migration with stale resource IDs**, because:

1. The proposal save path in `createTWUProposalTeamMembers` deletes all of a proposal's `twuProposalMember` rows and re-inserts from the request body.
2. The server-side validator only checks that each submitted resource ID *exists* in `twuResources`. Resources from old opportunity versions are never deleted, so a stale ID validates fine.

Once a `twuProposalMember` row references an orphaned old-version resource, the front-end can no longer match it to a current-version resource by UUID. The team selections render with blank names and blank rates in both the view and edit tabs, and the dropdown also filters those staff out (they look "already added" by `member.id`), so the vendor can't even re-pick them manually.

### The fix

Tighten `validateTWUProposalTeamMembers` to require each member's resource ID to be one of the *current* opportunity version's resources. The opportunity is already loaded at every call site, so the check is `Set.has` against `opportunity.resources.map(r => r.id)` — no new queries.

When the check fails the validator now returns a specific error message asking the user to refresh, which surfaces through the existing validation channel.

### Behaviour change

- **Before:** stale form save → corrupted proposal state, silently → blank UI later.
- **After:** stale form save → validation error → user refreshes → re-saves with current IDs → no corruption.

### Out of scope

- Front-end "fallback match by `(serviceArea, order)`" — no longer necessary now that the back end guarantees current-version IDs, but worth doing later as defence in depth.
- The `.every()` array-length quirk in the opportunity-version porting code — latent issue, did not contribute to the observed incident.
- One-time data cleanup for any proposals already corrupted by this race. A detection query is included in the audit notes below.

## Test plan

- [ ] Open a draft TWU proposal in two tabs; in tab A amend the opportunity (e.g. extend deadline); in tab B save the proposal — save should now be rejected with the new error message instead of silently corrupting state.
- [ ] Confirm a normal "open, edit, save (no amendment in flight)" flow still works.
- [ ] Confirm submission of a proposal whose team is already current still works.
- [ ] Run the audit query below against a non-prod DB to confirm no proposals get into the orphaned-resource state after the fix:
  ```sql
  SELECT p.id AS proposal_id, pm.resource AS stale_resource_id,
         r."opportunityVersion" AS resource_belongs_to_version
  FROM   "twuProposalMember" pm
  JOIN   "twuProposals"            p ON pm.proposal = p.id
  JOIN   "twuResources"            r ON pm.resource = r.id
  JOIN   "twuOpportunityVersions"  cv ON cv.opportunity = p.opportunity
  WHERE  cv."createdAt" = (SELECT MAX("createdAt") FROM "twuOpportunityVersions" WHERE opportunity = p.opportunity)
    AND  r."opportunityVersion" <> cv.id;
  ```