### PR TITLE
fix: reject CWU proposal creation as submitted after deadline

### DIFF
--- a/src/back-end/lib/resources/proposal/code-with-us.ts
+++ b/src/back-end/lib/resources/proposal/code-with-us.ts
@@ -19,6 +19,7 @@ import {
 import { get, omit } from "lodash";
 import { getNumber, getString, getStringArray } from "shared/lib";
 import { FileRecord } from "shared/lib/resources/file";
+import { isCWUOpportunityAcceptingProposals } from "shared/lib/resources/opportunity/code-with-us";
 import {
   createBlankIndividualProponent,
   CreateCWUProposalStatus,
@@ -310,6 +311,19 @@ const create: crud.Create<
       if (isInvalid(validatedCWUOpportunity)) {
         return invalid({
           notFound: ["The specified opportunity does not exist."]
+        });
+      }
+
+      // Reject submissions once the opportunity is no longer accepting
+      // proposals (not published, or past its deadline). This guards the
+      // create endpoint, which otherwise allows creating a proposal directly
+      // as Submitted after the deadline has passed.
+      if (
+        validatedStatus.value === CWUProposalStatus.Submitted &&
+        !isCWUOpportunityAcceptingProposals(validatedCWUOpportunity.value)
+      ) {
+        return invalid({
+          status: ["This opportunity is no longer accepting proposals."]
         });
       }
 

--- a/tests/back-end/integration/resources/proposals/code-with-us.test.ts
+++ b/tests/back-end/integration/resources/proposals/code-with-us.test.ts
@@ -413,3 +413,62 @@ test("code-with-us proposal crud", async () => {
     createdAt: expect.any(String) // TODO: fix this after writing tests
   });
 });
+
+test("code-with-us proposal cannot be created as submitted after the deadline has passed", async () => {
+  const { testUser, testUserSession, testAdminSession, userAppAgent } =
+    await setup();
+
+  // Publish an opportunity with a near-future proposal deadline.
+  const opportunityParams = buildCreateCWUOpportunityParams({
+    status: CWUOpportunityStatus.Published,
+    proposalDeadline: faker.date.soon()
+  });
+  const opportunity = await insertCWUOpportunity(
+    connection,
+    opportunityParams,
+    testAdminSession
+  );
+
+  // Move the deadline into the past and close the opportunity, mirroring the
+  // production auto-close that transitions the opportunity to Evaluation.
+  await updateCWUOpportunityVersion(
+    connection,
+    {
+      ...omit(opportunityParams, ["status"]),
+      id: opportunity.id,
+      proposalDeadline: faker.date.recent()
+    },
+    testAdminSession
+  );
+  await closeCWUOpportunities(connection);
+
+  // A vendor attempts to create a proposal directly as Submitted after the
+  // deadline. Every field below is valid; the ONLY thing wrong is that the
+  // opportunity is no longer accepting proposals. The create endpoint must
+  // reject it (the draft->submit path is already guarded by the deadline).
+  const submittedBody: CreateRequestBody = {
+    opportunity: opportunity.id,
+    proposalText: faker.lorem.paragraphs(),
+    additionalComments: faker.lorem.paragraphs(),
+    proponent: adt("individual", {
+      ...omit(
+        buildCWUIndividualProponent({
+          legalName: testUser.name,
+          ...(testUser.email ? { email: testUser.email } : {})
+        }),
+        ["id", "phone", "street2"]
+      ),
+      phone: getPhoneNumber(),
+      street2: null
+    }),
+    attachments: [],
+    status: CWUProposalStatus.Submitted
+  };
+
+  const createRequest = userAppAgent
+    .post("/api/proposals/code-with-us")
+    .send(submittedBody);
+  const createResult = await requestWithCookie(createRequest, testUserSession);
+
+  expect(createResult.status).toEqual(400);
+});


### PR DESCRIPTION
## Problem

A Code With Us proposal could be **created and submitted after the opportunity's deadline**. The `create` endpoint (`POST /api/proposals/code-with-us`) accepted a body with `status: Submitted` and only validated that the opportunity *existed* — it never checked whether the opportunity was still accepting proposals. (The separate draft→submit path is guarded, but the create-directly-as-submitted path was not.)

This was observed in production: a proposal was created ~2 hours after the deadline, after the opportunity had already auto-transitioned to `Evaluation`. Because the close job had already run, the proposal was never moved to `UnderReview` and stayed `Submitted` indefinitely, which:

- is **counted** in the opportunity header (`reporting.numProposals`) but **hidden** from the proposals list (gov/admin don't see `Submitted`), producing a confusing "37 proposals" header vs 36 rows; and
- **blocks the opportunity from advancing** `Evaluation → Processing` (a still-active, unevaluated proposal), so the Award button never appears and the opportunity can't be awarded through the UI.

## Fix

Guard the create handler with `isCWUOpportunityAcceptingProposals(opportunity)` (status `Published` **and** deadline in the future) — the same helper the front-end already uses to gate the create page on load. When `status === Submitted` and the opportunity is no longer accepting proposals, return `400 "This opportunity is no longer accepting proposals."` Draft creation is unaffected.

## Test

Adds an integration test that publishes an opportunity, moves its deadline into the past and closes it (mirroring the production auto-close), then asserts a direct `Submitted` create is rejected.

## Verification

Verified locally end-to-end against the running server + create endpoint:

| Case | Before | After |
|---|---|---|
| Open opportunity → submit (control) | 201 | 201 |
| Closed/past-deadline opportunity → submit | 201 (bug) | 400 |

`back-end:typecheck` passes.

## Follow-up (not in this PR)

- Defense-in-depth: apply the same guard to the `update` submit action (covers a cancelled-but-not-yet-expired opportunity), deferred by request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)