### PR TITLE
Release: promote development to master (incl. CWU post-deadline submission fix)

### DIFF
--- a/src/back-end/lib/resources/proposal/code-with-us.ts
+++ b/src/back-end/lib/resources/proposal/code-with-us.ts
@@ -19,6 +19,7 @@ import {
 import { get, omit } from "lodash";
 import { getNumber, getString, getStringArray } from "shared/lib";
 import { FileRecord } from "shared/lib/resources/file";
+import { isCWUOpportunityAcceptingProposals } from "shared/lib/resources/opportunity/code-with-us";
 import {
   createBlankIndividualProponent,
   CreateCWUProposalStatus,
@@ -310,6 +311,19 @@ const create: crud.Create<
       if (isInvalid(validatedCWUOpportunity)) {
         return invalid({
           notFound: ["The specified opportunity does not exist."]
+        });
+      }
+
+      // Reject submissions once the opportunity is no longer accepting
+      // proposals (not published, or past its deadline). This guards the
+      // create endpoint, which otherwise allows creating a proposal directly
+      // as Submitted after the deadline has passed.
+      if (
+        validatedStatus.value === CWUProposalStatus.Submitted &&
+        !isCWUOpportunityAcceptingProposals(validatedCWUOpportunity.value)
+      ) {
+        return invalid({
+          status: ["This opportunity is no longer accepting proposals."]
         });
       }
 

--- a/tests/back-end/integration/resources/proposals/code-with-us.test.ts
+++ b/tests/back-end/integration/resources/proposals/code-with-us.test.ts
@@ -413,3 +413,62 @@ test("code-with-us proposal crud", async () => {
     createdAt: expect.any(String) // TODO: fix this after writing tests
   });
 });
+
+test("code-with-us proposal cannot be created as submitted after the deadline has passed", async () => {
+  const { testUser, testUserSession, testAdminSession, userAppAgent } =
+    await setup();
+
+  // Publish an opportunity with a near-future proposal deadline.
+  const opportunityParams = buildCreateCWUOpportunityParams({
+    status: CWUOpportunityStatus.Published,
+    proposalDeadline: faker.date.soon()
+  });
+  const opportunity = await insertCWUOpportunity(
+    connection,
+    opportunityParams,
+    testAdminSession
+  );
+
+  // Move the deadline into the past and close the opportunity, mirroring the
+  // production auto-close that transitions the opportunity to Evaluation.
+  await updateCWUOpportunityVersion(
+    connection,
+    {
+      ...omit(opportunityParams, ["status"]),
+      id: opportunity.id,
+      proposalDeadline: faker.date.recent()
+    },
+    testAdminSession
+  );
+  await closeCWUOpportunities(connection);
+
+  // A vendor attempts to create a proposal directly as Submitted after the
+  // deadline. Every field below is valid; the ONLY thing wrong is that the
+  // opportunity is no longer accepting proposals. The create endpoint must
+  // reject it (the draft->submit path is already guarded by the deadline).
+  const submittedBody: CreateRequestBody = {
+    opportunity: opportunity.id,
+    proposalText: faker.lorem.paragraphs(),
+    additionalComments: faker.lorem.paragraphs(),
+    proponent: adt("individual", {
+      ...omit(
+        buildCWUIndividualProponent({
+          legalName: testUser.name,
+          ...(testUser.email ? { email: testUser.email } : {})
+        }),
+        ["id", "phone", "street2"]
+      ),
+      phone: getPhoneNumber(),
+      street2: null
+    }),
+    attachments: [],
+    status: CWUProposalStatus.Submitted
+  };
+
+  const createRequest = userAppAgent
+    .post("/api/proposals/code-with-us")
+    .send(submittedBody);
+  const createResult = await requestWithCookie(createRequest, testUserSession);
+
+  expect(createResult.status).toEqual(400);
+});


### PR DESCRIPTION
Promotes `development` to `master`.

### Included
- **fix: reject CWU proposal creation as submitted after deadline** (#543) — guards the CWU proposal create endpoint with `isCWUOpportunityAcceptingProposals`, so a proposal can no longer be created directly as `Submitted` after the opportunity's deadline / once it's no longer accepting proposals. Includes an integration test. Verified locally end-to-end.

### Notes
- Pushing to `master` triggers the release workflow (`releases.yaml`) → creates a GitHub release/tag (patch bump by default).