### PR TITLE
Add vendor information sessions page route

### DIFF
--- a/src/front-end/typescript/lib/app/router.ts
+++ b/src/front-end/typescript/lib/app/router.ts
@@ -703,6 +703,12 @@ const router: router_.Router<Route> = {
       }
     },
     {
+      path: prefixPath("/vendor-information-sessions"),
+      makeRoute() {
+        return adt("vendorInformationSessions", null);
+      }
+    },
+    {
       path: prefixPath("/cwu/:guideAudience"),
       makeRoute({ path, params }) {
         return PageGuide.isGuideAudience(params.guideAudience)
@@ -1059,6 +1065,8 @@ const router: router_.Router<Route> = {
               return prefixPath(`/notice/${route.value.tag}`);
           }
         })();
+      case "vendorInformationSessions":
+        return prefixPath("/vendor-information-sessions");
       case "cwuGuide":
         return prefixPath(`/cwu/${route.value.guideAudience}`);
       case "swuGuide":

--- a/src/front-end/typescript/lib/app/types.ts
+++ b/src/front-end/typescript/lib/app/types.ts
@@ -12,6 +12,7 @@ import * as PageLanding from "front-end/lib/pages/landing";
 import * as PageLearnMoreCWU from "front-end/lib/pages/learn-more/code-with-us";
 import * as PageLearnMoreTWU from "front-end/lib/pages/learn-more/team-with-us";
 import * as PageLearnMoreSWU from "front-end/lib/pages/learn-more/sprint-with-us";
+import * as PageVendorInformationSessions from "front-end/lib/pages/vendor-information-sessions/view";
 import * as PageNotFound from "front-end/lib/pages/not-found";
 import * as PageNotice from "front-end/lib/pages/notice";
 import * as PageOpportunityCWUCreate from "front-end/lib/pages/opportunity/code-with-us/create";
@@ -158,6 +159,7 @@ export type Route =
   | ADT<"cwuGuide", PageGuideView.RouteParams>
   | ADT<"swuGuide", PageGuideView.RouteParams>
   | ADT<"twuGuide", PageGuideView.RouteParams>
+  | ADT<"vendorInformationSessions", PageVendorInformationSessions.RouteParams>
   | ADT<"swuOpportunityCompleteView", PageOpportunitySWUComplete.RouteParams>
   | ADT<"cwuOpportunityCompleteView", PageOpportunityCWUComplete.RouteParams>
   | ADT<"twuOpportunityCompleteView", PageOpportunityTWUComplete.RouteParams>;
@@ -168,6 +170,7 @@ export type Route =
 const routesAllowedForUsersWithUnacceptedTerms: Array<Route["tag"]> = [
   "signUpStepTwo",
   "contentView",
+  "vendorInformationSessions",
   "learnMoreCWU",
   "learnMoreTWU",
   "learnMoreSWU",

--- a/src/front-end/typescript/lib/app/update.ts
+++ b/src/front-end/typescript/lib/app/update.ts
@@ -22,6 +22,7 @@ import * as PageLanding from "front-end/lib/pages/landing";
 import * as PageLearnMoreCWU from "front-end/lib/pages/learn-more/code-with-us";
 import * as PageLearnMoreTWU from "front-end/lib/pages/learn-more/team-with-us";
 import * as PageLearnMoreSWU from "front-end/lib/pages/learn-more/sprint-with-us";
+import * as PageVendorInformationSessions from "front-end/lib/pages/vendor-information-sessions/view";
 import * as PageNotFound from "front-end/lib/pages/not-found";
 import * as PageNotice from "front-end/lib/pages/notice";
 import * as PageOpportunityCWUCreate from "front-end/lib/pages/opportunity/code-with-us/create";
@@ -662,6 +663,18 @@ function initPage(
         pageStatePath: ["pages", "contentView"],
         pageRouteParams: route.value,
         pageInit: PageGuideView.init,
+        pageGetMetadata: PageContentView.component.getMetadata,
+        mapPageMsg(value) {
+          return adt("pageContentView", value);
+        }
+      });
+
+    case "vendorInformationSessions":
+      return component.app.initPage({
+        ...defaultPageInitParams,
+        pageStatePath: ["pages", "contentView"],
+        pageRouteParams: route.value,
+        pageInit: PageVendorInformationSessions.init,
         pageGetMetadata: PageContentView.component.getMetadata,
         mapPageMsg(value) {
           return adt("pageContentView", value);

--- a/src/front-end/typescript/lib/app/view/footer.tsx
+++ b/src/front-end/typescript/lib/app/view/footer.tsx
@@ -24,6 +24,10 @@ const links: AnchorProps[] = [
     dest: routeDest(adt("contentView", "about"))
   },
   {
+    children: "Vendor Information Sessions",
+    dest: routeDest(adt("vendorInformationSessions", null))
+  },
+  {
     children: "Disclaimer",
     dest: routeDest(adt("contentView", "disclaimer"))
   },

--- a/src/front-end/typescript/lib/app/view/index.tsx
+++ b/src/front-end/typescript/lib/app/view/index.tsx
@@ -167,6 +167,7 @@ function pageToViewPageProps(
         (value) => ({ tag: "pageLearnMoreSWU", value })
       );
 
+    case "vendorInformationSessions":
     case "cwuGuide":
     case "swuGuide":
     case "twuGuide":

--- a/src/front-end/typescript/lib/pages/vendor-information-sessions/view.ts
+++ b/src/front-end/typescript/lib/pages/vendor-information-sessions/view.ts
@@ -1,0 +1,27 @@
+import { Route, SharedState } from "front-end/lib/app/types";
+import { immutable, component } from "front-end/lib/framework";
+import * as api from "front-end/lib/http/api";
+import { InnerMsg, Msg, State } from "front-end/lib/pages/content/view";
+import { adt } from "shared/lib/types";
+import { valid } from "shared/lib/validation";
+
+export const CONTENT_SLUG = "vendor-information-sessions";
+
+export type RouteParams = null;
+
+export const init: component.page.Init<
+  RouteParams,
+  SharedState,
+  State,
+  InnerMsg,
+  Route
+> = ({ routePath }) => {
+  return [
+    valid(immutable({ routePath, content: null })),
+    [
+      api.content.readOne<Msg>()(CONTENT_SLUG, (msg) =>
+        adt("onContentResponse", msg)
+      )
+    ]
+  ];
+};

--- a/src/migrations/tasks/20260720224453_vendor-information-sessions-content-stub.ts
+++ b/src/migrations/tasks/20260720224453_vendor-information-sessions-content-stub.ts
@@ -1,0 +1,38 @@
+import { generateUuid } from "back-end/lib";
+import { makeDomainLogger } from "back-end/lib/logger";
+import { console as consoleAdapter } from "back-end/lib/logger/adapters";
+import { Knex } from "knex";
+
+const logger = makeDomainLogger(consoleAdapter, "migrations");
+
+const SLUG = "vendor-information-sessions";
+
+async function insertFixedContent(connection: Knex, slug: string) {
+  const now = new Date();
+  const body = "Initial version";
+  const id = generateUuid();
+  await connection("content").insert({ id, createdAt: now, slug, fixed: true });
+  await connection("contentVersions").insert({
+    id: 1,
+    title: slug,
+    body,
+    createdAt: now,
+    contentId: id
+  });
+}
+
+async function deleteFixedContent(connection: Knex, slug: string) {
+  await connection("content").where({ slug }).delete();
+}
+
+export async function up(connection: Knex): Promise<void> {
+  await insertFixedContent(connection, SLUG);
+  logger.info(
+    "Completed adding vendor-information-sessions content slug to content table."
+  );
+}
+
+export async function down(connection: Knex): Promise<void> {
+  await deleteFixedContent(connection, SLUG);
+  logger.info("Completed reverting vendor-information-sessions content slug.");
+}


### PR DESCRIPTION
Adds a public `/vendor-information-sessions` pretty URL and footer link that load fixed CMS content (`vendor-information-sessions`) via the shared content-view flow. Includes a migration that seeds the fixed content stub.

This PR closes issue: n/a

Includes tests? N (manual smoke; no new automated suite for this thin alias)
Updated docs? N

## Proposed changes
- Add pretty URL route `vendorInformationSessions` → CMS slug `vendor-information-sessions`
- Seed fixed content stub via migration
- Add footer discovery link: Vendor Information Sessions

## Additional notes
- Content body is editable in admin CMS after deploy
- Merge to `development` publishes the image to GHCR; OpenShift auto-deploy job is still commented out